### PR TITLE
test: cross-checked L-value/zero asserts for examples; expand make check (7→10)

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -97,6 +97,7 @@ CHECK_BINS = \
 	build/examples/tau.exe \
 	build/examples/cmf_7.3.b.a.exe \
 	build/examples/cmf_23.1.b.a.exe \
+	build/examples/cmf_25.12.a.a.exe \
 	build/examples/dir.exe
 
 check: all

--- a/Makefile.in
+++ b/Makefile.in
@@ -96,6 +96,7 @@ CHECK_BINS = \
 	build/examples/ec_5077.a1.exe \
 	build/examples/tau.exe \
 	build/examples/cmf_7.3.b.a.exe \
+	build/examples/cmf_23.1.b.a.exe \
 	build/examples/dir.exe
 
 check: all

--- a/Makefile.in
+++ b/Makefile.in
@@ -98,6 +98,7 @@ CHECK_BINS = \
 	build/examples/cmf_7.3.b.a.exe \
 	build/examples/cmf_23.1.b.a.exe \
 	build/examples/cmf_25.12.a.a.exe \
+	build/examples/artin.exe \
 	build/examples/dir.exe
 
 check: all

--- a/examples/artin.cpp
+++ b/examples/artin.cpp
@@ -5,6 +5,19 @@
  * the local data to deduce the local factors from the conjugacy classes
  *
  * python function to generate input provided at the bottom with an example
+ *
+ * Two run modes:
+ *   - Tool mode (argc == 3): `artin <input> <output>` reads Artin-rep local
+ *     data line by line from <input>, computes each L-function, prints a
+ *     summary, and writes a result record per line to <output>. This is the
+ *     real LMFDB data-generation path and is unchanged.
+ *   - Self-test mode (argc == 1): with no arguments, runs an embedded
+ *     regression test on the dimension-2, conductor-47 rep 2.47.5t2.a.a (the
+ *     odd dihedral D5 = 5t2 Artin L-function, i.e. the weight-1 level-47
+ *     dihedral form). It feeds the embedded input line through the exact same
+ *     parse -> lpoly -> Lfunc_compute pipeline the tool mode uses, then asserts
+ *     on certified output: rank, L(1), and the first zero. Exits 0 on success.
+ *   Any other argc prints a usage message and exits nonzero.
  */
 #define __STDC_FORMAT_MACROS
 #define special_values_size 2 // implies computing L(1) ... L(special_values_size)
