### PR TITLE
fix: build cleanly on FLINT 3.x (3.0.1 and 3.6.0)

### DIFF
--- a/examples/artin.cpp
+++ b/examples/artin.cpp
@@ -21,6 +21,7 @@
 #include <string>
 #include <vector>
 #include <flint/fmpz.h>
+#include <flint/nmod.h>
 #include <flint/nmod_poly.h>
 #include <flint/nmod_poly_factor.h>
 #include <flint/fq_nmod.h>
@@ -199,13 +200,13 @@ void powers_sum(fq_nmod_t res,
                 const vector<int64_t> &powers,
                 const fq_nmod_ctx_t ctx) {
   fq_nmod_zero(res, ctx);
-  const fmpz *p = fq_nmod_ctx_prime(ctx);
+  ulong p = ctx->mod.n;
   fmpz_t tmp;
   fmpz_init(tmp);
   fq_nmod_t power;
   fq_nmod_init2(power, ctx);
   for(auto &j : powers) {
-    fmpz_pow_ui(tmp, p, j);
+    fmpz_ui_pow_ui(tmp, p, j);
     fq_nmod_pow(power, r, tmp, ctx);
     fq_nmod_add(res, res, power, ctx);
   }
@@ -373,7 +374,7 @@ inline bool operator<(const pair<size_t, const fq_nmod_struct*>& a,
 void frobenius_permutation(vector<size_t> &res,
                            const vector<fq_nmod_struct> &roots,
                            const fq_nmod_ctx_t ctx) {
-  uint64_t p = fmpz_get_ui(fq_nmod_ctx_prime(ctx));
+  uint64_t p = ctx->mod.n;
   vector<pair<size_t, const fq_nmod_struct*> > roots_ext(roots.size());
   vector<pair<size_t, const fq_nmod_struct*> >roots_frob_ext(roots.size());
   vector<fq_nmod_struct> roots_frob(roots.size());

--- a/examples/rational.c
+++ b/examples/rational.c
@@ -228,7 +228,7 @@ void Lfunc_rational_init(Lfunc_rational_t L) {
 int Lfunc_rational_set_s(Lfunc_rational_t L, char *s) {
 
   char **tokens;
-  size_t tokens_length;
+  size_t tokens_length = 0;
   int status = 0;
 
   status = split(s, ':', &tokens, &tokens_length);

--- a/include/examples_tools.h
+++ b/include/examples_tools.h
@@ -60,7 +60,7 @@ using lfun::ZZX;
   const std::string comma = ", "s;
 #else
   const std::string comma = ","s;
-#endif;
+#endif
 
 
 
@@ -135,11 +135,7 @@ istream & operator>>(istream& s, ZZ& output) {
     buffer.put(s.get());
     c = s.peek();
   }
-  mpz_t tmp;
-  mpz_init(tmp);
-  gmp_sscanf(buffer.str().c_str(),"%Zd", tmp);
-  fmpz_set_mpz(output._fmpz(), tmp);
-  mpz_clear(tmp);
+  fmpz_set_str(output._fmpz(), buffer.str().c_str(), 10);
   return s;
 }
 

--- a/src/g.c
+++ b/src/g.c
@@ -1,3 +1,4 @@
+#include <gmp.h>  // must precede FLINT headers so the GMP-interop decls (fmpz_set_mpz) are visible
 #include "glfunc.h"
 #include "glfunc_internals.h"
 #include <stdio.h>


### PR DESCRIPTION
## What

Make the tree build with **zero warnings/errors** under `-pedantic -Wall -Wextra`, and fix
compile failures introduced by newer FLINT (3.1+), while remaining buildable on FLINT 3.0.1.

## Why

Newer FLINT changed three things the examples/library relied on:

1. **GMP interop is now opt-in.** `flint.h` no longer includes `gmp.h`, and `fmpz_set_mpz`
   (and friends) are declared only behind `#if defined(__GMP_H__)`. Any TU that uses
   `mpz_*` / `fmpz_set_mpz` without including `<gmp.h>` *before* the FLINT headers fails.
2. **`fq_nmod_ctx_prime` now returns `ulong`** (the `fmpz p` field was dropped from
   `fq_nmod_ctx_struct`); it used to return `const fmpz *`.
3. **`flint/nmod.h` is no longer transitively included**, so `nmod_neg` is undeclared.

On FLINT 3.0.1 none of this surfaced; on 3.6.0 it breaks `examples/artin.cpp`,
`include/examples_tools.h`, and `src/g.c`. Two pre-existing warnings are also cleaned up.

## Changes

- **`include/examples_tools.h`** — parse `ZZ` from a string with `fmpz_set_str(..., 10)`
  instead of the `mpz_t` + `gmp_sscanf` + `fmpz_set_mpz` roundtrip. This removes the
  GMP-interop dependency and the include-ordering requirement entirely (adding `gmp.h`
  here wouldn't help — the header is included *after* each example's FLINT headers). Also
  drops a stray `;` after `#endif` (`-Wendif-labels`).
- **`examples/artin.cpp`** — read the prime as `ctx->mod.n` (portable, word-sized) instead
  of `fq_nmod_ctx_prime`; use `fmpz_ui_pow_ui`; add `#include <flint/nmod.h>` for `nmod_neg`.
- **`src/g.c`** — `#include <gmp.h>` before the FLINT headers so its `mpz_*` I/O and
  `fmpz_set_mpz` are declared on newer FLINT (no logic change).
- **`examples/rational.c`** — initialise `tokens_length` (`-Wmaybe-uninitialized`). This is
  also a real fix: `split()` does not write `*length` on its `calloc`-failure path, so the
  caller previously read an uninitialised value.

The `ctx->mod.n`, `fmpz_ui_pow_ui`, and `fmpz_set_str` substitutions were checked to be
value-identical to the originals (equality verified over a range of primes/exponents/strings
on FLINT 3.0.1, where the old APIs still exist).

## Verification

| FLINT | Build (`-pedantic -Wall -Wextra`) | `make check` |
|-------|-----------------------------------|--------------|
| 3.0.1 (system) | zero diagnostics | PASSED |
| 3.6.0 (built from `main`) | zero diagnostics | PASSED |

`make check` runs the curated regression suite (rank-0/1/2/3 elliptic curves, `tau`, a
classical modular form, and Dirichlet), asserting against certified L-values — so the change
is confirmed to preserve numerical behavior, not merely to compile.
