### PR TITLE
test: add make check regression suite and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential libflint-dev libprimesieve-dev
+      - name: Configure
+        run: ./configure
+      - name: Build
+        run: make
+      - name: Test
+        run: make check

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ Makefile
 .?*
 
 # g files
-g_*_*
+g_[0-9]*
 
 # Prerequisites
 *.d

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ Makefile
 
 # Hidden files
 .?*
+!.github
 
 # g files
 g_[0-9]*

--- a/Makefile.in
+++ b/Makefile.in
@@ -73,7 +73,8 @@ CHECK_BINS = \
 	build/examples/ec_37.a1.exe \
 	build/examples/ec_389.a1.exe \
 	build/examples/ec_5077.a1.exe \
-	build/examples/tau.exe
+	build/examples/tau.exe \
+	build/examples/cmf_7.3.b.a.exe
 
 check: all
 	@rm -f g_[0-9]*

--- a/Makefile.in
+++ b/Makefile.in
@@ -72,7 +72,8 @@ CHECK_BINS = \
 	build/test/dir_test1.exe \
 	build/examples/ec_37.a1.exe \
 	build/examples/ec_389.a1.exe \
-	build/examples/ec_5077.a1.exe
+	build/examples/ec_5077.a1.exe \
+	build/examples/tau.exe
 
 check: all
 	@rm -f g_[0-9]*

--- a/Makefile.in
+++ b/Makefile.in
@@ -67,7 +67,8 @@ print-%:
 .PHONY: clean check
 
 # Curated regression suite. Exit code is the oracle (assertions are on by default).
-# Stale g_<mu> caches poison results, so scrub them before and after.
+# Stale/colliding g_<mu> caches poison results, so scrub them before the suite
+# and after each binary (different L-functions can share a g_<mu> filename).
 CHECK_BINS = \
 	build/test/dir_test1.exe \
 	build/examples/ec_37.a1.exe \

--- a/Makefile.in
+++ b/Makefile.in
@@ -74,7 +74,8 @@ CHECK_BINS = \
 	build/examples/ec_389.a1.exe \
 	build/examples/ec_5077.a1.exe \
 	build/examples/tau.exe \
-	build/examples/cmf_7.3.b.a.exe
+	build/examples/cmf_7.3.b.a.exe \
+	build/examples/dir.exe
 
 check: all
 	@rm -f g_[0-9]*
@@ -83,7 +84,7 @@ check: all
 	  printf 'RUN  %s\n' "$$t"; \
 	  if ./$$t >$$t.log 2>&1; then printf 'PASS %s\n' "$$t"; rm -f $$t.log; \
 	  else rc=$$?; printf 'FAIL %s (rc=%s)\n' "$$t" "$$rc"; cat $$t.log; rm -f $$t.log; fail=1; fi; \
+	  rm -f g_[0-9]*; \
 	done; \
-	rm -f g_[0-9]*; \
 	if [ $$fail -ne 0 ]; then echo 'CHECK FAILED'; exit 1; fi; \
 	echo 'CHECK PASSED'

--- a/Makefile.in
+++ b/Makefile.in
@@ -64,4 +64,24 @@ $(BUILD_DIRS): % :
 print-%:
 	@echo '$*=$($*)'
 
-.PHONY: clean
+.PHONY: clean check
+
+# Curated regression suite. Exit code is the oracle (assertions are on by default).
+# Stale g_<mu> caches poison results, so scrub them before and after.
+CHECK_BINS = \
+	build/test/dir_test1.exe \
+	build/examples/ec_37.a1.exe \
+	build/examples/ec_389.a1.exe \
+	build/examples/ec_5077.a1.exe
+
+check: all
+	@rm -f g_[0-9]*
+	@fail=0; \
+	for t in $(CHECK_BINS); do \
+	  printf 'RUN  %s\n' "$$t"; \
+	  if ./$$t >$$t.log 2>&1; then printf 'PASS %s\n' "$$t"; rm -f $$t.log; \
+	  else rc=$$?; printf 'FAIL %s (rc=%s)\n' "$$t" "$$rc"; cat $$t.log; rm -f $$t.log; fail=1; fi; \
+	done; \
+	rm -f g_[0-9]*; \
+	if [ $$fail -ne 0 ]; then echo 'CHECK FAILED'; exit 1; fi; \
+	echo 'CHECK PASSED'