@@ -775,10 +788,151 @@ void lpoly(const int64_t &p, artin_rep &AR) {
 
 
 
+// Process one input line: parse it into AR, deduce all Euler factors, run
+// Lfunc_compute, print the summary, compute the special values, and write the
+// result record to `output`. On return AR is fully populated (rank, sign,
+// special_values, etc.); the caller owns AR and must artin_rep_clear it.
+// Returns nonzero if non-fatal warnings were collected (other than ERR_SPEC_PREC).
+// Shared verbatim between the tool mode and the embedded self-test so both
+// exercise the identical parse -> lpoly -> Lfunc_compute pipeline.
+int process_line(const string &line, ostream &output, primesieve::iterator &ps, artin_rep &AR) {
+  Lfunc_t &L = AR.L;
+
+  SystemTime start(std::chrono::system_clock::now());
+  std::time_t startt = std::chrono::system_clock::to_time_t(start);
+  cout << "Date:   \t" <<  std::put_time(std::localtime(&startt), "%F %T") << endl;
+
+  // read a line
+  stringstream linestream(line);
+  linestream >> AR;
+  cout << "Starting:\t"<<AR.label<<endl;
+
+  // we need all the local factors p <= target_M
+  uint64_t target_M = Lfunc_nmax(L);
+
+  cout <<"using p <= " << target_M << endl;
+
+  // populate local factors
+  ps.jump_to(0);
+  for(uint64_t p = ps.next_prime(); p <= target_M; p = ps.next_prime())
+    lpoly(int64_t(p), AR);
+
+
+  // do the computation
+  AR.ecode |= Lfunc_compute(L);
+  if(fatal_error(AR.ecode)) {
+    fprint_errors(stderr, AR.ecode);
+    std::abort();
+  }
+
+  printf("Rank = %" PRIu64 "\n",Lfunc_rank(L));
+  printf("Epsilon = ");acb_printd(Lfunc_sign(L),20);printf("\n");
+  printf("Leading Taylor coeff = ");arb_printd(Lfunc_Taylor(L), 20);printf("\n");
+  printf("First zero = ");arb_printd(Lfunc_zeros(L, 0), 20);printf("\n");
+
+  for(size_t i = 0; i < AR.special_values.size(); ++i) {
+    acb_init(&AR.special_values[i]);
+    AR.ecode |= Lfunc_special_value(&AR.special_values[i], L, i + 1, 0);
+    if(fatal_error(AR.ecode)) {
+      fprint_errors(stderr, AR.ecode);
+      std::abort();
+    }
+    printf("L(%lu) = ", i + 1);acb_printd(&AR.special_values[i],20);printf("\n");
+  }
+
+  output << AR << endl;
+  int r = 0;
+  // print any warnings collected along the way
+  // ignore could not achieve target error bound in special value
+  if( AR.ecode != ERR_SUCCESS and AR.ecode != ERR_SPEC_PREC ) {
+    cerr << "Begin warnings for " << AR.label << endl;
+    fprint_errors(stderr, AR.ecode);
+    cerr << "End warnings for " << AR.label << endl;
+    r++;
+  }
+
+  SystemTime end(std::chrono::system_clock::now());
+  std::time_t endt = std::chrono::system_clock::to_time_t(end);
+  double walltime = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+  cout << "Date:   \t" <<  std::put_time(std::localtime(&endt), "%F %T") << endl;
+  cout << "Done:   \t"<< AR.label << "\ttook ";
+  cout << std::setw(6) << std::setfill(' ')  << std::fixed << std::setprecision(2) << walltime/1000 << "s"<< endl << endl;
+
+  return r;
+}
+
+
+// Embedded self-test: run the conductor-47 dimension-2 dihedral rep
+// 2.47.5t2.a.a through the same pipeline as the tool mode and assert on
+// certified output. Golden constants are the certified values printed by this
+// program, independently cross-checked in Magma (Dokchitser L-series built
+// from the a_p of the weight-1 level-47 dihedral form for Q(sqrt(-47)), see
+// the commit message). Returns 0 on success; asserts otherwise.
+int self_test() {
+  // Verbatim 2.47.5t2.a.a line from the bottom-of-file example (no spaces).
+  const string line =
+    "2.47.5t2.a.a:2:47:[1,0,-1,2,-2,1]:[0,1]:5:"
+    "[[[1],[-2],[1]],[[1],[0],[-1]],[[1],[0,0,-1,-1],[1]],[[1],[1,0,1,1],[1]],[[1],[-1]]]:"
+    "[[2,47],[3,5]]:[[[1,1,1,1,1],[1,2,2]],[1,2]]:"
+    "[[[5]],[[[[4,[-47,1]],[3,[47,1]]],[2,3,4,5,1]]]]:[[],[]]";
+
+  primesieve::iterator ps;
+  artin_rep AR;
+  Lfunc_t &L = AR.L;
+
+  // Exercise the output path too (into a stringstream rather than a file).
+  stringstream record;
+  process_line(line, record, ps, AR);
+
+  // --- regression asserts on certified output ---
+  // (1) rank
+  assert(Lfunc_rank(L) == 0);
+
+  // (2) L(1): special_values[0] = L(1) (computed by process_line above).
+  //     Cross-checked against Magma Dokchitser: 0.4506602209473905297...
+  {
+    acb_t ref; acb_init(ref);
+    arb_set_str(acb_realref(ref), "0.45066022094739052973", 300);
+    arb_set_str(acb_imagref(ref), "0", 300);
+    arb_add_error_2exp_si(acb_realref(ref), -50);
+    arb_add_error_2exp_si(acb_imagref(ref), -50);
+    assert(acb_overlaps(&AR.special_values[0], ref));
+    acb_clear(ref);
+  }
+
+  // (3) first zero on the critical line.
+  //     Cross-checked against Magma sign-change bisection: 2.9874346957843450...
+  {
+    arb_t ref; arb_init(ref);
+    arb_set_str(ref, "2.9874346957843450441", 300);
+    arb_add_error_2exp_si(ref, -50);
+    assert(arb_overlaps(Lfunc_zeros(L, 0), ref));
+    arb_clear(ref);
+  }
+
+  cout << "self-test PASSED for " << AR.label << endl;
+  artin_rep_clear(AR);
+  return 0;
+}
+
+
 int main (int argc, char**argv)
 {
   try {
-    assert_print(argc, ==, 3);
+    if(argc == 1) {
+      // no arguments: run the embedded regression self-test
+      int rc = self_test();
+      flint_cleanup();
+      return rc;
+    }
+
+    if(argc != 3) {
+      cerr << "Usage:" << endl;
+      cerr << "  " << argv[0] << " <input> <output>   compute L-data for each line of <input>" << endl;
+      cerr << "  " << argv[0] << "                     run the embedded self-test" << endl;
+      return 1;
+    }
+
     printf("Input: %s\n", argv[1]);
     printf("Output: %s\n", argv[2]);
 
@@ -792,69 +946,8 @@ int main (int argc, char**argv)
 
 
     while(std::getline(input, line)) {
-      SystemTime start(std::chrono::system_clock::now());
-      std::time_t startt = std::chrono::system_clock::to_time_t(start);
-      cout << "Date:   \t" <<  std::put_time(std::localtime(&startt), "%F %T") << endl;
-
       artin_rep AR;
-      Lfunc_t &L = AR.L;
-
-
-      // read a line
-      stringstream linestream(line);
-      linestream >> AR;
-      cout << "Starting:\t"<<AR.label<<endl;
-
-      // we need all the local factors p <= target_M
-      uint64_t target_M = Lfunc_nmax(L);
-
-      cout <<"using p <= " << target_M << endl;
-
-      // populate local factors
-      ps.jump_to(0);
-      for(uint64_t p = ps.next_prime(); p <= target_M; p = ps.next_prime())
-        lpoly(int64_t(p), AR);
-
-
-      // do the computation
-      AR.ecode |= Lfunc_compute(L);
-      if(fatal_error(AR.ecode)) {
-        fprint_errors(stderr, AR.ecode);
-        std::abort();
-      }
-
-      printf("Rank = %" PRIu64 "\n",Lfunc_rank(L));
-      printf("Epsilon = ");acb_printd(Lfunc_sign(L),20);printf("\n");
-      printf("Leading Taylor coeff = ");arb_printd(Lfunc_Taylor(L), 20);printf("\n");
-      printf("First zero = ");arb_printd(Lfunc_zeros(L, 0), 20);printf("\n");
-
-      for(size_t i = 0; i < AR.special_values.size(); ++i) {
-        acb_init(&AR.special_values[i]);
-        AR.ecode |= Lfunc_special_value(&AR.special_values[i], L, i + 1, 0);
-        if(fatal_error(AR.ecode)) {
-          fprint_errors(stderr, AR.ecode);
-          std::abort();
-        }
-        printf("L(%lu) = ", i + 1);acb_printd(&AR.special_values[i],20);printf("\n");
-      }
-
-      output << AR << endl;
-      // print any warnings collected along the way
-      // ignore could not achieve target error bound in special value
-      if( AR.ecode != ERR_SUCCESS and AR.ecode != ERR_SPEC_PREC ) {
-        cerr << "Begin warnings for " << AR.label << endl;
-        fprint_errors(stderr, AR.ecode);
-        cerr << "End warnings for " << AR.label << endl;
-        r++;
-      }
-
-      SystemTime end(std::chrono::system_clock::now());
-      std::time_t endt = std::chrono::system_clock::to_time_t(end);
-      double walltime = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
-      cout << "Date:   \t" <<  std::put_time(std::localtime(&endt), "%F %T") << endl;
-      cout << "Done:   \t"<< AR.label << "\ttook ";
-      cout << std::setw(6) << std::setfill(' ')  << std::fixed << std::setprecision(2) << walltime/1000 << "s"<< endl << endl;
-
+      r += process_line(line, output, ps, AR);
       //free memory
       artin_rep_clear(AR);
     }

--- a/examples/bound.cpp
+++ b/examples/bound.cpp
@@ -1,3 +1,46 @@
+// Copyright Edgar Costa 2019
+// See LICENSE file for license details.
+/*
+ * Diagnostic/parameter-tuning helper: for a given degree, normalisation, and
+ * Gamma_R shifts (mus), prints
+ *
+ *   ceil(100 * exp(2*pi*(hi_i+0.5)/B)) / 100  =  M / sqrt(N)
+ *
+ * the number of Dirichlet coefficients per unit sqrt(conductor) the library
+ * will need.  Here:
+ *   - one_over_B = degree/512, so B = 512/degree.
+ *   - hi_i (glfunc_internals.h) is the top of the G u-grid: the largest index
+ *     i such that |G(u_i)| > 2^{-prec}; it determines where the G-kernel
+ *     drops below the precision threshold.
+ *   - M (glfunc_internals.h) = floor(sqrt(N) * exp(2*pi*(hi_i+0.5)/B)) is the
+ *     largest coefficient index a_n the library actually uses; it scales as
+ *     sqrt(conductor).
+ *
+ * The printed value M/sqrt(N) depends only on the gamma parameters (degree +
+ * mus) and lets you gauge the coefficient cost of a given parameter choice
+ * before fixing a conductor.  (The critical-line height the library analyses is
+ * the separate fixed quantity T_max = 512/(degree*OUTPUT_RATIO) = 64/degree.)
+ *
+ * Usage:
+ *   bound <degree> <normalisation> <mu_0> <mu_1> ... <mu_{degree-1}>
+ *
+ * Examples:
+ *   - L-function of an elliptic curve over Q (degree 2, weight 2):
+ *       # bound 2 0.5 0 1
+ *    or # bound 2 0 0.5 1.5
+ *   - L-function of a classical modular form of weight w (degree 2):
+ *       # bound 2 (w-1)*0.5 0 1
+ *    or # bound 2 0 (w-1)*0.5 (w-1)*0.5+1
+ *
+ * Why this is print-only and excluded from make check:
+ *   - Requires CLI arguments; there is no argument-free default run.
+ *   - Uses conductor 1 as a placeholder; it never supplies Euler factors.
+ *   - Never calls Lfunc_compute; it only inspects Lfunc_init output.
+ *   - The printed value depends solely on the gamma parameters, not on any
+ *     precomputed mathematical reference value — it is a manual diagnostic
+ *     for gauging coefficient cost, not a regression test.
+ */
+
 #define __STDC_FORMAT_MACROS
 #include "assert.h"
 #include <flint/acb_poly.h>

--- a/examples/cmf_23.1.b.a.cpp
+++ b/examples/cmf_23.1.b.a.cpp
@@ -68,6 +68,7 @@ Z-plot in [0, 10]:
 #include <vector>
 #include <flint/fmpz.h>
 #include <flint/acb_poly.h>
+#include <cassert>
 #include "glfunc_internals.h"
 
 
@@ -186,6 +187,15 @@ int main ()
   }
   printf("L(1) = ");acb_printd(ctmp, DIGITS);printf("\n");
   if (RAW) cout<<"RAW: "<<ctmp << endl;
+  { // regression assert: L(1)
+    acb_t ref; acb_init(ref);
+    arb_set_str(acb_realref(ref), "0.36840932071582682111", 300);
+    arb_set_str(acb_imagref(ref), "0", 300);
+    arb_add_error_2exp_si(acb_realref(ref), -50);
+    arb_add_error_2exp_si(acb_imagref(ref), -50);
+    assert(acb_overlaps(ctmp, ref));
+    acb_clear(ref);
+  }
   ecode|=Lfunc_special_value(ctmp, L, 2,0.0);
   if(fatal_error(ecode)) {
     fprint_errors(stderr, ecode);
@@ -204,6 +214,14 @@ int main ()
     arb_printd(zeros+i, DIGITS);
     printf("\n");
     if (RAW) cout<<"RAW: "<<zeros + i<< endl;
+  }
+
+  { // regression assert: first zero
+    arb_t ref; arb_init(ref);
+    arb_set_str(ref, "5.1156833288151175986", 300);
+    arb_add_error_2exp_si(ref, -50);
+    assert(arb_overlaps(zeros + 0, ref));
+    arb_clear(ref);
   }
 
   printf("Z-plot in [0, 10]:\n");

--- a/examples/cmf_25.12.a.a.cpp
+++ b/examples/cmf_25.12.a.a.cpp
@@ -1,7 +1,7 @@
 // Copyright Edgar Costa 2019
 // See LICENSE file for license details.
 /*
- * Make up a degree 2 L-function associated to the classical modular form 23.1.b.a
+ * Make up a degree 2 L-function associated to the classical modular form 25.12.a.a
  * https://www.lmfdb.org/ModularForm/GL2/Q/holomorphic/25/12/a/a/
  *
  * Change the following two lines, to modify the number of decimal digits printed, or to print raw format (not human friendly)
@@ -12,45 +12,34 @@
  * with DIGITS = 20 and RAW = False, running this file should generate something
  * comparable to:
 Order of vanishing = 0
-Epsilon = (1 + 0j)  +/-  (2.52e-114, 2.24e-57j)
-First non-zero Taylor coeff = 0.33298177148293397364 +/- 8.2499e-57
-L(1) = (0.19673558706889585505 + 5.1688917606710579456e-57j)  +/-  (1.16e-38, 1.16e-38j)
-L(2) = (0.46721176888437312394 - 1.2275191787387591289e-56j)  +/-  (2.75e-38, 2.75e-38j)
+Epsilon = (1.0000000000000000000 + 0j)  +/-  (9.59e-104, 4.38e-52j)
+First non-zero Taylor coeff = 2.3573722738933456389 +/- 1.6265e-51
+L(1) = (364965.60485831434308 + 0.00081806356038705015127j)  +/-  (5.84e+2, 1.00e+3j)
+L(2) = (57140.220519766063563 + 5.5635477242815001228e-14j)  +/-  (1.01e-7, 6.62e-8j)
 First 10 zeros
-Zero 0 = 7.2145891812871844435 +/- 1.3364e-51
-Zero 1 = 9.2568107485814985876 +/- 1.0691e-50
-Zero 2 = 10.580974854111851196 +/- 1.3685e-48
-Zero 3 = 12.965859683008166209 +/- 1.3685e-48
-Zero 4 = 15.648104672594291642 +/- 7.0065e-46
-Zero 5 = 16.796003155249041724 +/- 7.0065e-46
-Zero 6 = 18.404976306799735748 +/- 1.121e-44
-Zero 7 = 19.213914502107617614 +/- 8.9683e-44
-Zero 8 = 20.72321683128359949 +/- 1.7937e-43
-Zero 9 = 22.543649261523556672 +/- 1.1479e-41
+Zero 0 = 1.2521055080217079202 +/- 2.2421e-44
+Zero 1 = 2.8663117829294118922 +/- 1.4013e-45
+Zero 2 = 4.5142977865922327037 +/- 2.8026e-45
+Zero 3 = 7.5598700385509993010 +/- 2.1895e-47
+Zero 4 = 8.3258354537392895351 +/- 8.7581e-47
+Zero 5 = 9.3485234343846508216 +/- 2.1895e-47
+Zero 6 = 10.446349369085456678 +/- 2.1895e-47
+Zero 7 = 12.933820963892282617 +/- 7.0065e-46
+Zero 8 = 13.832442737850603893 +/- 2.8026e-45
+Zero 9 = 14.830138630976254483 +/- 1.1210e-44
 Z-plot in [0, 10]:
-0.00	0.33	                              |-o
-0.50	0.36	                              |-o
-1.00	0.45	                              |--o
-1.50	0.61	                              |---o
-2.00	0.85	                              |-----o
-2.50	1.18	                              |-------o
-3.00	1.58	                              |----------o
-3.50	2.04	                              |--------------o
-4.00	2.49	                              |-----------------o
-4.50	2.86	                              |--------------------o
-5.00	3.01	                              |---------------------o
-5.50	2.85	                              |--------------------o
-6.00	2.32	                              |----------------o
-6.50	1.45	                              |---------o
-7.00	0.43	                              |--o
-7.21	zero	                              Z
-7.50	-0.49	                           o--|
-8.00	-1.00	                       o------|
-8.50	-0.94	                       o------|
-9.00	-0.37	                            o-|
-9.26	zero	                              Z
-9.50	0.32	                              |-o
-10.00	0.63	                              |---o
+0.00	2.36	                              |----------------o
+1.25	zero	                              Z
+1.60	-0.79	                         o----|
+2.87	zero	                              Z
+3.20	0.88	                              |-----o
+4.51	zero	                              Z
+4.80	-1.49	                   o----------|
+6.41	-5.00	------------------------------|
+7.56	zero	                              Z
+8.01	0.33	                              |-o
+8.33	zero	                              Z
+9.61	0.52	                              |--o
  */
 #define __STDC_FORMAT_MACROS
 #include <chrono>
@@ -66,6 +55,7 @@ Z-plot in [0, 10]:
 #include <vector>
 #include <flint/fmpz.h>
 #include <flint/acb_poly.h>
+#include <cassert>
 #include "glfunc.h"
 
 
@@ -336,6 +326,15 @@ int main ()
     std::abort();
   }
   printf("L(2) = ");acb_printd(ctmp, DIGITS);printf("\n");
+  { // regression assert: L(2)
+    acb_t ref; acb_init(ref);
+    arb_set_str(acb_realref(ref), "57140.220519766063563", 300);
+    arb_set_str(acb_imagref(ref), "0", 300);
+    arb_add_error_2exp_si(acb_realref(ref), -50);
+    arb_add_error_2exp_si(acb_imagref(ref), -50);
+    assert(acb_overlaps(ctmp, ref));
+    acb_clear(ref);
+  }
   acb_clear(ctmp);
 
   printf("First 10 zeros\n");
@@ -346,6 +345,14 @@ int main ()
     arb_printd(zeros+i, DIGITS);
     printf("\n");
     if (RAW) cout<<"RAW: "<<zeros + i<< endl;
+  }
+
+  { // regression assert: first zero
+    arb_t ref; arb_init(ref);
+    arb_set_str(ref, "1.2521055080217079202", 300);
+    arb_add_error_2exp_si(ref, -50);
+    assert(arb_overlaps(zeros + 0, ref));
+    arb_clear(ref);
   }
 
   printf("Z-plot in [0, 10]:\n");

