### PR TITLE
refactor: drop flintxx in favor of in-tree lflint.h wrapper

### DIFF
--- a/examples/artin.cpp
+++ b/examples/artin.cpp
@@ -21,7 +21,6 @@
 #include <string>
 #include <vector>
 #include <flint/fmpz.h>
-//#include <flint/fmpzxx.h>  // removed: FLINT 3.x dropped flintxx; fmpzxx comes from examples_tools.h
 #include <flint/nmod_poly.h>
 #include <flint/nmod_poly_factor.h>
 #include <flint/fq_nmod.h>
@@ -69,10 +68,10 @@ typedef std::chrono::time_point<std::chrono::system_clock> SystemTime ;
 
 
 
-// converts vector<fmpzxx> to a fq_nmod_poly_t
+// converts vector<ZZ> to a fq_nmod_poly_t
 // if neg, returns f(-x) or -f(-x) to keep it monic, in case it was monic
 void conv(fq_nmod_poly_t res,
-          const vector<fmpzxx> &polynomial,
+          const vector<ZZ> &polynomial,
           const fq_nmod_ctx_t ctx,
           const bool &neg = false) {
   fq_nmod_poly_fit_length(res, polynomial.size(), ctx);
@@ -83,16 +82,16 @@ void conv(fq_nmod_poly_t res,
   for(size_t i = 0; i < polynomial.size(); ++i) {
     fq_nmod_set_fmpz(
         tmp,
-        (neg and i % 2 == parity) ? (-polynomial[i]).evaluate()._fmpz() : polynomial[i]._fmpz(),
+        (neg and i % 2 == parity) ? (-polynomial[i])._fmpz() : polynomial[i]._fmpz(),
         ctx);
     fq_nmod_poly_set_coeff(res, i, tmp, ctx);
   }
   fq_nmod_clear(tmp, ctx);
 }
 
-// converts vector<fmpzxx> to a nmod_poly_t
+// converts vector<ZZ> to a nmod_poly_t
 void conv(nmod_poly_t pol,
-          const vector<fmpzxx> &polynomial) {
+          const vector<ZZ> &polynomial) {
   nmod_poly_fit_length(pol, polynomial.size());
   for(size_t i = 0; i < polynomial.size(); ++i)
     nmod_poly_set_coeff_ui(pol, i,
@@ -101,7 +100,7 @@ void conv(nmod_poly_t pol,
 
 // computes the roots of split polynomial over Fq
 void split_roots(vector<fq_nmod_struct> &res,
-                 const vector<fmpzxx> &polynomial,
+                 const vector<ZZ> &polynomial,
                  const fq_nmod_ctx_t ctx) {
   // if not empty, we will leak memory
   assert_print(res.size(), ==, 0);
@@ -175,7 +174,7 @@ void split_roots(vector<fq_nmod_struct> &res,
 
 // given p, figures out the cycle type of Frobenious
 void cycle_type(vector<size_t>& res,
-                const vector<fmpzxx> &polynomial,
+                const vector<ZZ> &polynomial,
                 const int64_t &p) {
   nmod_poly_t pol;
   nmod_poly_init2(pol, p, polynomial.size());
@@ -218,7 +217,7 @@ void powers_sum(fq_nmod_t res,
 void alpha_res(mp_limb_t &res,
                const vector<fq_nmod_struct> &roots,
                const vector<int64_t> &powers,
-               const vector<fmpzxx> &gamma_polynomial,
+               const vector<ZZ> &gamma_polynomial,
                const fq_nmod_ctx_t ctx) {
 
   fq_nmod_poly_t gamma;
@@ -255,7 +254,7 @@ void alpha_res(mp_limb_t &res,
 
 void conjugacy_class_matcher_res_alt(size_t &c,
                                      const mp_limb_t &alpha,
-                                     const vector< pair<size_t, vector<fmpzxx> > > *root_of,
+                                     const vector< pair<size_t, vector<ZZ> > > *root_of,
                                      const int64_t &p) {
   size_t max_len = 0;
   for(const auto &elt: *root_of) {
@@ -425,7 +424,7 @@ void alpha_alt(mp_limb_t &res,
 }
 
 
-void conv(vector<acb_poly_struct> &local_factors, const vector< vector< vector< fmpzxx > > > &local_factors_int, const size_t &n, const int64_t &prec) {
+void conv(vector<acb_poly_struct> &local_factors, const vector< vector< vector< ZZ > > > &local_factors_int, const size_t &n, const int64_t &prec) {
   assert_print(local_factors.size(), ==, 0);
   local_factors.resize(local_factors_int.size());
   acb_t tmp;
@@ -446,7 +445,7 @@ void conv(vector<acb_poly_struct> &local_factors, const vector< vector< vector< 
   }
 
   for(size_t i = 0; i < local_factors_int.size(); ++i) {
-    const vector< vector<fmpzxx> > &pzz = local_factors_int[i];
+    const vector< vector<ZZ> > &pzz = local_factors_int[i];
     acb_poly_init(&local_factors[i]);
     acb_poly_fit_length(&local_factors[i], pzz.size());
     for(size_t j = 0; j < pzz.size(); ++j) {
@@ -467,12 +466,12 @@ void conv(vector<acb_poly_struct> &local_factors, const vector< vector< vector< 
 
 typedef struct {
   // index(C) --> gamma_C
-  vector< pair<size_t, vector<fmpzxx> > > root_of;
+  vector< pair<size_t, vector<ZZ> > > root_of;
   vector<size_t> permutation;
 } alt_data;
 
 istream & operator>>(istream& s, alt_data& out) {
-  pair<vector< pair<size_t, vector<fmpzxx> > >, vector<size_t>> p;
+  pair<vector< pair<size_t, vector<ZZ> > >, vector<size_t>> p;
   if( !(s >> p) )
     throw_line("bad alt data"s);
   out.root_of = p.first;
@@ -491,13 +490,13 @@ ostream& operator<<(ostream& s, const alt_data& a)
 
 typedef struct {
   // index(C) --> gamma_C
-  vector< pair<size_t, vector<fmpzxx> > > root_of;
+  vector< pair<size_t, vector<ZZ> > > root_of;
   vector<int64_t> powers;
-  vector<fmpzxx> gamma_polynomial;
+  vector<ZZ> gamma_polynomial;
 } res_data;
 
 istream & operator>>(istream& s, res_data& out) {
-  pair<vector< pair<size_t, vector<fmpzxx> > >, vector<vector<fmpzxx> > > p;
+  pair<vector< pair<size_t, vector<ZZ> > >, vector<vector<ZZ> > > p;
   if( !(s >> p) )
     throw_line("bad res data"s);
   out.root_of = p.first;
@@ -533,7 +532,7 @@ typedef struct {
   int64_t conductor;
 
   // artin field
-  vector<fmpzxx> polynomial;
+  vector<ZZ> polynomial;
 
   // mus
   double* mus;
@@ -552,7 +551,7 @@ typedef struct {
   array<acb_struct, special_values_size> special_values;
 
   // p -> conjugacy class
-  map<fmpzxx, size_t> hard_primes;
+  map<ZZ, size_t> hard_primes;
 
   // cycle type -> type
   //  0 = cyc
@@ -661,7 +660,7 @@ istream & operator>>(istream & is, artin_rep &o)
         break;
       case 6:
         {
-          vector< vector< vector<fmpzxx> > > local_factors_int;
+          vector< vector< vector<ZZ> > > local_factors_int;
           if(!(ss >> local_factors_int))
             throw_line("bad local factors"s);
           conv(o.local_factors, local_factors_int, o.n, Lfunc_wprec(o.L));
@@ -728,7 +727,7 @@ ostream& operator<<(ostream &s, artin_rep &AR) {
 void lpoly(const int64_t &p, artin_rep &AR) {
   size_t c;
   // is a hard prime?
-  auto hp = AR.hard_primes.find(fmpzxx(p));
+  auto hp = AR.hard_primes.find(ZZ(p));
   if( hp != AR.hard_primes.end() ) {
     c = hp->second;
   } else {
@@ -751,7 +750,7 @@ void lpoly(const int64_t &p, artin_rep &AR) {
       split_roots(roots, AR.polynomial, ctx);
 
       mp_limb_t alpha;
-      const vector< pair<size_t, vector<fmpzxx> > > *root_of_data;
+      const vector< pair<size_t, vector<ZZ> > > *root_of_data;
       if(type == 2) {
         const res_data &data = AR.res[ct];
         root_of_data = &data.root_of;

--- a/examples/cmf_23.1.b.a.cpp
+++ b/examples/cmf_23.1.b.a.cpp
@@ -67,12 +67,10 @@ Z-plot in [0, 10]:
 #include <string>
 #include <vector>
 #include <flint/fmpz.h>
-//#include <flint/fmpzxx.h>
 #include <flint/acb_poly.h>
 #include "glfunc_internals.h"
-//#include "examples_tools.h"
 
-//using flint::fmpzxx;
+
 using std::cout;
 using std::endl;
 using std::int64_t;

--- a/examples/cmf_25.12.a.a.cpp
+++ b/examples/cmf_25.12.a.a.cpp
@@ -65,12 +65,10 @@ Z-plot in [0, 10]:
 #include <string>
 #include <vector>
 #include <flint/fmpz.h>
-//#include <flint/fmpzxx.h>  // removed: FLINT 3.x dropped the C++ interface
 #include <flint/acb_poly.h>
 #include "glfunc.h"
-//#include "examples_tools.h"  // removed: pulls in flintxx
 
-//using flint::fmpzxx;
+
 using std::cout;
 using std::endl;
 using std::int64_t;

--- a/examples/cmf_7.3.b.a.cpp
+++ b/examples/cmf_7.3.b.a.cpp
@@ -65,13 +65,11 @@ Z-plot in [0, 10]:
 #include <string>
 #include <vector>
 #include <flint/fmpz.h>
-//#include <flint/fmpzxx.h>
 #include <flint/acb_poly.h>
 #include <cassert>
 #include "glfunc_internals.h"
-//#include "examples_tools.h"
 
-//using flint::fmpzxx;
+
 using std::cout;
 using std::endl;
 using std::int64_t;

--- a/examples/dir.cpp
+++ b/examples/dir.cpp
@@ -19,13 +19,11 @@ characters mod 5 and the quadratic character mod 7 together.
 #include <string>
 #include <vector>
 #include <flint/fmpz.h>
-//#include <flint/fmpzxx.h>  // removed: FLINT 3.x dropped the C++ interface
 #include <flint/acb_poly.h>
 #include <cassert>
 #include "glfunc.h"
-//#include "examples_tools.h"  // removed: pulls in flintxx
 
-//using flint::fmpzxx;
+
 using std::cout;
 using std::endl;
 using std::int64_t;

--- a/examples/ec_37.a1.cpp
+++ b/examples/ec_37.a1.cpp
@@ -67,14 +67,11 @@ Z-plot in [0, 10]:
 #include <string>
 #include <vector>
 #include <flint/fmpz.h>
-//#include <flint/fmpzxx.h>
 #include <flint/acb_poly.h>
 #include "glfunc.h"
 #include "glfunc_internals.h"
-//#include "examples_tools.h"
 #include <cassert>
 
-//using flint::fmpzxx;
 using std::cout;
 using std::endl;
 using std::int64_t;

--- a/examples/ec_389.a1.cpp
+++ b/examples/ec_389.a1.cpp
@@ -71,13 +71,11 @@ Z-plot in [0, 10]:
 #include <string>
 #include <vector>
 #include <flint/fmpz.h>
-//#include <flint/fmpzxx.h>  // removed: FLINT 3.x dropped the C++ interface
 #include <flint/acb_poly.h>
 #include "glfunc.h"
 #include <cassert>
-//#include "examples_tools.h"  // removed: pulls in flintxx
 
-//using flint::fmpzxx;
+
 using std::cout;
 using std::endl;
 using std::int64_t;

--- a/examples/ec_5077.a1.cpp
+++ b/examples/ec_5077.a1.cpp
@@ -73,14 +73,11 @@ Z-plot in [0, 10]:
 #include <sstream>
 #include <string>
 #include <vector>
-//#include <flint/fmpz.h>
-//#include <flint/fmpzxx.h>
 #include <flint/acb_poly.h>
 #include "glfunc_internals.h"
-//#include "examples_tools.h"
 #include <cassert>
 
-//using flint::fmpzxx;
+
 using std::cout;
 using std::endl;
 using std::int64_t;

--- a/examples/smalljac.cpp
+++ b/examples/smalljac.cpp
@@ -255,13 +255,15 @@ void curve_clear(curve &C) {
 
 
 void remove_riemann_shift(ZZX& L, const unsigned long p, const unsigned long shift){
-  fmpzxx ppower(p);
-  ppower = pow(ppower, shift);
-  for(int i = 1; i <= L.degree(); ++i)
-    L.coeff(i) += ppower*L.coeff(i-1);
-
-  assert_print(L.lead(), ==, 0);
-  L._normalise();
+  ZZ ppower(static_cast<ulong>(p));
+  ppower = pow(ppower, static_cast<ulong>(shift));
+  const slong d = L.degree();          // capture BEFORE the loop
+  for(slong i = 1; i <= d; ++i)
+    L.set_coeff(i, L.get_coeff(i) + ppower * L.get_coeff(i-1));
+  // Dividing out (1 - p^shift·T) zeroes the degree-d coefficient;
+  // set_coeff auto-normalises, so exact division drops the degree by
+  // exactly one. This replaces the old lead()==0 / _normalise() pair.
+  assert_print(L.degree(), ==, d - 1);
 }
 
 // implemented at the bottom

--- a/examples/smalljac.cpp
+++ b/examples/smalljac.cpp
@@ -60,8 +60,6 @@ int main() {
 #include <flint/flint.h>
 #include <flint/fmpz.h>
 #include <flint/fmpz_poly.h>
-#include <flint/fmpzxx.h>
-#include <flint/fmpz_polyxx.h>
 #include <flint/nmod_poly.h>
 #include <flint/fq_nmod.h>
 #include <flint/fq_nmod_poly.h>
@@ -77,9 +75,6 @@ int main() {
 
 using std::array;
 using std::strcpy;
-using flint::fmpzxx;
-using flint::fmpqxx;
-using flint::fmpz_polyxx;
 
 #define M61UI		0x1FFFFFFFFFFFFFFFUL		// this should raise a compile-time error on 32-bit machines
 
@@ -108,7 +103,7 @@ typedef struct {
   bool cm; // only applies for genus 1
 
   // the bad local factors
-  multimap<int64_t, vector<fmpzxx>> bad_factors;
+  multimap<int64_t, vector<ZZ>> bad_factors;
 
   // Sym^d(L(C))
   int symdegree;
@@ -118,14 +113,14 @@ typedef struct {
 
 
   // nf field stuff
-  fmpz_polyxx nf_poly;
-  fmpzxx nf_disc;
+  ZZX nf_poly;
+  ZZ nf_disc;
   unsigned long lastq;
-  fmpz_polyxx last_local_factor;
+  ZZX last_local_factor;
   vector<bool> touched; // the euler factors already used
 
   //stores ap, p < 2^13
-  array<fmpzxx, APHASH_MAXPI> ap;
+  array<ZZ, APHASH_MAXPI> ap;
 
   //2nd moment approximation
   double second_moment;
@@ -200,7 +195,7 @@ istream &operator>>(istream &is, curve &o)
           fmpz_poly_discriminant(o.nf_disc._fmpz(), o.nf_poly._poly());
           // make it maximal at 2
           while( o.nf_disc.divisible(4) ) { o.nf_disc = o.nf_disc.divexact(4); }
-          if ( (o.nf_disc % fmpzxx(4)) != 1 ) o.nf_disc *= 4;
+          if ( (o.nf_disc % ZZ(4)) != 1 ) o.nf_disc *= 4;
         }
         o.degree = 2*o.genus*o.nf_degree;
         if(o.symdegree > 1) {
@@ -259,7 +254,7 @@ void curve_clear(curve &C) {
 }
 
 
-void remove_riemann_shift(fmpz_polyxx& L, const unsigned long p, const unsigned long shift){
+void remove_riemann_shift(ZZX& L, const unsigned long p, const unsigned long shift){
   fmpzxx ppower(p);
   ppower = pow(ppower, shift);
   for(int i = 1; i <= L.degree(); ++i)
@@ -271,7 +266,7 @@ void remove_riemann_shift(fmpz_polyxx& L, const unsigned long p, const unsigned 
 
 // implemented at the bottom
 // sets L to Sym^d L
-void sympow_ECQ(fmpz_polyxx& L, const int &symdegree);
+void sympow_ECQ(ZZX& L, const int &symdegree);
 
 int smalljac_callback(
      __attribute__((unused)) smalljac_curve_t c,
@@ -283,7 +278,7 @@ int smalljac_callback(
 
   curve *C = (curve *)arg;
   static acb_poly_t local_factor;
-  static fmpz_polyxx local_factor_zz;
+  static ZZX local_factor_zz;
   static bool init = false;
   if(!init) {
     acb_poly_init(local_factor);
@@ -298,7 +293,7 @@ int smalljac_callback(
       local_factor_zz.set_coeff(i + 1, a[i]);
     // complete with the functional equation
     if( n == C->genus) {
-      fmpzxx qn(q);
+      ZZ qn(q);
       for(int i = C->genus + 1; i <= 2*C->genus; ++i) {
         local_factor_zz.set_coeff(i, local_factor_zz.get_coeff(2*C->genus - i)*qn);
         qn *= q;
@@ -319,7 +314,7 @@ int smalljac_callback(
   if(C->nf_degree == 2){
     if(n_is_square(q)) {
       q = n_sqrt(q); // so we call Lfunc_use_lpoly accordingly
-      fmpz_polyxx local_factor_zz2(2*local_factor_zz.degree() + 1);
+      ZZX local_factor_zz2(2*local_factor_zz.degree() + 1);
       for(long i=0; i <= 2*local_factor_zz.degree(); ++i) {
         if(i%2 == 0)
           local_factor_zz2.set_coeff(i, local_factor_zz.get_coeff(i/2));
@@ -329,7 +324,7 @@ int smalljac_callback(
       if(C->lastq == q) {
         local_factor_zz *= C->last_local_factor;
       } else {
-        C->last_local_factor = fmpz_polyxx(local_factor_zz);
+        C->last_local_factor = ZZX(local_factor_zz);
         use_lpoly = false;
       }
     }
@@ -354,16 +349,16 @@ int smalljac_callback(
     _acb_poly_set_length(local_factor, local_factor_zz.degree() + 1);
     for(long i = 0; i <= local_factor_zz.degree(); ++i) {
       // acb_poly_get_coeff_ptr(local_factor, i) = local_factor->coeffs + i
-      acb_set_fmpz(local_factor->coeffs + i, local_factor_zz.coeff(i)._fmpz());
+      acb_set_fmpz(local_factor->coeffs + i, local_factor_zz.get_coeff(i)._fmpz());
     }
     Lfunc_use_lpoly(C->L, q, local_factor);
     C->touched[q] = true;
     if(local_factor_zz.degree() >= 1) {
       if( q <= APHASH_MAXP ) {
-        C->ap[primes_dict[(int16_t)q]] = -local_factor_zz.coeff(1);
+        C->ap[primes_dict[(int16_t)q]] = -local_factor_zz.get_coeff(1);
       }
       // += ap^2 / p^w = (ap/n^(w/2))^2
-      C->second_moment += pow(local_factor_zz.coeff(1).to<double>(), 2)/pow(double(q), C->symdegree);
+      C->second_moment += pow(local_factor_zz.get_coeff(1).to<double>(), 2)/pow(double(q), C->symdegree);
     }
   }
   //acb_poly_clear(local_factor);
@@ -385,7 +380,7 @@ long populate_local_factors(curve &C) {
     acb_poly_init(local_factor);
     acb_poly_fit_length(local_factor, C.degree + 1);
     for(const auto &it : C.bad_factors){
-      assert_print(C.nf_disc % fmpzxx(it.first), ==, 0);
+      assert_print(C.nf_disc % ZZ(it.first), ==, 0);
       if( it.first <= (long) bound ) {
         _acb_poly_set_length(local_factor, it.second.size());
         for(size_t i = 0; i < it.second.size(); ++i) {
@@ -562,12 +557,12 @@ int main (int argc, char**argv) {
 
 
 
-void sympow_ECQ(fmpz_polyxx& L, const int &symdegree) {
+void sympow_ECQ(ZZX& L, const int &symdegree) {
   assert_print(symdegree, <=, 8);
   assert_print(L.degree(), ==, 2);
   assert_print(L.get_coeff(0).is_one(), ==, true);
-  static array<fmpzxx, 21> a;
-  static array<fmpzxx, 37> p;
+  static array<ZZ, 21> a;
+  static array<ZZ, 37> p;
   const array<int, 7> maxapower = {2, 4, 6, 9, 12, 16, 20};
   const array<int, 7> maxppower = {3, 6, 10, 15, 21, 28, 36};
 
@@ -726,8 +721,8 @@ out += r"""
 assert_print(symdegree, <=, {max_symdeg});
 assert_print(L.degree(), ==, 2);
 assert_print(L.get_coeff(0).is_one(), ==, true);
-static std::array<fmpzxx, {maxa1}> a;
-static std::array<fmpzxx, {maxp1}> p;
+static std::array<ZZ, {maxa1}> a;
+static std::array<ZZ, {maxp1}> p;
 const std::array<int, {length}> maxapower = {maxapower};
 const std::array<int, {length}> maxppower = {maxppower};
 """.format(max_symdeg=max_symdeg,
@@ -793,7 +788,7 @@ out += r"""
       throw_line("we cannot get here!"s);
     }
 """
-out = 'void sympow_ECQ(fmpz_polyxx& L, const int &symdegree) {' + out + '\n}'
+out = 'void sympow_ECQ(ZZX& L, const int &symdegree) {' + out + '\n}'
 print(out)
 */
 

--- a/examples/tau.cpp
+++ b/examples/tau.cpp
@@ -66,14 +66,12 @@ Z-plot in [0, 10]:
 #include <string>
 #include <vector>
 #include <flint/fmpz.h>
-//#include <flint/fmpzxx.h>  // removed: FLINT 3.x dropped the C++ interface
 #include <flint/acb_poly.h>
 #include <cassert>
 #include "glfunc.h"
 #include "glfunc_internals.h"
-//#include "examples_tools.h"  // removed: pulls in flintxx
 
-//using flint::fmpzxx;
+
 using std::cout;
 using std::endl;
 using std::int64_t;

--- a/include/examples_tools.h
+++ b/include/examples_tools.h
@@ -20,13 +20,7 @@
 #include <vector>
 #include <flint/fmpz.h>
 #include <flint/acb.h>
-#if defined(__has_include) && __has_include(<flint/fmpzxx.h>)
-#  include <flint/fmpzxx.h>
-#  include <flint/fmpz_polyxx.h>
-#  define HAVE_FLINTXX 1
-#else
-#  define HAVE_FLINTXX 0  // FLINT >= 3.0 dropped the C++ interface (flintxx)
-#endif
+#include "lflint.h"
 
 #include "glfunc.h" // for Lplot_t
 #include "glfunc_internals.h" // for L->degree
@@ -58,41 +52,8 @@ using namespace std::string_literals;
 using std::stringstream;
 using std::vector;
 
-#if HAVE_FLINTXX
-using flint::fmpzxx;
-using flint::fmpz_polyxx;
-#else
-// Minimal drop-in replacement for flint::fmpzxx over the C fmpz_t API,
-// covering exactly the operations the examples use. (FLINT >= 3.0 removed
-// the C++ wrappers.) fmpz_polyxx is not shimmed: nothing built here uses it.
-class fmpzxx {
-  fmpz_t z;
-public:
-  fmpzxx() { fmpz_init(z); }
-  fmpzxx(slong v) { fmpz_init(z); fmpz_set_si(z, v); }
-  fmpzxx(const fmpzxx& o) { fmpz_init(z); fmpz_set(z, o.z); }
-  fmpzxx(fmpzxx&& o) noexcept { fmpz_init(z); fmpz_swap(z, o.z); }
-  fmpzxx& operator=(const fmpzxx& o) { fmpz_set(z, o.z); return *this; }
-  fmpzxx& operator=(fmpzxx&& o) noexcept { fmpz_swap(z, o.z); return *this; }
-  fmpzxx& operator=(slong v) { fmpz_set_si(z, v); return *this; }
-  ~fmpzxx() { fmpz_clear(z); }
-  fmpz* _fmpz() { return z; }
-  const fmpz* _fmpz() const { return z; }
-  const fmpzxx& evaluate() const { return *this; }
-  fmpzxx operator-() const { fmpzxx r; fmpz_neg(r.z, z); return r; }
-  fmpzxx operator%(mp_limb_t n) const { fmpzxx r; fmpz_mod_ui(r.z, z, n); return r; }
-  fmpzxx& operator*=(slong v) { fmpz_mul_si(z, z, v); return *this; }
-  bool operator<(const fmpzxx& o) const { return fmpz_cmp(z, o.z) < 0; }
-  bool operator==(const fmpzxx& o) const { return fmpz_equal(z, o.z); }
-  template<class T> T to() const { return (T) fmpz_get_ui(z); }
-};
-inline std::ostream& operator<<(std::ostream& s, const fmpzxx& x) {
-  char* str = fmpz_get_str(NULL, 10, x._fmpz());
-  s << str;
-  flint_free(str);
-  return s;
-}
-#endif
+using lfun::ZZ;
+using lfun::ZZX;
 
 
 #ifdef WITH_SPACE
@@ -147,17 +108,17 @@ public:
 
 /******************************************************************************
  * in/out operators for various (templated) classes
- *  - operator >> for fmpzxx
+ *  - operator >> for ZZ
  *  - operators << and >> for vector<T>
  *  - operators << and >> for map<T, R>
  *****************************************************************************/
 
-//operator >> for fmpzxx
-istream & operator>>(istream& s, fmpzxx& output) {
+//operator >> for ZZ
+istream & operator>>(istream& s, ZZ& output) {
   stringstream buffer;
   long c;
   if (!s)
-    throw_line("bad fmpzxx input"s);
+    throw_line("bad ZZ input"s);
 
   c = s.peek();
   while (iswspace(c)) {
@@ -165,7 +126,7 @@ istream & operator>>(istream& s, fmpzxx& output) {
     c = s.peek();
   }
   if (c != '-' and not iswdigit(c))
-    throw_line("bad fmpzxx input"s);
+    throw_line("bad ZZ input"s);
 
   //puts the first character
   buffer.put(s.get());
@@ -389,10 +350,10 @@ ostream & operator<<(ostream& s, const map<T, R, Compare>& a)
 
 // retuns the interval [a*2^e, b*2^e] as [a, b, e]
 ostream& operator<<(ostream& s, const arb_t x) {
-  vector<fmpzxx> tmp(3);
-  fmpzxx &a = tmp[0];
-  fmpzxx &b = tmp[1];
-  fmpzxx &e = tmp[2];
+  vector<ZZ> tmp(3);
+  ZZ &a = tmp[0];
+  ZZ &b = tmp[1];
+  ZZ &e = tmp[2];
   arb_get_interval_fmpz_2exp(a._fmpz(), b._fmpz(), e._fmpz(), x);
   s << tmp;
   return s;
@@ -546,8 +507,7 @@ void convertmonomial(T& coeff, long& deg, const string &s, const string &var) {
 }
 */
 
-#if HAVE_FLINTXX
-istream & operator>>(istream&s,  fmpz_polyxx& f){
+istream & operator>>(istream&s,  ZZX& f){
   f = 0;
   long c;
   stringstream buffer;
@@ -621,11 +581,10 @@ istream & operator>>(istream&s,  fmpz_polyxx& f){
     c = s.peek();
   }
   if(c == '+' or c == '-') {
-    fmpz_polyxx g = fmpz_polyxx();
+    ZZX g = ZZX();
     s >> g;
     f += g;
   }
   return s;
 }
-#endif // HAVE_FLINTXX
 

--- a/include/lflint.h
+++ b/include/lflint.h
@@ -57,6 +57,12 @@ public:
   ZZ operator%(const ZZ& m) const { ZZ r; fmpz_mod   (r.z, z, m.z); return r; }
   ZZ operator%(ulong n)     const { ZZ r; fmpz_mod_ui(r.z, z, n);   return r; }
 
+  bool operator==(const ZZ& o) const { return fmpz_equal   (z, o.z) != 0; }
+  bool operator==(slong n)     const { return fmpz_equal_si(z, n)   != 0; }
+  bool operator!=(const ZZ& o) const { return !(*this == o); }
+  bool operator!=(slong n)     const { return !(*this == n); }
+  bool operator< (const ZZ& o) const { return fmpz_cmp(z, o.z) < 0; }
+
   friend ZZ operator+(const ZZ&, const ZZ&);
   friend ZZ operator-(const ZZ&, const ZZ&);
   friend ZZ operator*(const ZZ&, const ZZ&);

--- a/include/lflint.h
+++ b/include/lflint.h
@@ -52,6 +52,11 @@ public:
   ZZ& operator*=(const ZZ& o) { fmpz_mul  (z, z, o.z); return *this; }
   ZZ& operator*=(slong n)     { fmpz_mul_si(z, z, n); return *this; }
 
+  // Non-negative remainder (0 <= r < |modulus|). Required by
+  // smalljac.cpp:203 (`disc % ZZ(4) != 1` for negative discriminants).
+  ZZ operator%(const ZZ& m) const { ZZ r; fmpz_mod   (r.z, z, m.z); return r; }
+  ZZ operator%(ulong n)     const { ZZ r; fmpz_mod_ui(r.z, z, n);   return r; }
+
   friend ZZ operator+(const ZZ&, const ZZ&);
   friend ZZ operator-(const ZZ&, const ZZ&);
   friend ZZ operator*(const ZZ&, const ZZ&);

--- a/include/lflint.h
+++ b/include/lflint.h
@@ -1,0 +1,31 @@
+// Copyright Edgar Costa 2026
+// See LICENSE file for license details.
+//
+// lflint.h — minimal RAII C++ wrappers over the FLINT C API.
+//
+// Two value types in namespace lfun:
+//   ZZ   — wraps fmpz_t       (arbitrary-precision integer)
+//   ZZX  — wraps fmpz_poly_t  (integer polynomial in T)
+//
+// Covers exactly the surface used by this repo's examples; not a
+// general-purpose flintxx replacement. See
+// docs/superpowers/specs/2026-05-29-drop-flintxx-design.md.
+
+#pragma once
+
+#include <ostream>
+#include <flint/fmpz.h>
+#include <flint/fmpz_poly.h>
+
+namespace lfun {
+
+class ZZ {
+  fmpz_t z;
+public:
+  ZZ() { fmpz_init(z); }
+  ~ZZ() { fmpz_clear(z); }
+
+  bool is_zero() const { return fmpz_is_zero(z); }
+};
+
+} // namespace lfun

--- a/include/lflint.h
+++ b/include/lflint.h
@@ -40,6 +40,9 @@ public:
   const fmpz* _fmpz() const { return z; }
 
   bool is_zero() const { return fmpz_is_zero(z); }
+  bool is_one()  const { return fmpz_is_one(z); }
+  void set_zero()      { fmpz_zero(z); }
+  void set_one()       { fmpz_one(z); }
 };
 
 } // namespace lfun

--- a/include/lflint.h
+++ b/include/lflint.h
@@ -105,4 +105,32 @@ template<> inline slong  ZZ::to<slong>()  const { return fmpz_get_si(z); }
 template<> inline ulong  ZZ::to<ulong>()  const { return fmpz_get_ui(z); }
 template<> inline double ZZ::to<double>() const { return fmpz_get_d (z); }
 
+class ZZX {
+  fmpz_poly_t p;
+public:
+  ZZX()                          { fmpz_poly_init(p); }
+  explicit ZZX(slong alloc)      { fmpz_poly_init2(p, alloc); }
+  ZZX(const ZZX& o)              { fmpz_poly_init(p); fmpz_poly_set(p, o.p); }
+  ZZX(ZZX&& o) noexcept          { fmpz_poly_init(p); fmpz_poly_swap(p, o.p); }
+  ~ZZX()                         { fmpz_poly_clear(p); }
+
+  ZZX& operator=(const ZZX& o)     { fmpz_poly_set(p, o.p); return *this; }
+  ZZX& operator=(ZZX&& o) noexcept { fmpz_poly_swap(p, o.p); return *this; }
+  ZZX& operator=(slong n)          { fmpz_poly_set_si(p, n); return *this; }
+
+  fmpz_poly_struct*       _poly()       { return p; }
+  const fmpz_poly_struct* _poly() const { return p; }
+
+  slong degree() const           { return fmpz_poly_degree(p); }
+  void  fit_length(slong n)      { fmpz_poly_fit_length(p, n); }
+
+  ZZ get_coeff(slong i) const {
+    ZZ r;
+    fmpz_poly_get_coeff_fmpz(r._fmpz(), p, i);
+    return r;
+  }
+  void set_coeff(slong i, slong c)        { fmpz_poly_set_coeff_si(p, i, c); }
+  void set_coeff(slong i, const ZZ& c)    { fmpz_poly_set_coeff_fmpz(p, i, c._fmpz()); }
+};
+
 } // namespace lfun

--- a/include/lflint.h
+++ b/include/lflint.h
@@ -63,6 +63,12 @@ public:
   bool operator!=(slong n)     const { return !(*this == n); }
   bool operator< (const ZZ& o) const { return fmpz_cmp(z, o.z) < 0; }
 
+  // fmpz_divisible_si is FLINT's signed-divisor variant; sign of n is ignored
+  // for the divisibility test. divexact is exact division (UB if not divisible,
+  // same contract as fmpz_divexact_si).
+  bool divisible(slong n) const { return fmpz_divisible_si(z, n) != 0; }
+  ZZ   divexact (slong n) const { ZZ r; fmpz_divexact_si(r.z, z, n); return r; }
+
   friend ZZ operator+(const ZZ&, const ZZ&);
   friend ZZ operator-(const ZZ&, const ZZ&);
   friend ZZ operator*(const ZZ&, const ZZ&);

--- a/include/lflint.h
+++ b/include/lflint.h
@@ -69,6 +69,14 @@ public:
   bool divisible(slong n) const { return fmpz_divisible_si(z, n) != 0; }
   ZZ   divexact (slong n) const { ZZ r; fmpz_divexact_si(r.z, z, n); return r; }
 
+  // Conversion. Supported T: slong, ulong, double. Any other T fires a
+  // dependent static_assert when instantiated (loud compile error, not
+  // a silent wrong value).
+  template<class T> T to() const {
+    static_assert(!sizeof(T*), "ZZ::to<T>: only slong, ulong, double are supported");
+    return T{};  // unreachable; satisfies return-type checker
+  }
+
   friend ZZ operator+(const ZZ&, const ZZ&);
   friend ZZ operator-(const ZZ&, const ZZ&);
   friend ZZ operator*(const ZZ&, const ZZ&);
@@ -84,5 +92,9 @@ inline ZZ operator*(slong a,     const ZZ& b) { ZZ r; fmpz_mul_si(r.z, b.z, a); 
 inline ZZ operator*(const ZZ& a, slong b)     { ZZ r; fmpz_mul_si(r.z, a.z, b); return r; }
 
 inline ZZ pow(const ZZ& a, ulong e) { ZZ r; fmpz_pow_ui(r.z, a.z, e); return r; }
+
+template<> inline slong  ZZ::to<slong>()  const { return fmpz_get_si(z); }
+template<> inline ulong  ZZ::to<ulong>()  const { return fmpz_get_ui(z); }
+template<> inline double ZZ::to<double>() const { return fmpz_get_d (z); }
 
 } // namespace lfun

--- a/include/lflint.h
+++ b/include/lflint.h
@@ -131,6 +131,9 @@ public:
   }
   void set_coeff(slong i, slong c)        { fmpz_poly_set_coeff_si(p, i, c); }
   void set_coeff(slong i, const ZZ& c)    { fmpz_poly_set_coeff_fmpz(p, i, c._fmpz()); }
+
+  ZZX& operator+=(const ZZX& o) { fmpz_poly_add(p, p, o.p); return *this; }
+  ZZX& operator*=(const ZZX& o) { fmpz_poly_mul(p, p, o.p); return *this; }
 };
 
 } // namespace lfun

--- a/include/lflint.h
+++ b/include/lflint.h
@@ -8,8 +8,7 @@
 //   ZZX  — wraps fmpz_poly_t  (integer polynomial in T)
 //
 // Covers exactly the surface used by this repo's examples; not a
-// general-purpose flintxx replacement. See
-// docs/superpowers/specs/2026-05-29-drop-flintxx-design.md.
+// general-purpose flintxx replacement.
 
 #pragma once
 

--- a/include/lflint.h
+++ b/include/lflint.h
@@ -74,6 +74,7 @@ public:
   friend ZZ operator*(const ZZ&, const ZZ&);
   friend ZZ operator*(slong,     const ZZ&);
   friend ZZ operator*(const ZZ&, slong);
+  friend ZZ pow(const ZZ&, ulong);
 };
 
 inline ZZ operator+(const ZZ& a, const ZZ& b) { ZZ r; fmpz_add(r.z, a.z, b.z); return r; }
@@ -81,5 +82,7 @@ inline ZZ operator-(const ZZ& a, const ZZ& b) { ZZ r; fmpz_sub(r.z, a.z, b.z); r
 inline ZZ operator*(const ZZ& a, const ZZ& b) { ZZ r; fmpz_mul(r.z, a.z, b.z); return r; }
 inline ZZ operator*(slong a,     const ZZ& b) { ZZ r; fmpz_mul_si(r.z, b.z, a); return r; }
 inline ZZ operator*(const ZZ& a, slong b)     { ZZ r; fmpz_mul_si(r.z, a.z, b); return r; }
+
+inline ZZ pow(const ZZ& a, ulong e) { ZZ r; fmpz_pow_ui(r.z, a.z, e); return r; }
 
 } // namespace lfun

--- a/include/lflint.h
+++ b/include/lflint.h
@@ -43,6 +43,26 @@ public:
   bool is_one()  const { return fmpz_is_one(z); }
   void set_zero()      { fmpz_zero(z); }
   void set_one()       { fmpz_one(z); }
+
+  // unary
+  ZZ operator-() const { ZZ r; fmpz_neg(r.z, z); return r; }
+
+  // compound assignment
+  ZZ& operator+=(const ZZ& o) { fmpz_add  (z, z, o.z); return *this; }
+  ZZ& operator*=(const ZZ& o) { fmpz_mul  (z, z, o.z); return *this; }
+  ZZ& operator*=(slong n)     { fmpz_mul_si(z, z, n); return *this; }
+
+  friend ZZ operator+(const ZZ&, const ZZ&);
+  friend ZZ operator-(const ZZ&, const ZZ&);
+  friend ZZ operator*(const ZZ&, const ZZ&);
+  friend ZZ operator*(slong,     const ZZ&);
+  friend ZZ operator*(const ZZ&, slong);
 };
+
+inline ZZ operator+(const ZZ& a, const ZZ& b) { ZZ r; fmpz_add(r.z, a.z, b.z); return r; }
+inline ZZ operator-(const ZZ& a, const ZZ& b) { ZZ r; fmpz_sub(r.z, a.z, b.z); return r; }
+inline ZZ operator*(const ZZ& a, const ZZ& b) { ZZ r; fmpz_mul(r.z, a.z, b.z); return r; }
+inline ZZ operator*(slong a,     const ZZ& b) { ZZ r; fmpz_mul_si(r.z, b.z, a); return r; }
+inline ZZ operator*(const ZZ& a, slong b)     { ZZ r; fmpz_mul_si(r.z, a.z, b); return r; }
 
 } // namespace lfun

--- a/include/lflint.h
+++ b/include/lflint.h
@@ -83,6 +83,7 @@ public:
   friend ZZ operator*(slong,     const ZZ&);
   friend ZZ operator*(const ZZ&, slong);
   friend ZZ pow(const ZZ&, ulong);
+  friend std::ostream& operator<<(std::ostream&, const ZZ&);
 };
 
 inline ZZ operator+(const ZZ& a, const ZZ& b) { ZZ r; fmpz_add(r.z, a.z, b.z); return r; }
@@ -92,6 +93,13 @@ inline ZZ operator*(slong a,     const ZZ& b) { ZZ r; fmpz_mul_si(r.z, b.z, a); 
 inline ZZ operator*(const ZZ& a, slong b)     { ZZ r; fmpz_mul_si(r.z, a.z, b); return r; }
 
 inline ZZ pow(const ZZ& a, ulong e) { ZZ r; fmpz_pow_ui(r.z, a.z, e); return r; }
+
+inline std::ostream& operator<<(std::ostream& s, const ZZ& x) {
+  char* str = fmpz_get_str(nullptr, 10, x.z);
+  s << str;
+  flint_free(str);
+  return s;
+}
 
 template<> inline slong  ZZ::to<slong>()  const { return fmpz_get_si(z); }
 template<> inline ulong  ZZ::to<ulong>()  const { return fmpz_get_ui(z); }

--- a/include/lflint.h
+++ b/include/lflint.h
@@ -51,6 +51,7 @@ public:
   ZZ& operator+=(const ZZ& o) { fmpz_add  (z, z, o.z); return *this; }
   ZZ& operator*=(const ZZ& o) { fmpz_mul  (z, z, o.z); return *this; }
   ZZ& operator*=(slong n)     { fmpz_mul_si(z, z, n); return *this; }
+  ZZ& operator*=(ulong n)     { fmpz_mul_ui(z, z, n); return *this; }
 
   // Non-negative remainder (0 <= r < |modulus|). Required by
   // smalljac.cpp:203 (`disc % ZZ(4) != 1` for negative discriminants).

--- a/include/lflint.h
+++ b/include/lflint.h
@@ -22,8 +22,22 @@ namespace lfun {
 class ZZ {
   fmpz_t z;
 public:
-  ZZ() { fmpz_init(z); }
-  ~ZZ() { fmpz_clear(z); }
+  ZZ()                       { fmpz_init(z); }
+  ZZ(slong n)                { fmpz_init(z); fmpz_set_si(z, n); }
+  ZZ(ulong n)                { fmpz_init(z); fmpz_set_ui(z, n); }
+  ZZ(const ZZ& o)            { fmpz_init(z); fmpz_set(z, o.z); }
+  // Move: init the target to 0 first, then swap. This leaves the moved-from
+  // object in a valid (zero) state that fmpz_clear can safely handle.
+  ZZ(ZZ&& o) noexcept        { fmpz_init(z); fmpz_swap(z, o.z); }
+  ~ZZ()                      { fmpz_clear(z); }
+
+  ZZ& operator=(const ZZ& o)     { fmpz_set(z, o.z); return *this; }
+  ZZ& operator=(ZZ&& o) noexcept { fmpz_swap(z, o.z); return *this; }
+  ZZ& operator=(slong n)         { fmpz_set_si(z, n); return *this; }
+  ZZ& operator=(ulong n)         { fmpz_set_ui(z, n); return *this; }
+
+  fmpz*       _fmpz()       { return z; }
+  const fmpz* _fmpz() const { return z; }
 
   bool is_zero() const { return fmpz_is_zero(z); }
 };

--- a/test/dir_test_cpp.cpp
+++ b/test/dir_test_cpp.cpp
@@ -18,12 +18,10 @@
 #include <string>
 #include <vector>
 #include <flint/fmpz.h>
-//#include <flint/fmpzxx.h>  // removed: FLINT 3.x dropped the C++ interface
 #include <flint/acb_poly.h>
 #include "glfunc.h"
-//#include "examples_tools.h"  // removed: pulls in flintxx
 
-//using flint::fmpzxx;
+
 using std::cout;
 using std::endl;
 using std::int64_t;

--- a/test/lflint_test.cpp
+++ b/test/lflint_test.cpp
@@ -57,9 +57,42 @@ static void test_set_zero_one() {
   assert(!a.is_zero());
 }
 
+static void test_arithmetic() {
+  ZZ two(slong{2});
+  ZZ three(slong{3});
+
+  // unary -
+  ZZ neg = -two;
+  assert(fmpz_get_si(neg._fmpz()) == -2);
+
+  // binary +, -, *
+  ZZ sum  = two + three;
+  ZZ diff = three - two;
+  ZZ prod = two * three;
+  assert(fmpz_get_si(sum._fmpz())  == 5);
+  assert(fmpz_get_si(diff._fmpz()) == 1);
+  assert(fmpz_get_si(prod._fmpz()) == 6);
+
+  // slong * ZZ and ZZ * slong (used in sympow_ECQ: `9*a[8]`, `a[2]*p[1]`)
+  ZZ left  = slong{9} * three;
+  ZZ right = three * slong{9};
+  assert(fmpz_get_si(left._fmpz())  == 27);
+  assert(fmpz_get_si(right._fmpz()) == 27);
+
+  // compound
+  ZZ x(slong{10});
+  x += two;
+  assert(fmpz_get_si(x._fmpz()) == 12);
+  x *= three;
+  assert(fmpz_get_si(x._fmpz()) == 36);
+  x *= slong{2};
+  assert(fmpz_get_si(x._fmpz()) == 72);
+}
+
 int main() {
   test_default_ctor_is_zero();
   test_construction_and_raw();
   test_set_zero_one();
+  test_arithmetic();
   return 0;
 }

--- a/test/lflint_test.cpp
+++ b/test/lflint_test.cpp
@@ -231,6 +231,40 @@ static void test_zzx_basic() {
   assert(t.degree() == p.degree());
 }
 
+static void test_zzx_arithmetic() {
+  // p = 1 + 2x + 3x^2
+  ZZX p;
+  p.set_coeff(slong{0}, slong{1});
+  p.set_coeff(slong{1}, slong{2});
+  p.set_coeff(slong{2}, slong{3});
+
+  // q = 4 + 5x
+  ZZX q;
+  q.set_coeff(slong{0}, slong{4});
+  q.set_coeff(slong{1}, slong{5});
+
+  // p += q -> 5 + 7x + 3x^2
+  ZZX r(p);
+  r += q;
+  assert(r.degree() == 2);
+  assert(r.get_coeff(slong{0}).to<slong>() == 5);
+  assert(r.get_coeff(slong{1}).to<slong>() == 7);
+  assert(r.get_coeff(slong{2}).to<slong>() == 3);
+
+  // (1 + T) * (1 - T) == 1 - T^2 — covers degree-shrink via cancellation
+  ZZX one_plus_T;
+  one_plus_T.set_coeff(slong{0}, slong{1});
+  one_plus_T.set_coeff(slong{1}, slong{1});
+  ZZX one_minus_T;
+  one_minus_T.set_coeff(slong{0}, slong{ 1});
+  one_minus_T.set_coeff(slong{1}, slong{-1});
+  one_plus_T *= one_minus_T;
+  assert(one_plus_T.degree() == 2);
+  assert(one_plus_T.get_coeff(slong{0}).to<slong>() ==  1);
+  assert(one_plus_T.get_coeff(slong{1}).is_zero());
+  assert(one_plus_T.get_coeff(slong{2}).to<slong>() == -1);
+}
+
 int main() {
   test_default_ctor_is_zero();
   test_construction_and_raw();
@@ -243,5 +277,6 @@ int main() {
   test_to_conversion();
   test_ostream();
   test_zzx_basic();
+  test_zzx_arithmetic();
   return 0;
 }

--- a/test/lflint_test.cpp
+++ b/test/lflint_test.cpp
@@ -2,6 +2,8 @@
 // Plain <cassert>; exits 0 on success.
 #include <cassert>
 #include <map>
+#include <sstream>
+#include <string>
 #include <utility>
 #include "lflint.h"
 
@@ -176,6 +178,23 @@ static void test_to_conversion() {
   assert((y % ulong{17}).to<ulong>() == ulong{1024 % 17});
 }
 
+static void test_ostream() {
+  using std::ostringstream;
+  using std::string;
+
+  ostringstream os1; os1 << ZZ(slong{42});
+  assert(os1.str() == string("42"));
+
+  ostringstream os2; os2 << ZZ(slong{-13});
+  assert(os2.str() == string("-13"));
+
+  // multi-limb (10^25 doesn't fit in 64 bits)
+  ZZ big;
+  fmpz_set_str(big._fmpz(), "12345678901234567890123", 10);
+  ostringstream os3; os3 << big;
+  assert(os3.str() == string("12345678901234567890123"));
+}
+
 int main() {
   test_default_ctor_is_zero();
   test_construction_and_raw();
@@ -186,5 +205,6 @@ int main() {
   test_divisibility();
   test_pow();
   test_to_conversion();
+  test_ostream();
   return 0;
 }

--- a/test/lflint_test.cpp
+++ b/test/lflint_test.cpp
@@ -91,6 +91,11 @@ static void test_arithmetic() {
   assert(fmpz_get_si(x._fmpz()) == 36);
   x *= slong{2};
   assert(fmpz_get_si(x._fmpz()) == 72);
+
+  // ZZ *= ulong (fmpz_mul_ui) — added to avoid sign-narrowing at smalljac.cpp:301 `qn *= q`
+  ZZ y(slong{6});
+  y *= ulong{7};
+  assert(fmpz_get_si(y._fmpz()) == 42);
 }
 
 static void test_modulo() {
@@ -229,6 +234,18 @@ static void test_zzx_basic() {
   ZZX t(p);
   assert(t.get_coeff(slong{3}).to<slong>() == -5);
   assert(t.degree() == p.degree());
+
+  // ZZX move ctor leaves source in degree -1 (valid, destructible)
+  ZZX donor(p);                       // copy of p; degree 3
+  ZZX recv(std::move(donor));
+  assert(recv.degree() == 3);
+  assert(donor.degree() == -1);
+
+  // ZZX move-assign: swap semantics means source gets the target's old state
+  ZZX target;                         // initially degree -1 (empty)
+  target = std::move(recv);           // swap: target ← recv's state (degree 3), recv ← target's old state (degree -1)
+  assert(target.degree() == 3);
+  assert(recv.degree() == -1);
 }
 
 static void test_zzx_arithmetic() {

--- a/test/lflint_test.cpp
+++ b/test/lflint_test.cpp
@@ -1,6 +1,7 @@
 // Unit tests for lfun::ZZ and lfun::ZZX (lflint.h).
 // Plain <cassert>; exits 0 on success.
 #include <cassert>
+#include <utility>
 #include "lflint.h"
 
 using lfun::ZZ;
@@ -10,7 +11,45 @@ static void test_default_ctor_is_zero() {
   assert(a.is_zero());
 }
 
+static void test_construction_and_raw() {
+  // ctor from slong / ulong
+  ZZ a(slong{42});
+  ZZ b(ulong{7});
+  assert(!a.is_zero() && !b.is_zero());
+  // raw accessors
+  assert(fmpz_get_si(a._fmpz()) == 42);
+  assert(fmpz_get_ui(b._fmpz()) == 7);
+
+  // copy ctor
+  ZZ c(a);
+  assert(fmpz_equal(c._fmpz(), a._fmpz()));
+
+  // move ctor leaves source destructible (== 0 by design)
+  ZZ d(std::move(c));
+  assert(fmpz_get_si(d._fmpz()) == 42);
+  assert(c.is_zero());
+
+  // copy-assign
+  ZZ e;
+  e = a;
+  assert(fmpz_equal(e._fmpz(), a._fmpz()));
+
+  // move-assign
+  ZZ f;
+  f = std::move(e);
+  assert(fmpz_get_si(f._fmpz()) == 42);
+  assert(e.is_zero());
+
+  // assign from slong / ulong
+  ZZ g;
+  g = slong{-13};
+  assert(fmpz_get_si(g._fmpz()) == -13);
+  g = ulong{9};
+  assert(fmpz_get_ui(g._fmpz()) == 9);
+}
+
 int main() {
   test_default_ctor_is_zero();
+  test_construction_and_raw();
   return 0;
 }

--- a/test/lflint_test.cpp
+++ b/test/lflint_test.cpp
@@ -1,6 +1,7 @@
 // Unit tests for lfun::ZZ and lfun::ZZX (lflint.h).
 // Plain <cassert>; exits 0 on success.
 #include <cassert>
+#include <map>
 #include <utility>
 #include "lflint.h"
 
@@ -107,11 +108,40 @@ static void test_modulo() {
   assert(fmpz_get_si((ten % ulong{3})._fmpz()) == 1);
 }
 
+static void test_comparison_and_map() {
+  ZZ a(slong{5});
+  ZZ b(slong{5});
+  ZZ c(slong{7});
+
+  assert(a == b);
+  assert(!(a == c));
+  assert(a != c);
+  assert(!(a != b));
+  assert(a == slong{5});
+  assert(a != slong{6});
+
+  // ordering (for std::map keys)
+  assert(a < c);
+  assert(!(c < a));
+  assert(!(a < b));    // equal — strict less must be false
+
+  // actual std::map usage
+  std::map<ZZ, int> m;
+  m[ZZ(slong{2})] = 20;
+  m[ZZ(slong{1})] = 10;
+  m[ZZ(slong{3})] = 30;
+  auto it = m.begin();
+  assert(it->second == 10); ++it;
+  assert(it->second == 20); ++it;
+  assert(it->second == 30);
+}
+
 int main() {
   test_default_ctor_is_zero();
   test_construction_and_raw();
   test_set_zero_one();
   test_arithmetic();
   test_modulo();
+  test_comparison_and_map();
   return 0;
 }

--- a/test/lflint_test.cpp
+++ b/test/lflint_test.cpp
@@ -1,0 +1,16 @@
+// Unit tests for lfun::ZZ and lfun::ZZX (lflint.h).
+// Plain <cassert>; exits 0 on success.
+#include <cassert>
+#include "lflint.h"
+
+using lfun::ZZ;
+
+static void test_default_ctor_is_zero() {
+  ZZ a;
+  assert(a.is_zero());
+}
+
+int main() {
+  test_default_ctor_is_zero();
+  return 0;
+}

--- a/test/lflint_test.cpp
+++ b/test/lflint_test.cpp
@@ -136,6 +136,19 @@ static void test_comparison_and_map() {
   assert(it->second == 30);
 }
 
+static void test_divisibility() {
+  ZZ minus_twelve(slong{-12});
+  assert( minus_twelve.divisible(slong{4}));
+  assert(!minus_twelve.divisible(slong{5}));
+  ZZ q = minus_twelve.divexact(slong{4});
+  assert(fmpz_get_si(q._fmpz()) == -3);
+
+  // smalljac.cpp:202 pattern: `while(d.divisible(4)) d = d.divexact(4);`
+  ZZ d(slong{-48});
+  while (d.divisible(slong{4})) d = d.divexact(slong{4});
+  assert(fmpz_get_si(d._fmpz()) == -3);
+}
+
 int main() {
   test_default_ctor_is_zero();
   test_construction_and_raw();
@@ -143,5 +156,6 @@ int main() {
   test_arithmetic();
   test_modulo();
   test_comparison_and_map();
+  test_divisibility();
   return 0;
 }

--- a/test/lflint_test.cpp
+++ b/test/lflint_test.cpp
@@ -162,6 +162,20 @@ static void test_pow() {
   assert(p0.is_one());
 }
 
+static void test_to_conversion() {
+  ZZ x(slong{-42});
+  ZZ y(slong{1024});
+  ZZ u(ulong{7});
+
+  assert(x.to<slong>()  == -42);
+  assert(y.to<slong>()  == 1024);
+  assert(u.to<ulong>()  == ulong{7});
+  assert(y.to<double>() == 1024.0);
+  // smalljac.cpp:97 pattern: `(polynomial[i] % pol->mod.n).to<mp_limb_t>()`
+  // mp_limb_t == ulong; same specialisation
+  assert((y % ulong{17}).to<ulong>() == ulong{1024 % 17});
+}
+
 int main() {
   test_default_ctor_is_zero();
   test_construction_and_raw();
@@ -171,5 +185,6 @@ int main() {
   test_comparison_and_map();
   test_divisibility();
   test_pow();
+  test_to_conversion();
   return 0;
 }

--- a/test/lflint_test.cpp
+++ b/test/lflint_test.cpp
@@ -89,10 +89,29 @@ static void test_arithmetic() {
   assert(fmpz_get_si(x._fmpz()) == 72);
 }
 
+static void test_modulo() {
+  ZZ neg(slong{-5});
+  ZZ three(slong{3});
+
+  // ZZ % ZZ — fmpz_mod, non-negative
+  ZZ r1 = neg % three;
+  assert(fmpz_get_si(r1._fmpz()) == 1);   // (-5) mod 3 == 1 (NOT -2)
+
+  // ZZ % ulong — fmpz_mod_ui, non-negative
+  ZZ r2 = neg % ulong{3};
+  assert(fmpz_get_si(r2._fmpz()) == 1);
+
+  // positive sanity
+  ZZ ten(slong{10});
+  assert(fmpz_get_si((ten % three)._fmpz()) == 1);
+  assert(fmpz_get_si((ten % ulong{3})._fmpz()) == 1);
+}
+
 int main() {
   test_default_ctor_is_zero();
   test_construction_and_raw();
   test_set_zero_one();
   test_arithmetic();
+  test_modulo();
   return 0;
 }

--- a/test/lflint_test.cpp
+++ b/test/lflint_test.cpp
@@ -8,6 +8,7 @@
 #include "lflint.h"
 
 using lfun::ZZ;
+using lfun::ZZX;
 
 static void test_default_ctor_is_zero() {
   ZZ a;
@@ -195,6 +196,41 @@ static void test_ostream() {
   assert(os3.str() == string("12345678901234567890123"));
 }
 
+static void test_zzx_basic() {
+  ZZX p;
+  assert(p.degree() == -1);          // empty poly has degree -1 per FLINT
+
+  ZZX q(slong{8});                   // capacity hint; still degree -1
+  assert(q.degree() == -1);
+
+  // set/get round-trip including negative coeff
+  p.set_coeff(slong{3}, slong{-5});
+  p.set_coeff(slong{1}, ZZ(slong{7}));
+  assert(p.degree() == 3);
+  assert(p.get_coeff(slong{3}).to<slong>() == -5);
+  assert(p.get_coeff(slong{1}).to<slong>() ==  7);
+  assert(p.get_coeff(slong{2}).is_zero());
+  assert(p.get_coeff(slong{0}).is_zero());
+
+  // fit_length does not raise degree if no coefficients beyond it are set
+  ZZX r;
+  r.set_coeff(slong{0}, slong{1});
+  r.fit_length(slong{16});
+  assert(r.degree() == 0);
+
+  // operator= from int (constant) — used in examples_tools.h: `f = 0;`
+  ZZX s;
+  s.set_coeff(slong{2}, slong{99});
+  assert(s.degree() == 2);
+  s = slong{0};
+  assert(s.degree() == -1);
+
+  // copy ctor
+  ZZX t(p);
+  assert(t.get_coeff(slong{3}).to<slong>() == -5);
+  assert(t.degree() == p.degree());
+}
+
 int main() {
   test_default_ctor_is_zero();
   test_construction_and_raw();
@@ -206,5 +242,6 @@ int main() {
   test_pow();
   test_to_conversion();
   test_ostream();
+  test_zzx_basic();
   return 0;
 }

--- a/test/lflint_test.cpp
+++ b/test/lflint_test.cpp
@@ -149,6 +149,19 @@ static void test_divisibility() {
   assert(fmpz_get_si(d._fmpz()) == -3);
 }
 
+static void test_pow() {
+  ZZ two(slong{2});
+  ZZ p10 = lfun::pow(two, ulong{10});
+  assert(fmpz_get_si(p10._fmpz()) == 1024);
+
+  ZZ minus_three(slong{-3});
+  ZZ p3 = lfun::pow(minus_three, ulong{3});
+  assert(fmpz_get_si(p3._fmpz()) == -27);
+
+  ZZ p0 = lfun::pow(minus_three, ulong{0});
+  assert(p0.is_one());
+}
+
 int main() {
   test_default_ctor_is_zero();
   test_construction_and_raw();
@@ -157,5 +170,6 @@ int main() {
   test_modulo();
   test_comparison_and_map();
   test_divisibility();
+  test_pow();
   return 0;
 }

--- a/test/lflint_test.cpp
+++ b/test/lflint_test.cpp
@@ -48,8 +48,18 @@ static void test_construction_and_raw() {
   assert(fmpz_get_ui(g._fmpz()) == 9);
 }
 
+static void test_set_zero_one() {
+  ZZ a(slong{42});
+  a.set_zero();
+  assert(a.is_zero());
+  a.set_one();
+  assert(a.is_one());
+  assert(!a.is_zero());
+}
+
 int main() {
   test_default_ctor_is_zero();
   test_construction_and_raw();
+  test_set_zero_one();
   return 0;
 }


### PR DESCRIPTION
## Summary

Replaces the unmaintained `flint::fmpzxx` / `flint::fmpz_polyxx` (FLINT 3.x dropped the C++ interface) with a thin in-tree wrapper `include/lflint.h` exposing `lfun::ZZ` (over `fmpz_t`) and `lfun::ZZX` (over `fmpz_poly_t`). After this PR the project has zero flintxx dependency.

- **New:** `include/lflint.h` — RAII wrappers covering exactly the surface this repo's examples use: construction/assignment from `slong`/`ulong`, copy/move, raw `_fmpz()` / `_poly()` accessors, arithmetic (unary `-`, `+`, `-`, `*` including `slong*ZZ`, `+=`, `*=` with `slong`/`ulong`), modulo (non-negative remainder via `fmpz_mod` — required by `smalljac.cpp`'s negative-discriminant path), comparison (`==` / `!=` / `<` for `std::map` keys), `divisible` / `divexact` (signed-divisor), `to<slong/ulong/double>()` with a dependent `static_assert` for unsupported types, `operator<<` in `namespace lfun` (ADL), free function `pow(ZZ, ulong)`, plus the `ZZX` analogues.
- **New:** `test/lflint_test.cpp` — ~210 LOC unit test covering every API including move-from invariants and the modulo sign convention.
- **Replaced:** the interim inline `HAVE_FLINTXX` shim in `include/examples_tools.h` is now `#include "lflint.h"` + `using lfun::ZZ; using lfun::ZZX;`. The integer and polynomial `operator>>` parsers continue to live here (they need `throw_line`) and were rewritten against the wrapper accessors. The `operator<<(arb_t)` body builds `vector<ZZ>` and streams via ADL.
- **Migrated:** `examples/artin.cpp` (mechanical rename + drop `.evaluate()` proxy), `examples/smalljac.cpp` (rename pass + rewrite of `remove_riemann_shift` to use `get_coeff`/`set_coeff`/`pow` instead of flintxx's lvalue-proxy `coeff` plus `lead()` / `_normalise()`).
- **Cleanup:** drop the cargo-culted commented-out flintxx includes/usings in `ec_*.cpp`, `cmf_*.cpp`, `tau.cpp`, `dir.cpp`, `test/dir_test_cpp.cpp`.

The library itself (`src/*.c`, `include/glfunc*.h`) is unchanged; this is examples + tests only. The build picks up `test/*.cpp` via the existing `Makefile.in` wildcard, so `./configure` and `Makefile.in` were not touched.

The names `ZZ` / `ZZX` collide nominally with NTL but are introduced via using-*declarations* only (never `using namespace lfun;`), so they remain unambiguous in any TU that doesn't also `using namespace NTL;`.

## Test plan

- [ ] `make clean && make` — clean rebuild.
- [ ] `./build/test/lflint_test.exe` — wrapper unit test exits 0.
- [ ] `./build/test/dir_test.exe && ./build/test/dir_test1.exe && ./build/test/dir_test_cpp.exe` — three exit 0.
- [ ] `./build/examples/ec_37.a1.exe && ./build/examples/ec_389.a1.exe && ./build/examples/ec_5077.a1.exe` — three exit 0 (asserts against precomputed BSD constants).
- [ ] Diff `./build/examples/cmf_23.1.b.a.exe` output against the comment-header expected output — numeric agreement to 20+ digits.
