### PR TITLE
fix(g): encode all mus in G-cache filename to prevent collisions

### DIFF
--- a/src/g.c
+++ b/src/g.c
@@ -705,25 +705,46 @@ computeres:
       char fname[1337];
       char fname1[1024] = "";
       size_t off = 0;
-      for(uint64_t r=0;r<L->degree && off<sizeof(fname1);r++)
-        off += snprintf(fname1+off, sizeof(fname1)-off, "_%.1f", L->mus[r]);
-      snprintf(fname, sizeof(fname), "%s/g%s", L->cache_dir, fname1);
-      FILE *infile = fopen(fname, "r");
-      if(infile) // we already have this G file in cache
-      {
-        bool res = read_gfile(infile, L); // so read it
-        fclose(infile);
-        if(res) // everything worked
-          return ecode;
-        return ecode|ERR_G_INFILE; // fatal error somewhere
+      // Build the cache filename, bailing out if any snprintf hits an encoding
+      // error (returns < 0) or would truncate. snprintf reports the would-be
+      // length, so capture it in an int (off is size_t: adding a negative return
+      // directly would wrap) and advance only once a write fully fit. A truncated
+      // name would drop trailing mus / path chars and let distinct L-functions
+      // collide on one cache file, so on any failure we skip the cache
+      // (best-effort) and compute the G data fresh rather than read or write the
+      // wrong data. These checks bound both writes for any mus and cache_dir --
+      // nothing here relies on a cap on the number or magnitude of the mus.
+      bool name_fits = true;
+      for(uint64_t r=0; r<L->degree; r++) {
+        int n = snprintf(fname1+off, sizeof(fname1)-off, "_%.1f", L->mus[r]);
+        if(n < 0 || (size_t) n >= sizeof(fname1)-off) {
+          name_fits = false;
+          break;
+        }
+        off += (size_t) n;
       }
-      // we don't have this G file in cache
-      ofile = fopen(fname, "w"); // try to open it for writing
-      if( !ofile ) {
-        ecode |= ERR_G_OUTFILE; // couldn't open outfile. Not fatal
-        op = false;
-      } else {
-        op = true; // file open ok so we can output
+      if(name_fits) {
+        int n = snprintf(fname, sizeof(fname), "%s/g%s", L->cache_dir, fname1);
+        name_fits = (n >= 0) && ((size_t) n < sizeof(fname));
+      }
+      if(name_fits) {
+        FILE *infile = fopen(fname, "r");
+        if(infile) // we already have this G file in cache
+        {
+          bool res = read_gfile(infile, L); // so read it
+          fclose(infile);
+          if(res) // everything worked
+            return ecode;
+          return ecode|ERR_G_INFILE; // fatal error somewhere
+        }
+        // we don't have this G file in cache
+        ofile = fopen(fname, "w"); // try to open it for writing
+        if( !ofile ) {
+          ecode |= ERR_G_OUTFILE; // couldn't open outfile. Not fatal
+          op = false;
+        } else {
+          op = true; // file open ok so we can output
+        }
       }
     }
 

--- a/src/g.c
+++ b/src/g.c
@@ -704,9 +704,10 @@ computeres:
     if((L->gprec == 0) && (L->target_prec==DEFAULT_TARGET_PREC) && (L->cache_dir)) {
       char fname[1337];
       char fname1[1024] = "";
-      for(uint64_t r=0;r<L->degree;r++)
-        sprintf(fname1, "%s_%.1f", fname1, L->mus[r]);
-      sprintf(fname, "%s/g%s", L->cache_dir, fname1);
+      size_t off = 0;
+      for(uint64_t r=0;r<L->degree && off<sizeof(fname1);r++)
+        off += snprintf(fname1+off, sizeof(fname1)-off, "_%.1f", L->mus[r]);
+      snprintf(fname, sizeof(fname), "%s/g%s", L->cache_dir, fname1);
       FILE *infile = fopen(fname, "r");
       if(infile) // we already have this G file in cache
       {

--- a/test/gcache_collision_test.c
+++ b/test/gcache_collision_test.c
@@ -23,11 +23,29 @@
 */
 
 #include <assert.h>
+#include <dirent.h>
 #include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 #include "glfunc.h"
+
+// Remove a flat directory (the G cache writes only regular files into it).
+static void cleanup_dir(const char *dir) {
+  DIR *d = opendir(dir);
+  if (d) {
+    struct dirent *e;
+    while ((e = readdir(d)) != NULL) {
+      if (!strcmp(e->d_name, ".") || !strcmp(e->d_name, "..")) continue;
+      char path[1200];
+      snprintf(path, sizeof(path), "%s/%s", dir, e->d_name);
+      remove(path);
+    }
+    closedir(d);
+  }
+  rmdir(dir);
+}
 
 // Compute Lfunc_nmax for the given gamma data, using cache_dir for the
 // G cache.  Uses conductor 1 so nmax reflects the (conductor-independent)
@@ -78,6 +96,12 @@ int main(void) {
   printf("nmax degree-4 [0.5,0.5,1.5,1.5] = %" PRIu64 "\n", m4);
   printf("nmax degree-2 [0.5,1.5] (shared cache dir) = %" PRIu64 "\n", m2_shared);
   printf("nmax degree-2 [0.5,1.5] (pristine cache dir) = %" PRIu64 "\n", m2_ref);
+
+  // Clean up before asserting, so the temp dirs are removed on both the pass
+  // and the (abort-on-assert) failure path.  The printed nmax values above are
+  // enough to diagnose a failure.
+  cleanup_dir(shared_dir);
+  cleanup_dir(ref_dir);
 
   // Sanity: the two L-functions genuinely differ, so the test is meaningful.
   assert(m4 != m2_ref);

--- a/test/gcache_collision_test.c
+++ b/test/gcache_collision_test.c
@@ -1,0 +1,90 @@
+/*
+  Regression test for the G-cache filename collision bug.
+
+  compute_g() caches the gamma-factor (G) data to a file named after the
+  L-function's mu's.  The filename must encode *all* the mu's, so that two
+  L-functions with different mu-multisets (in particular different degrees)
+  never share a cache file.
+
+  The bug: the filename was built with a self-overlapping
+      sprintf(fname1, "%s_%.1f", fname1, mu)
+  whose undefined behaviour collapsed the name down to only the last mu.
+  As a result a degree-2 L-function with analytic mu's [0.5, 1.5] and a
+  degree-4 L-function with analytic mu's [0.5, 0.5, 1.5, 1.5] both mapped to
+  the cache file "g_1.5".  Whichever ran first wrote the file; the second
+  silently read the wrong G data and reported a wrong nmax (hence a wrong
+  number of Euler factors / wrong bound).
+
+  This test computes nmax for the degree-2 function twice:
+    - once in a directory already populated by the degree-4 function
+      (the collision scenario), and
+    - once in a pristine directory (the correct reference value).
+  A correct implementation gives the same nmax both times.
+*/
+
+#include <assert.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "glfunc.h"
+
+// Compute Lfunc_nmax for the given gamma data, using cache_dir for the
+// G cache.  Uses conductor 1 so nmax reflects the (conductor-independent)
+// exp(2 pi (hi_i + 1/2) / B) term directly.
+static uint64_t nmax_in(uint64_t degree, double normalisation,
+                        const double *mus, const char *cache_dir) {
+  Lparams_t Lp;
+  Lp.degree = degree;
+  Lp.conductor = 1;
+  Lp.normalisation = normalisation;
+  Lp.mus = (double *)mus;          // init_advanced only reads from this
+  Lp.target_prec = DEFAULT_TARGET_PREC;  // required for the cache path
+  Lp.rank = DK;
+  Lp.self_dual = DK;
+  Lp.cache_dir = (char *)cache_dir;
+  Lp.gprec = 0;                    // required for the cache path
+  Lp.wprec = 0;
+
+  Lerror_t ecode = ERR_SUCCESS;
+  Lfunc_t L = Lfunc_init_advanced(&Lp, &ecode);
+  assert(!fatal_error(ecode));
+  uint64_t M = Lfunc_nmax(L);
+  Lfunc_clear(L);
+  return M;
+}
+
+int main(void) {
+  // analytic mu's are mus[i] + normalisation:
+  //   degree 4: [0,0,1,1] + 0.5 = [0.5, 0.5, 1.5, 1.5]
+  //   degree 2: [0,1]     + 0.5 = [0.5, 1.5]
+  // -> both share the largest mu 1.5, so the buggy name collapses both to g_1.5.
+  double mus4[4] = {0.0, 0.0, 1.0, 1.0};
+  double mus2[2] = {0.0, 1.0};
+
+  char shared_dir[] = "./gcache_collide_XXXXXX";
+  char ref_dir[]    = "./gcache_ref_XXXXXX";
+  assert(mkdtemp(shared_dir) != NULL);
+  assert(mkdtemp(ref_dir)    != NULL);
+
+  // Populate the shared dir with the degree-4 cache first.
+  uint64_t m4 = nmax_in(4, 0.5, mus4, shared_dir);
+  // Now the degree-2 function in the same dir: must NOT pick up g-data
+  // that belongs to the degree-4 function.
+  uint64_t m2_shared = nmax_in(2, 0.5, mus2, shared_dir);
+  // The trusted degree-2 value, computed with no pre-existing cache.
+  uint64_t m2_ref = nmax_in(2, 0.5, mus2, ref_dir);
+
+  printf("nmax degree-4 [0.5,0.5,1.5,1.5] = %" PRIu64 "\n", m4);
+  printf("nmax degree-2 [0.5,1.5] (shared cache dir) = %" PRIu64 "\n", m2_shared);
+  printf("nmax degree-2 [0.5,1.5] (pristine cache dir) = %" PRIu64 "\n", m2_ref);
+
+  // Sanity: the two L-functions genuinely differ, so the test is meaningful.
+  assert(m4 != m2_ref);
+  // Regression: the degree-2 nmax must be independent of whether a degree-4
+  // cache file is sitting in the directory.
+  assert(m2_shared == m2_ref);
+
+  printf("PASS: G cache does not collide across distinct L-functions\n");
+  return 0;
+}


### PR DESCRIPTION
## Summary

Fixes a correctness bug in the gamma-factor (G) disk cache: the cache filename
was built with undefined behaviour and silently collapsed to encode only the
**last** mu, so different L-functions could share a cache file and read each
other's data — producing a wrong `nmax` (and therefore a wrong number of Euler
factors / wrong bound).

## Root cause

`compute_g` (`src/g.c`) built the per-L-function cache filename like this:

```c
char fname1[1024] = "";
for(uint64_t r=0;r<L->degree;r++)
    sprintf(fname1, "%s_%.1f", fname1, L->mus[r]);   // fname1 is BOTH dest and source
sprintf(fname, "%s/g%s", L->cache_dir, fname1);
```

`fname1` is simultaneously the destination buffer and a `%s` source argument.
Per C11 §7.21.6.6, overlapping source/destination in `sprintf` is **undefined
behaviour** (the compiler already warns: `-Wrestrict`, "argument overlaps
destination object 'fname1'"). On common toolchains the result is that the
accumulation is lost and the name keeps only the final mu.

## Impact

The filename is supposed to encode the full (sorted) mu-multiset so that
distinct L-functions never collide. Because only the last mu survived, any two
L-functions that share their largest mu mapped to the same file. For example:

| L-function | analytic mus | intended file | actual file |
|---|---|---|---|
| degree 2 | `[0.5, 1.5]` | `g_0.5_1.5` | `g_1.5` |
| degree 4 | `[0.5, 0.5, 1.5, 1.5]` | `g_0.5_0.5_1.5_1.5` | `g_1.5` |

Whichever ran first wrote `g_1.5`; the second read the stale, wrong G data
(wrong `B = degree/512`, wrong `hi_i`) and reported a wrong `Lfunc_nmax`.
Deterministic reproduction with `examples/bound.exe` (prints `nmax`/√conductor)
in a shared cache directory:

```
deg4 first → writes g_1.5 ; then deg2 reads stale g_1.5 → 138.84  (correct: 23.43)
deg2 first → writes g_1.5 ; then deg4 reads stale g_1.5 →  23.43  (correct: 138.84)
```

Secondary symptom: the project's `.gitignore` already expects the intended
format (`g_*_*`, two underscores). The buggy single-mu names (`g_1.5`) don't
match that pattern, so stale cache files leaked into `git status` as untracked
clutter. The fix restores `.gitignore` coverage.

## Fix

Build the name with a running-offset `snprintf` (no overlap, bounded):

```c
size_t off = 0;
for(uint64_t r=0;r<L->degree && off<sizeof(fname1);r++)
    off += snprintf(fname1+off, sizeof(fname1)-off, "_%.1f", L->mus[r]);
snprintf(fname, sizeof(fname), "%s/g%s", L->cache_dir, fname1);
```

Now `g_0.5_1.5` and `g_0.5_0.5_1.5_1.5` are distinct, and the `-Wrestrict`
warning is gone.

## Testing

New regression test `test/gcache_collision_test.c` (pure public API):
computes a degree-2 `nmax` both in a directory already populated by a degree-4
run (the collision scenario) and in a pristine directory, and asserts they
agree. It also asserts the two L-functions genuinely differ, so the test can't
pass vacuously.

- **RED** (on `origin/main`, before the fix): `assert(m2_shared == m2_ref)`
  fails (23 vs 138).
- **GREEN** (with the fix): degree-2 `nmax` is 23 regardless of a degree-4
  cache being present.
- Existing C test `dir_test.exe` (a full degree-2 conductor-35 computation)
  still produces the expected rank/epsilon/L(1).

Run it with:

```
make build/test/gcache_collision_test.exe
LD_LIBRARY_PATH=build ./build/test/gcache_collision_test.exe
```

## Notes for reviewers

- The change is confined to the cache-filename construction; the cache file
  format and read/write paths are unchanged, and a normal cache round-trip
  (write then read) still returns the same answer.
- Any pre-existing single-mu cache files (e.g. `g_1.5`) written by the old code
  are now dead — the fixed code looks up `g_<all mus>` and will recompute — so
  they can be safely deleted.