--- a/examples/cmf_7.3.b.a.cpp
+++ b/examples/cmf_7.3.b.a.cpp
@@ -1,8 +1,8 @@
 // Copyright Edgar Costa 2019
 // See LICENSE file for license details.
 /*
- * Make up a degree 2 L-function associated to the classical modular form 23.1.b.a
- * http://www.lmfdb.org/L/ModularForm/GL2/Q/holomorphic/23/1/b/a/
+ * Make up a degree 2 L-function associated to the classical modular form 7.3.b.a
+ * http://www.lmfdb.org/L/ModularForm/GL2/Q/holomorphic/7/3/b/a/
  *
  * Change the following two lines, to modify the number of decimal digits printed, or to print raw format (not human friendly)
  */
@@ -80,7 +80,7 @@ using std::vector;
 
 
 // such dictionary can be obtained directly from the sidebar
-// http://www.lmfdb.org/L/ModularForm/GL2/Q/holomorphic/23/1/b/a/
+// http://www.lmfdb.org/L/ModularForm/GL2/Q/holomorphic/7/3/b/a/
 map<int64_t, vector<int64_t>> euler_factors  = {
 {2, { 1, 3, 4 }},
 {3, { 1, 0, -9 }},

--- a/examples/ec_37.a1.cpp
+++ b/examples/ec_37.a1.cpp
@@ -194,6 +194,13 @@ int main ()
     printf("\n");
     if (RAW) cout<<"RAW: "<<zeros + i<< endl;
   }
