### PR TITLE
docs: document global constants and internal Lfunc attributes

### DIFF
--- a/include/glfunc.h
+++ b/include/glfunc.h
@@ -5,22 +5,22 @@
 #include <flint/acb_poly.h>
 #include <stdbool.h>
 
-#define DK (-1) // don't know
-#define YES (1)
-#define NO (0)
+#define DK (-1) // tri-state "don't know" (for self_dual / rank)
+#define YES (1) // tri-state "yes" (for self_dual / rank)
+#define NO (0) // tri-state "no" (for self_dual / rank)
 
-//#define BUTHE
-#define TURING
+//#define BUTHE // if defined, verify RH via Buthe's method (off by default)
+#define TURING // if defined, verify RH via Booker/Turing's method (default)
 
 #define MAX_DEGREE (9) // if increasing, need more integrals in buthe.c
 // and probably need to take a good look at g.c
-#define MAX_R MAX_DEGREE
-#define MAX_ZEROS (256)
-#define DEFAULT_TARGET_PREC (100)
+#define MAX_R MAX_DEGREE // alias for MAX_DEGREE (max degree r); sizes the Buthe tables
+#define MAX_ZEROS (256) // hard cap on the number of zeros found/stored per side
+#define DEFAULT_TARGET_PREC (100) // default target precision in bits when none is given
 // error codes
 // those in lower 32 bits are fatal
 // those in upper 32 bits are warnings
-#define ERR_SUCCESS (0)
+#define ERR_SUCCESS (0) // no error
 // fatalities
 #define ERR_NO_DATA (1) // the first two Lambda(t) values contained zero. Totally fatal
 #define ERR_ZERO_ERROR (2) // some unexpected error isolating zeros
@@ -30,7 +30,7 @@
 #define ERR_OOM (8) // out of memory error
 #define ERR_UPSAMPLE (16) // something bad happened trying to upsample
 #define ERR_MU_HALF (32) // mus should be 1/2 integers
-#define ERR_M_ERROR (64)
+#define ERR_M_ERROR (64) // fatal: failed to compute the M (coeff-count) bound (M_error Lemma 2)
 #define ERR_STAT_POINT (128) // fatal error in stat_point
 #define ERR_SPEC_VALUE (256) // fatal error in Special Value
 #define ERR_G_INFILE ((uint64_t) 512) // fatal error reading g_data from cache