--- a/examples/cmf_7.3.b.a.cpp
+++ b/examples/cmf_7.3.b.a.cpp
@@ -67,6 +67,7 @@ Z-plot in [0, 10]:
 #include <flint/fmpz.h>
 //#include <flint/fmpzxx.h>
 #include <flint/acb_poly.h>
+#include <cassert>
 #include "glfunc_internals.h"
 //#include "examples_tools.h"
 
@@ -195,6 +196,15 @@ int main ()
   }
   printf("L(1) = ");acb_printd(ctmp, DIGITS);printf("\n");
   if (RAW) cout<<"RAW: "<<ctmp << endl;
+  { // regression assert: L(1)
+    acb_t ref; acb_init(ref);
+    arb_set_str(acb_realref(ref), "0.19673558706889585505", 300);
+    arb_set_str(acb_imagref(ref), "0", 300);
+    arb_add_error_2exp_si(acb_realref(ref), -50);
+    arb_add_error_2exp_si(acb_imagref(ref), -50);
+    assert(acb_overlaps(ctmp, ref));
+    acb_clear(ref);
+  }
   ecode|=Lfunc_special_value(ctmp, L, 2,0.0);
   if(fatal_error(ecode)) {
     fprint_errors(stderr, ecode);
@@ -211,6 +221,13 @@ int main ()
     arb_printd(zeros+i, DIGITS);
     printf("\n");
     if (RAW) cout<<"RAW: "<<zeros + i<< endl;
+  }
+  { // regression assert: first zero
+    arb_t ref; arb_init(ref);
+    arb_set_str(ref, "7.2145891812871844435", 300);
+    arb_add_error_2exp_si(ref, -50);
+    assert(arb_overlaps(zeros + 0, ref));
+    arb_clear(ref);
   }
 
   printf("Z-plot in [0, 10]:\n");

--- a/examples/dir.cpp
+++ b/examples/dir.cpp
@@ -21,6 +21,7 @@ characters mod 5 and the quadratic character mod 7 together.
 #include <flint/fmpz.h>
 //#include <flint/fmpzxx.h>  // removed: FLINT 3.x dropped the C++ interface
 #include <flint/acb_poly.h>
+#include <cassert>
 #include "glfunc.h"
 //#include "examples_tools.h"  // removed: pulls in flintxx
 
@@ -136,6 +137,15 @@ int main (int argc, char**argv)
   }
   printf("L(1) = ");acb_printd(ctmp, DIGITS);printf("\n");
   if (RAW) cout<<"RAW: "<<ctmp << endl;
+  { // regression assert: L(1) (complex)
+    acb_t ref; acb_init(ref);
+    arb_set_str(acb_realref(ref), "1.0268799643452569392", 300);
+    arb_set_str(acb_imagref(ref), "0.24241347631804096081", 300);
+    arb_add_error_2exp_si(acb_realref(ref), -50);
+    arb_add_error_2exp_si(acb_imagref(ref), -50);
+    assert(acb_overlaps(ctmp, ref));
+    acb_clear(ref);
+  }
   ecode|=Lfunc_special_value(ctmp, L, 2,0.0);
   if(fatal_error(ecode)) {
     fprint_errors(stderr, ecode);
@@ -151,6 +161,13 @@ int main (int argc, char**argv)
     arb_printd(zeros+i, DIGITS);
     printf("\n");
     if (RAW) cout<<"RAW: "<<zeros + i<< endl;
+  }
+  { // regression assert: first zero
+    arb_t ref; arb_init(ref);
+    arb_set_str(ref, "4.4757382837286831320", 300);
+    arb_add_error_2exp_si(ref, -50);
+    assert(arb_overlaps(zeros + 0, ref));
+    arb_clear(ref);
   }
 
   printf("Z-plot in [0, 10]:\n");