+  { // regression assert: first zero
+    arb_t ref; arb_init(ref);
+    arb_set_str(ref, "5.0031700140066586953", 300);
+    arb_add_error_2exp_si(ref, -50);
+    assert(arb_overlaps(zeros + 0, ref));
+    arb_clear(ref);
+  }
 
 
   acb_t ctmp;acb_init(ctmp);
@@ -204,6 +211,15 @@ int main ()
   }
   printf("L(1.5) = ");acb_printd(ctmp, DIGITS);printf("\n");
   if (RAW) cout<<"RAW: "<<ctmp << endl;
+  { // regression assert: L(1.5)
+    acb_t ref; acb_init(ref);
+    arb_set_str(acb_realref(ref), "0.18396547525832984973", 300);
+    arb_set_str(acb_imagref(ref), "0", 300);
+    arb_add_error_2exp_si(acb_realref(ref), -50);
+    arb_add_error_2exp_si(acb_imagref(ref), -50);
+    assert(acb_overlaps(ctmp, ref));
+    acb_clear(ref);
+  }
   // ~ 0.551792338072610900567950084313
   ecode|=Lfunc_special_value(ctmp, L, 2.5,0.0);
   if(fatal_error(ecode)) {

--- a/examples/ec_389.a1.cpp
+++ b/examples/ec_389.a1.cpp
@@ -242,7 +242,6 @@ int main ()
   assert(arb_overlaps(Lfunc_Taylor(L), bsd));
   arb_clear(bsd);
 
-  //FIXME add asserts and these two lines to intro text
   // ~ 0.133768432546318414418290373661
   acb_t ctmp;
   acb_init(ctmp);
@@ -253,6 +252,15 @@ int main ()
   }
   printf("L(1.5) = ");acb_printd(ctmp, DIGITS);printf("\n");
   if (RAW) cout<<"RAW: "<<ctmp << endl;
