### PR TITLE
docs(examples): fix off-by-one in bound.cpp hi_i comment

### DIFF
--- a/examples/bound.cpp
+++ b/examples/bound.cpp
@@ -9,9 +9,9 @@
  * the number of Dirichlet coefficients per unit sqrt(conductor) the library
  * will need.  Here:
  *   - one_over_B = degree/512, so B = 512/degree.
- *   - hi_i (glfunc_internals.h) is the top of the G u-grid: the largest index
- *     i such that |G(u_i)| > 2^{-prec}; it determines where the G-kernel
- *     drops below the precision threshold.
+ *   - hi_i (glfunc_internals.h) is the top of the G u-grid: the smallest index
+ *     i such that |G(u_i)| <= 2^{-prec}; it marks where the G-kernel first
+ *     drops to or below the precision threshold.
  *   - M (glfunc_internals.h) = floor(sqrt(N) * exp(2*pi*(hi_i+0.5)/B)) is the
  *     largest coefficient index a_n the library actually uses; it scales as
  *     sqrt(conductor).


### PR DESCRIPTION
## Summary

Corrects an off-by-one in the `examples/bound.cpp` header comment added in `ebfc4da`.

The comment described `hi_i` as *"the largest index i such that |G(u_i)| > 2^-prec"*, but `hi_i` is the **smallest** index i with `|G(u_i)| <= 2^-prec` — the authoritative definition in the struct doc (`include/glfunc_internals.h`) and the `imax` loop in `src/g.c` (`for (imax=imin; error_bound(...)<prec; imax++); L->hi_i=imax;`). The "largest i with |G|>2^-prec" is `hi_i - 1`.

Comment-only change to a print-only diagnostic helper; no code or behavior change.

## Test Plan

- [x] Purely a `/* */` comment edit (3 lines); cannot affect compilation or behavior.
- [x] `bound.cpp` never calls `Lfunc_compute` and is excluded from `make check`, so there is no runtime path to test.
