### PR TITLE
fix(g): include <stdio.h> before <gmp.h> so mpz_inp_str is declared

### DIFF
--- a/src/g.c
+++ b/src/g.c
@@ -1,7 +1,7 @@
+#include <stdio.h> // must precede <gmp.h>: GMP only declares its FILE* I/O (mpz_inp_str) when <stdio.h> is seen first
 #include <gmp.h>  // must precede FLINT headers so the GMP-interop decls (fmpz_set_mpz) are visible
 #include "glfunc.h"
 #include "glfunc_internals.h"
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>


### PR DESCRIPTION
## Summary

Completes the FLINT 3.x build fix from 4490a30. A user building current `main`
still hits:

```
src/g.c:600:9: error: implicit declaration of function ‘__gmpz_inp_str’;
  did you mean ‘__gmpz_set_str’? [-Wimplicit-function-declaration]
  600 |     if(!mpz_inp_str(x,infile,10))
```

## Root cause

Two independent include-ordering constraints apply to `src/g.c`:

1. `<gmp.h>` must precede the FLINT headers so the GMP-interop declarations
   (`fmpz_set_mpz`) are visible on FLINT 3.1+ (which gates them on
   `__GMP_H__` and no longer pulls in `<gmp.h>` from `flint.h`).
2. `<stdio.h>` must precede `<gmp.h>`, because GMP only declares its
   `FILE*`-based I/O — `mpz_inp_str`, used by `read_arb`/`read_gfile` — when
   `<stdio.h>` is already visible the **first** time `<gmp.h>` is processed
   (it gates them on `_GMP_H_HAVE_FILE`).

Commit 4490a30 satisfied (1) by adding `#include <gmp.h>` as the first line,
but that put `<gmp.h>` *before* the existing `<stdio.h>`, breaking (2). So
`mpz_inp_str` is still implicitly declared and the build still fails on any
toolchain whose FLINT headers don't themselves pull in `<stdio.h>` before
`<gmp.h>`. (Installs where `flint.h` includes `<stdio.h>` happen to mask it.)

`src/g.c` is the only file in the tree that uses any GMP/MPFR `FILE*` I/O
(six `mpz_inp_str` calls; the writer side uses FLINT's `fmpz_fprint`, which is
unaffected), so this is the sole affected site.

## Fix

Move `#include <stdio.h>` ahead of `#include <gmp.h>`, keeping `<gmp.h>`
ahead of the FLINT headers. The resulting order `stdio → gmp → FLINT`
satisfies both constraints. One line moved.

## Testing

On a toolchain whose FLINT headers don't pre-include `<stdio.h>` (gcc 15 +
system GMP here), the base (`main`) fails to compile `src/g.c` with the exact
error above at line 600 — proven by syntax-checking `main`'s `g.c` directly —
while this branch builds `liblfun.so` and passes the full `make check` suite.
The project build is the regression oracle: the broken ordering fails to
build, the fixed ordering builds and the numeric suite passes. The change is
a pure include reorder with no runtime effect.