+  { // regression assert: L(1.5)
+    acb_t ref; acb_init(ref);
+    arb_set_str(acb_realref(ref), "0.13376843254631841442", 300);
+    arb_set_str(acb_imagref(ref), "0", 300);
+    arb_add_error_2exp_si(acb_realref(ref), -50);
+    arb_add_error_2exp_si(acb_imagref(ref), -50);
+    assert(acb_overlaps(ctmp, ref));
+    acb_clear(ref);
+  }
   // ~ 0.552975867046450192416260240311
   ecode|=Lfunc_special_value(ctmp, L, 2.5,0.0);
   if(fatal_error(ecode)) {
@@ -270,6 +278,13 @@ int main ()
     arb_printd(zeros+i, DIGITS);
     printf("\n");
     if (RAW) cout<<"RAW: "<<zeros + i<< endl;
+  }
+  { // regression assert: first zero
+    arb_t ref; arb_init(ref);
+    arb_set_str(ref, "2.8760990712604652018", 300);
+    arb_add_error_2exp_si(ref, -50);
+    assert(arb_overlaps(zeros + 0, ref));
+    arb_clear(ref);
   }
 
   printf("Z-plot in [0, 10]:\n");

--- a/examples/ec_5077.a1.cpp
+++ b/examples/ec_5077.a1.cpp
@@ -430,6 +430,15 @@ int main ()
   }
   printf("L(1.5) = ");acb_printd(ctmp, DIGITS);printf("\n");
   if (RAW) cout<<"RAW: "<<ctmp << endl;