--- a/include/glfunc_internals.h
+++ b/include/glfunc_internals.h
@@ -45,7 +45,7 @@ extern "C"{
     int64_t wprec; // internal working precision in bits = target_prec + decay + EXTRA_BITS
     int64_t gprec; // precision in bits used by the G/gamma-factor computation (>= wprec)
     char *cache_dir; // directory for cached G-data; used only in default-precision mode
-    int self_dual; // self-dual? DK(-1)/NO(0)/YES(1); YES skips dual-side zeros & Turing
+    int self_dual; // self-dual? DK(-1)/NO(0)/YES(1); YES skips dual-side zero-finding (Turing then doubles the L-side)
     int rank; // analytic rank = order of vanishing at s=1/2; DK(-1) until computed
     arb_t mu; // scalar -1/2+(1+sum mus)/r (Artin Lemma 5.2); unused
     arb_t nu; // scalar 1/2+(2/r)*sum(nus); shift param for the error bounds (Lemma 2/5)
@@ -123,7 +123,7 @@ extern "C"{
     arb_t u_pi_by_H2; // -pi/h^2: coefficient of (t-k/A)^2 in the Gaussian window
     arb_t u_A; // upsampling sample rate = A*u_stride (= A, since u_stride = 1)
     arb_t u_one_over_A; // 1/u_A: the upsampling grid spacing in t
-    arb_t *u_values[2]; // per-side raw samples of -Lambda (full buffer incl. left guard)
+    arb_t *u_values[2]; // per-side raw samples of Lambda, sign-normalized so Lambda(0)>=0 (full buffer incl. left guard)
     arb_t *u_values_off[2]; // view into u_values past the guard: index k = Lam(k/A)
     // Lam(t)=eps^1/2 N^it/2 prod gamma_r(1/2+it+mu_j) L(1/2+it)
     uint64_t u_no_values; // element count of each u_values[side]

--- a/include/glfunc_internals.h
+++ b/include/glfunc_internals.h
@@ -12,22 +12,22 @@
 #define OUTPUT_RATIO (8) // we will analyse 1/this of B
 #define TURING_RATIO (16) // and use a further 1/this for Turing
 #define EXTRA_BITS (35) // extra bits of precision for convolves etc.
-#define verbose (false)
-#define BAD_64 (1LL<<62)
+#define verbose (false) // compile-time toggle for all diagnostic printf
+#define BAD_64 (1LL<<62) // sentinel: an arb value did not pin to a unique integer
 
 #ifdef BUTHE
 // how many integrals have I precomputed for Buthe's method?
 #define MAX_MUI (100)
-#define MAX_MUI_2 (200)
-#define MAX_MU ((double) MAX_MUI)
-#define MAX_MU_2 ((double) MAX_MUI_2)
+#define MAX_MUI_2 (200) // = 2*MAX_MUI; a Buthe table row holds 2*MAX_MUI_2+1 entries
+#define MAX_MU ((double) MAX_MUI) // largest mu Buthe can handle (MAX_MUI as a double)
+#define MAX_MU_2 ((double) MAX_MUI_2) // MAX_MUI_2 as a double
 #endif
 
 #define MAX_L (10) // maximum differential allowed in upsampling
 
 
-#define COMPUTE_ZEROS
-#define COMPUTE_RANK
+#define COMPUTE_ZEROS // compile-time switch: enable the zero-finding phase
+#define COMPUTE_RANK // compile-time switch: enable the rank-determination phase
 
 
 #ifdef __cplusplus
@@ -35,29 +35,29 @@ extern "C"{
 #endif
 
   typedef struct{
-    uint64_t degree;
-    uint64_t conductor;
-    double normalisation;
-    double *mus;
-    int64_t target_prec;
-    arb_t zero_prec;
-    arb_t zero_error;
-    int64_t wprec; // working precision
-    int64_t gprec; // precison used by g
-    char *cache_dir;
-    int self_dual;
-    int rank;
-    arb_t mu;
-    arb_t nu;
-    arb_t *nus;
+    uint64_t degree; // degree r (number of Gamma_R factors), 2 <= r <= MAX_DEGREE
+    uint64_t conductor; // arithmetic conductor N
+    double normalisation; // algebraic->analytic s-shift = (k-1)/2; only used to form mus
+    double *mus; // Gamma_R shifts (user mus + normalisation), sorted, non-neg half-ints
+    int64_t target_prec; // target output precision in bits (default DEFAULT_TARGET_PREC=100)
+    arb_t zero_prec; // intended zero half-width 2^(-target_prec-1); only feeds zero_error
+    arb_t zero_error; // intended zero error ball of radius zero_prec; unused
+    int64_t wprec; // internal working precision in bits = target_prec + decay + EXTRA_BITS
+    int64_t gprec; // precision in bits used by the G/gamma-factor computation (>= wprec)
+    char *cache_dir; // directory for cached G-data; used only in default-precision mode
+    int self_dual; // self-dual? DK(-1)/NO(0)/YES(1); YES skips dual-side zeros & Turing
+    int rank; // analytic rank = order of vanishing at s=1/2; DK(-1) until computed
+    arb_t mu; // scalar -1/2+(1+sum mus)/r (Artin Lemma 5.2); unused
+    arb_t nu; // scalar 1/2+(2/r)*sum(nus); shift param for the error bounds (Lemma 2/5)
+    arb_t *nus; // shifts nus[j]=(mus[j]-1/2)/2 for j<2 else (mus[j]-1)/2 (Lemma 2/5)
     arb_t C;           // coeff bound: |a_n| <= C*n^alpha
     arb_t alpha;       // alpha = 1 under Ramanujan (set in g.c)
     //arb_t k0; // no longer used
     //arb_t k2;
     double one_over_B; // 1/B = degree/512; the G-kernel u-grid step is 2*pi/B
-    arb_t B;
-    arb_t two_pi_by_B;
-    arb_t pi;
+    arb_t B; // scaling parameter B = 1/one_over_B; sets the t-spacing of Lambda samples
+    arb_t two_pi_by_B; // 2*pi/B: u-spacing between consecutive G/Lambda sample indices
+    arb_t pi; // the constant pi at working precision wprec
     int64_t low_i;     // bottom of G u-grid: floor(u_min/(2*pi/B)), u_min=-32*ln2; reaches the m=1 term
     int64_t hi_i;      // top of G u-grid: smallest i with |G(u_i)|<=2^-prec; sets M=sqrt(N)*exp(2*pi*(hi_i+.5)/B)
     uint64_t max_K;    // number of Taylor terms per grid point (first index of Gs)
@@ -66,69 +66,71 @@ extern "C"{
     arb_t **Gs;        // Gs[k][i-low_i] = k-th Taylor coeff G^(k)(u_i)/k! at u_i=i*(2*pi/B); built in g.c
 
     // computation related
-    uint64_t fft_N;
-    uint64_t fft_NN;
-    double A;
-    arb_t arb_A;
-    arf_t arf_A;
-    arb_t one_over_A;
-    arf_t arf_one_over_A;
-    acb_t *G;
+    uint64_t fft_N; // length of the short DFT for the Euler-product convolutions (2^11)
+    uint64_t fft_NN; // length of the final output iFFT (2^16)
+    double A; // output sampling rate = fft_NN/B; output sample i is Lambda at t = i/A
+    arb_t arb_A; // A as a rigorous real ball (for the error analysis)
+    arf_t arf_A; // A as an arf_t; only used to form arf_one_over_A
+    arb_t one_over_A; // 1/A as a ball; the t-grid spacing (sample i has imag part i/A)
+    arf_t arf_one_over_A; // 1/A as an arf_t; unused
+    acb_t *G; // length-fft_N acb scratch staging one Gs[k] column per convolution
     acb_t *w; // twiddle factors for length fft_N
     acb_t *ww; // ditto for fft_NN
-    arb_t *zeros[2];
-    double eta;
-    arb_t delta;
-    arb_t exp_delta;
-    acb_t *kres,*res,**skm;
-    arb_t pre_ftwiddle_error;
-    arb_t ftwiddle_error;
+    arb_t *zeros[2]; // zero ordinates t on the critical line; [0]=L, [1]=dual L
+    double eta; // contour-tilt knob in delta=(1-eta)*pi/2; =0, only feeds delta
+    arb_t delta; // contour offset (1-eta)*pi/2 = pi/2; only feeds (unused) exp_delta
+    arb_t exp_delta; // exp(-delta) = exp(-pi/2); unused
+    acb_t *kres; // per-k convolution result, accumulated into res
+    acb_t *res; // length-fft_NN buffer: convolution sum, then iFFT'd to Lambda samples
+    acb_t **skm; // skm[k][n]: a_m/sqrt(m)*(log(m/sqrtN)-u_m)^k bucketed by freq index n
+    arb_t pre_ftwiddle_error; // conductor-free bound on the truncated Dirichlet-series tail
+    arb_t ftwiddle_error; // truncation bound = pre_ftwiddle_error*sqrt(N); added per sample
 
 #ifdef BUTHE
-    arb_t buthe_Wf;
-    arb_t buthe_Winf;
-    arb_t buthe_Ws;
-    arb_t buthe_b;
-    arb_t buthe_C;
-    arb_t buthe_h;
-    arb_t buthe_ints[(MAX_R-1)*(2*MAX_MUI_2+1)];
-    uint64_t buthe_M;
+    arb_t buthe_Wf; // prime/Euler-sum term of Buthe's inequality
+    arb_t buthe_Winf; // archimedean (gamma) term of Buthe's inequality (uses buthe_ints)
+    arb_t buthe_Ws; // sum-over-computed-zeros term of Buthe's inequality
+    arb_t buthe_b; // height up to which RH is confirmed, b = B/OUTPUT_RATIO
+    arb_t buthe_C; // Buthe constant = degree (Lemma 3.4); unused
+    arb_t buthe_h; // Buthe test-function step h = BUTHE_H
+    arb_t buthe_ints[(MAX_R-1)*(2*MAX_MUI_2+1)]; // precomputed gamma-integral table [deg-2][2*mu]
+    uint64_t buthe_M; // prime-power cutoff for the Wf sum = floor(sqrt(#coeffs))
 #endif
 
 #ifdef TURING
-    arb_t X; // see eq 4.10
-    arb_t imint;
+    arb_t X; // Turing zero-counting verification height (see eq 4.10)
+    arb_t imint; // integral of Im sum_j logGamma((1/2+it+mu_j)/2) over the Turing region
 #endif
     
-    arb_t one_over_root_N;
-    arb_t sum_ans;
-    acb_t sqrt_sign;
-    acb_t sign;
-    acb_t *ans;
-    uint64_t M;
-    uint64_t M0;
-    uint64_t allocated_M;
-    double dc;
+    arb_t one_over_root_N; // 1/sqrt(N), the N^{s/2} factor base in Lambda
+    arb_t sum_ans; // running sum of |a_n|/sqrt(n), n<=M; scales the eq59 tail error
+    acb_t sqrt_sign; // unit-modulus square root of the root number (sqrt_sign^2 = sign)
+    acb_t sign; // root number eps in Lambda(s)=eps*Lambda(1-s); = sqrt_sign^2
+    acb_t *ans; // Dirichlet coefficients: ans[n-1] = a_n (analytic norm), len allocated_M
+    uint64_t M; // largest n with a_n used = floor(sqrt(N)*exp(2*pi*(hi_i+0.5)/B))
+    uint64_t M0; // split point ceil(sqrt(N)/100): n<M0 summed directly, n>=M0 via FFT
+    uint64_t allocated_M; // allocated capacity of ans (slots); M0, M <= allocated_M
+    double dc; // sqrt(conductor); log-scale center mapping coeff index to FFT bin
 
     bool nmax_called; // true if user/system has called Lfunc_nmax
 
-    int64_t offset;
+    int64_t offset; // FFT bin index of a_1 = calc_m(1); used only for a bounds check
 
-    uint64_t u_N;
+    uint64_t u_N; // upsampling kernel half-width = ceil(A^2 h^2/2); kernel = 2*u_N+1 pts
     //arb_t *u_coshs;
     //arb_t *u_exps;
-    arb_t u_H;
-    arb_t u_pi_by_H2; //-pi/H^2
-    arb_t u_A;
-    arb_t u_one_over_A;
-    arb_t *u_values[2];
-    arb_t *u_values_off[2]; // will contain Lam(t)
+    arb_t u_H; // Gaussian window width h in the interpolation kernel
+    arb_t u_pi_by_H2; // -pi/h^2: coefficient of (t-k/A)^2 in the Gaussian window
+    arb_t u_A; // upsampling sample rate = A*u_stride (= A, since u_stride = 1)
+    arb_t u_one_over_A; // 1/u_A: the upsampling grid spacing in t
+    arb_t *u_values[2]; // per-side raw samples of -Lambda (full buffer incl. left guard)
+    arb_t *u_values_off[2]; // view into u_values past the guard: index k = Lam(k/A)
     // Lam(t)=eps^1/2 N^it/2 prod gamma_r(1/2+it+mu_j) L(1/2+it)
-    uint64_t u_no_values;
-    uint64_t u_no_values_off;
-    uint64_t u_stride;
-    arb_t u_pi_A;
-    arb_t upsampling_error;
+    uint64_t u_no_values; // element count of each u_values[side]
+    uint64_t u_no_values_off; // count of each u_values_off[side] = u_no_values - 2*u_N*u_stride
+    uint64_t u_stride; // sample decimation; hardwired to 1 (use every FFT grid point)
+    arb_t u_pi_A; // pi*u_A: sinc-argument scale and (pi*A)^d derivative factor
+    arb_t upsampling_error; // rigorous upsampling error bound, added to every upsampled value
 
     arb_t Lam_d; // Lambda^(rank)(1/2)
     arb_t L_d; // L^(rank)(1/2)/rank!

--- a/src/buthe.c
+++ b/src/buthe.c
@@ -8,7 +8,7 @@ extern "C"{
 
 
   // We use Buthe's method to verify our list of zeros
-  // we set h=4
+  // we set h=8
   // and use the zeros up to height 96/r to check the list to height buthe_b=64/r
   // This is probably huge overkill
 

--- a/src/upsample.c
+++ b/src/upsample.c
@@ -343,7 +343,7 @@ Lerror_t init_upsampling(Lfunc *L)
   arb_set_d(L->u_H, h);
   L->u_N=H;
   if(verbose){printf("Upsampling H set to ");arb_printd(L->u_H,20);printf("\n");}
-  arb_init(L->u_pi_by_H2); // -1/2H^2
+  arb_init(L->u_pi_by_H2); // -pi/H^2
   arb_inv(L->u_pi_by_H2,L->u_H,prec); // 1/H
   arb_mul(L->u_pi_by_H2,L->u_pi_by_H2,L->u_pi_by_H2,prec); // 1/H^2
   arb_mul(L->u_pi_by_H2,L->u_pi_by_H2,L->pi,prec);


### PR DESCRIPTION
## Summary

Completes one-line documentation coverage for the library's global constants
and internal `Lfunc` fields, building on the G-kernel grid fields already
documented on `main` (3ae6ec5). Also corrects two stale code comments found
along the way. **Documentation/comment-only — no behavior change.**

## What changed

**`include/glfunc.h`** — comment-only
- Documented the tri-state `DK`/`YES`/`NO`, the `BUTHE`/`TURING` RH-method
  toggles, `MAX_R`/`MAX_ZEROS`/`DEFAULT_TARGET_PREC`, and the two error codes
  that had no comment (`ERR_SUCCESS`, `ERR_M_ERROR`). Existing one-liners are
  left as-is.

**`include/glfunc_internals.h`**
- Documented every macro (`verbose`, `BAD_64`, the `MAX_MU*` family,
  `COMPUTE_ZEROS`/`COMPUTE_RANK`) and every *remaining* `Lfunc` struct field,
  recording each one's mathematical meaning, units, and key formulas (mostly
  from the *Computing motivic L-functions* paper). The G-kernel grid fields
  (`C`, `alpha`, `one_over_B`, `low_i`, `hi_i`, `max_K`, `eq59`, `Gs`) were
  already documented on `main` by 3ae6ec5 and are kept as-is.
- The only non-comment change: `acb_t *kres,*res,**skm;` is split into three
  separate declarations (identical types) so each field gets its own doc.
  Also fixes a `precison` -> `precision` typo on `gprec`.

**`src/upsample.c`, `src/buthe.c`** — correct two stale comments
- `upsample.c`: the init-line comment on `u_pi_by_H2` read `-1/2H^2`, but the
  following lines compute `-pi/H^2` (matching the `arb_neg` trailing comment
  and the struct-field doc).
- `buthe.c`: a header comment said "we set h=4", but `BUTHE_H` is `8`
  (`#define BUTHE_H (8)` in `gp/buthe_ints.out`).

## Notable findings

Nine struct fields are **computed at init but never read** anywhere in the tree
(verified repo-wide). They are tagged `unused` in their doc comments, in case
they are worth pruning later:

- `mu`, `zero_error`, `exp_delta`, `arf_one_over_A`, `buthe_C`
- plus the dead feeder chains `eta` -> `delta` -> `exp_delta`,
  `zero_prec` -> `zero_error`, and `arf_A` -> `arf_one_over_A`.

## Verification

- **Comment-only proof:** after stripping `//` comments, this branch diffs
  against `main` to *nothing* — except the intentional `kres/res/skm`
  declaration split.
- **Compiles:** `glfunc.h` (C), `glfunc_internals.h` (C and C++ via
  `extern "C"`), and `src/compute.c` / `src/clear.c` / `src/upsample.c` all
  pass `gcc`/`g++ -fsyntax-only`.