--- a/examples/tau.cpp
+++ b/examples/tau.cpp
@@ -68,6 +68,7 @@ Z-plot in [0, 10]:
 #include <flint/fmpz.h>
 //#include <flint/fmpzxx.h>  // removed: FLINT 3.x dropped the C++ interface
 #include <flint/acb_poly.h>
+#include <cassert>
 #include "glfunc.h"
 #include "glfunc_internals.h"
 //#include "examples_tools.h"  // removed: pulls in flintxx
@@ -176,6 +177,15 @@ int main ()
   }
   printf("L(6.5) = ");acb_printd(ctmp, DIGITS);printf("\n");
   if (RAW) cout<<"RAW: "<<ctmp << endl;
+  { // regression assert: L(6.5)
+    acb_t ref; acb_init(ref);
+    arb_set_str(acb_realref(ref), "0.83934551203194208649", 300);
+    arb_set_str(acb_imagref(ref), "0", 300);
+    arb_add_error_2exp_si(acb_realref(ref), -50);
+    arb_add_error_2exp_si(acb_imagref(ref), -50);
+    assert(acb_overlaps(ctmp, ref));
+    acb_clear(ref);
+  }
   ecode|=Lfunc_special_value(ctmp, L, 7.5,0.0);
   if(fatal_error(ecode)) {
     fprint_errors(stderr, ecode);
@@ -192,6 +202,13 @@ int main ()
     arb_printd(zeros+i, DIGITS);
     printf("\n");
     if (RAW) cout<<"RAW: "<<zeros + i<< endl;
+  }
+  { // regression assert: first zero
+    arb_t ref; arb_init(ref);
+    arb_set_str(ref, "9.2223793999211025222", 300);
+    arb_add_error_2exp_si(ref, -50);
+    assert(arb_overlaps(zeros + 0, ref));
+    arb_clear(ref);
   }
 
   printf("Z-plot in [0, 10]:\n");


### PR DESCRIPTION
## Summary

Adds a runnable regression suite (`make check`) and GitHub Actions CI for `liblfun`, as a safety net for the upcoming `acb_dft`/FFT refactor. The pass/fail oracle is rigorous arb/acb ball asserts (`arb_overlaps`/`acb_overlaps`) — never printed-output comparison.

## What changed

- **`make check` target** (`Makefile.in`): runs a curated suite of self-checking binaries; exits non-zero if any aborts; prints a binary's captured output only on failure; scrubs `g_<mu>` G-cache files before the suite and after each binary so stale/colliding caches can't poison results.
- **Wired existing self-checkers**: `dir_test1`, `ec_37.a1`, `ec_389.a1`, `ec_5077.a1`.
- **Converted 3 print-only examples into tests** (each asserts a special value + the first zero): `tau` (L(6.5)), `cmf_7.3.b.a` (L(1)), `dir` (complex L(1)). Reference constants are LMFDB-consistent and inflated with a ~9e-16 tolerance to bridge 20-digit prints against the tighter rigorous balls.
- **GitHub Actions CI** (`.github/workflows/ci.yml`): on push to `main` and on pull requests, `ubuntu-latest`, apt `libflint-dev` + `libprimesieve-dev`, then `./configure && make && make check`.
- **`.gitignore`**: fixed the G-cache glob (`g_*_*` → `g_[0-9]*`) and un-ignored `.github`.

## Test plan

- [ ] `make clean && ./configure && make && make check` → `CHECK PASSED` (7/7, exit 0)
- [ ] CI is green on this PR

## Notes

- `artin` is intentionally excluded from the no-arg suite (it requires `argv[1]`/`argv[2]` input/output files).
- Surfaced a latent G-cache footgun: `g_<mu>` cache files aren't invalidated and can collide across different L-functions sharing a `mu`; `make check` scrubs them. Versioning the cache key is a possible follow-up.
- Follow-up (separate PR): the `acb_dft`/FFT swap + small cleanups (`arb_getd` → `arf_get_d`, dead `acb_t` in `abs_gamma`, etc.), guarded by this CI.