+  { // regression assert: L(1.5)
+    acb_t ref; acb_init(ref);
+    arb_set_str(acb_realref(ref), "0.086781447504949672575", 300);
+    arb_set_str(acb_imagref(ref), "0", 300);
+    arb_add_error_2exp_si(acb_realref(ref), -50);
+    arb_add_error_2exp_si(acb_imagref(ref), -50);
+    assert(acb_overlaps(ctmp, ref));
+    acb_clear(ref);
+  }
   // ~ 0.510863948654827254260483653705
   ecode|=Lfunc_special_value(ctmp, L, 2.5,0.0);
   if(fatal_error(ecode)) {
@@ -448,6 +457,13 @@ int main ()
     arb_printd(zeros+i, DIGITS);
     printf("\n");
     if (RAW) cout<<"RAW: "<<zeros + i<< endl;
+  }
+  { // regression assert: first zero
+    arb_t ref; arb_init(ref);
+    arb_set_str(ref, "2.0524728584799397697", 300);
+    arb_add_error_2exp_si(ref, -50);
+    assert(arb_overlaps(zeros + 0, ref));
+    arb_clear(ref);
   }
 
   printf("Z-plot in [0, 10]:\n");


### PR DESCRIPTION
## Summary

Expands the `make check` regression suite from 7 to 10 binaries and strengthens the example asserts, so more of the numeric core (FFT / upsampling / zero-finding / special values) is guarded against regressions. Every baked-in constant is the library's own **certified ball**, independently cross-checked against Sage and/or Magma (not LMFDB — several of these objects are not in it).

Closes beads `lfunctions-8f2`, `eds`, `u6s`, `1dp`, `1lx`, `loj`.

### Changes

- **`cmf_23.1.b.a`** (weight-1 dihedral, cond. 23) — added L(1) + first-zero asserts and wired into `CHECK_BINS`. Sage `Dokchitser` cross-check agreed to 15 significant figures. (`afc9b8a`)
- **`cmf_25.12.a.a`** (weight-12, level 25) — its in-file expected-output header was **stale** (copy-pasted from `cmf_7.3.b.a`: wrong L-values/zeros, prose mislabeled "23.1.b.a"). Regenerated the header from the actual run, fixed the mislabel, added an **L(2)** assert (tight ±1e-7 ball, Sage-confirmed to full double precision — L(1) here has a ±584 ball and would be a near-vacuous check) + first-zero assert, wired into `CHECK_BINS`. (`26715b8`)
- **`ec_37.a1` / `ec_389.a1` / `ec_5077.a1`** (ranks 1/2/3) — added L(1.5) + first-non-trivial-zero asserts alongside the existing BSD assert, for parity with the cmf/tau examples; cleared the `//FIXME` in `ec_389.a1`. Sage confirmed ranks, L(1.5), and the first zero heights for all three. (`f26f075`)
- **`artin`** (Artin-rep L-function tool) — added an **argument-free self-test mode** (embedded the documented `2.47.5t2.a.a` dim-2 dihedral rep) that asserts rank + L(1) + first zero on certified output, so it runs under `make check`; the existing `argc==3` file-based tool mode is preserved unchanged (shared `process_line` helper). Constants dual-cross-checked: Magma `LSeries` and Sage `Dokchitser`, both reproducing L(1)=0.4506602209… and the first zero 2.98743469578… to full printed precision (rep rebuilt independently from the class group of Q(√−47)). (`2d5599b`)
- **`bound.cpp`** — triaged as a parameter-tuning diagnostic (CLI-arg driven, conductor-1 placeholder, never calls `Lfunc_compute`, prints the coefficient-cost factor `M/√N`), so documented with an accurate header comment explaining why it is print-only and excluded from `make check`. (`fee3323`)
- **`cmf_7.3.b.a.cpp`** — corrected the mislabeled header (described the object as `23.1.b.a`; it is `7.3.b.a`, conductor 7). Cosmetic only. (`2660c5c`)

`CHECK_BINS` now also runs `cmf_23.1.b.a`, `cmf_25.12.a.a`, and `artin`.

## Test Plan

- [x] `make clean && make check` from a clean tree → `CHECK PASSED`, all 10 binaries pass.
- [x] Each new/changed numeric constant is the library's certified ball, cross-checked against an independent CAS (Sage `Dokchitser` and/or Magma `LSeries`/Artin representations).
- [x] `artin` self-test is hermetic (verified identical certified output across repeated runs and with a stale `g_<norm>` cache present; the suite scrubs `g_[0-9]*` between binaries).
- [x] `artin`'s `argc==3` production tool path verified behaviourally unchanged (traced `process_line` statement-by-statement against the original loop).
