### PR TITLE
ci: add --enable-sanitize build and an ASan/UBSan CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,3 +18,25 @@ jobs:
         run: make
       - name: Test
         run: make check
+
+  sanitizers:
+    runs-on: ubuntu-latest
+    env:
+      # Abort the run on any ASan/UBSan finding so CI fails loudly; print full
+      # UBSan stack traces. LeakSanitizer is on by default for ASan on Linux.
+      ASAN_OPTIONS: halt_on_error=1:detect_leaks=1:abort_on_error=1
+      UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1:abort_on_error=1
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential libflint-dev libprimesieve-dev
+      - name: Configure (sanitizers)
+        # ./configure carries --enable-sanitize (committed, generated from
+        # configure.ac), so no autotools regeneration step is needed.
+        run: ./configure --enable-sanitize
+      - name: Build
+        run: make
+      - name: Test under ASan/UBSan
+        run: make check

--- a/configure
+++ b/configure
@@ -709,6 +709,7 @@ ac_user_opts='
 enable_option_checking
 enable_assert
 enable_gdb
+enable_sanitize
 with_flint
 with_gmp
 with_mpfr
@@ -1345,6 +1346,9 @@ Optional Features:
   --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
   --disable-assert        compile with -DNDEBUG (turns asserts off)
   --disable-gdb           do not add -g debug symbols
+  --enable-sanitize       build with -fsanitize=address,undefined
+                          -fno-omit-frame-pointer (ASan/UBSan; for
+                          CI/debugging)
 
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
@@ -3899,6 +3903,14 @@ else $as_nop
   enable_gdb=yes
 fi
 
+# Check whether --enable-sanitize was given.
+if test ${enable_sanitize+y}
+then :
+  enableval=$enable_sanitize;
+else $as_nop
+  enable_sanitize=no
+fi
+
 
 
 # Check whether --with-flint was given.
@@ -4400,6 +4412,17 @@ then :
   LFUN_CXXFLAGS=$lfun_user_cxxflags
 else $as_nop
   LFUN_CXXFLAGS="$lfun_base -std=c++1z"
+fi
+
+# --enable-sanitize: append ASan/UBSan to the *final* flags (whether default or
+# user-supplied) so it applies regardless of CFLAGS. The Makefile link rules use
+# $(CFLAGS)/$(CXXFLAGS), so the same flags drive both compile and link (libasan
+# must be present at link time). Default off => normal build is unchanged.
+lfun_sanitize_flags="-fsanitize=address,undefined -fno-omit-frame-pointer"
+if test "x$enable_sanitize" = xyes
+then :
+  LFUN_CFLAGS="$LFUN_CFLAGS $lfun_sanitize_flags"
+   LFUN_CXXFLAGS="$LFUN_CXXFLAGS $lfun_sanitize_flags"
 fi
 
 # ---- parallel jobs = ncpu + 1 (replaces the python3 call) ----------------

--- a/configure.ac
+++ b/configure.ac
@@ -26,6 +26,10 @@ AC_ARG_ENABLE([assert],
 AC_ARG_ENABLE([gdb],
   [AS_HELP_STRING([--disable-gdb], [do not add -g debug symbols])],
   [], [enable_gdb=yes])
+AC_ARG_ENABLE([sanitize],
+  [AS_HELP_STRING([--enable-sanitize],
+     [build with -fsanitize=address,undefined -fno-omit-frame-pointer (ASan/UBSan; for CI/debugging)])],
+  [], [enable_sanitize=no])
 
 AC_ARG_WITH([flint],      [AS_HELP_STRING([--with-flint=DIR],      [location of FLINT (>=3.0; provides Arb)])])
 AC_ARG_WITH([gmp],        [AS_HELP_STRING([--with-gmp=DIR],        [location of GMP])])
@@ -133,6 +137,15 @@ AS_IF([test "x$enable_gdb"    != xno], [lfun_base="$lfun_base -g"])
 AS_IF([test "x$enable_assert" =  xno], [lfun_base="$lfun_base -DNDEBUG"])
 AS_IF([test "x$lfun_user_cflags_set"   = xyes], [LFUN_CFLAGS=$lfun_user_cflags],     [LFUN_CFLAGS="$lfun_base -std=gnu11"])
 AS_IF([test "x$lfun_user_cxxflags_set" = xyes], [LFUN_CXXFLAGS=$lfun_user_cxxflags], [LFUN_CXXFLAGS="$lfun_base -std=c++1z"])
+
+# --enable-sanitize: append ASan/UBSan to the *final* flags (whether default or
+# user-supplied) so it applies regardless of CFLAGS. The Makefile link rules use
+# $(CFLAGS)/$(CXXFLAGS), so the same flags drive both compile and link (libasan
+# must be present at link time). Default off => normal build is unchanged.
+lfun_sanitize_flags="-fsanitize=address,undefined -fno-omit-frame-pointer"
+AS_IF([test "x$enable_sanitize" = xyes],
+  [LFUN_CFLAGS="$LFUN_CFLAGS $lfun_sanitize_flags"
+   LFUN_CXXFLAGS="$LFUN_CXXFLAGS $lfun_sanitize_flags"])
 
 # ---- parallel jobs = ncpu + 1 (replaces the python3 call) ----------------
 lfun_ncpu=`getconf _NPROCESSORS_ONLN 2>/dev/null || nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 1`

--- a/src/error.c
+++ b/src/error.c
@@ -193,6 +193,7 @@ void init_ftwiddle_error(Lfunc *L, int64_t prec)
   arb_clear(two_pi);
   arb_clear(E);
   arb_clear(four_by_pi2);
+  arb_clear(beta);
 
 }
 
@@ -323,22 +324,31 @@ bool M_error(arb_t res, arb_t x, Lfunc *L, int64_t prec)
 #define BIG_ZETAD (1.001) // zeta([10,infinty]) in [1,1.001]
 void djp_zeta(arb_t res, const arb_t x, slong prec)
 {
+  // big_zeta / big_zetad are process-lifetime cached constants; init once.
+  // (The previous code never set init=true, so it re-ran arb_init every call,
+  // leaking big_zetad's heap mantissa each time -- numerically a no-op since
+  // the constants are recomputed identically.)
   static bool init=false;
-  static arb_t big_zeta,big_zetad,z;
-  
+  static arb_t big_zeta,big_zetad;
   if(!init)
     {
       arb_init(big_zeta);
       arb_init(big_zetad);
-      arb_init(z);
       arb_set_ui(big_zeta,1);
       arb_set_d(big_zetad,BIG_ZETAD);
       arb_union(big_zetad,big_zetad,big_zeta,prec);
       arb_set_ui(big_zeta,BIG_ZETA);
+      init=true;
     }
-      
+
+  // z is pure scratch: compute x-big_zeta, test its sign, discard. Keep it a
+  // plain local (init+clear each call) so its heap mantissa is not leaked.
+  arb_t z;
+  arb_init(z);
   arb_sub(z,x,big_zeta,prec);
-  if(arb_is_positive(z)) // very large x
+  bool very_large_x = arb_is_positive(z);
+  arb_clear(z);
+  if(very_large_x) // very large x
     {
       arb_set(res,big_zetad);
       return;

--- a/src/glfunc.c
+++ b/src/glfunc.c
@@ -139,12 +139,16 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
   L->mus = (double *)malloc(sizeof(double) * L->degree);
   if (!L->mus) {
     ecode[0] |= ERR_OOM;
+    free(L);
     return (Lfunc_t)NULL;
   }
   for (i = 0; i < L->degree; i++) {
     L->mus[i] = Lp->mus[i] + Lp->normalisation; // alg->anal
     if (!is_half_int(L->mus[i])) {
       ecode[0] |= ERR_MU_HALF;
+      // only L and L->mus are live here (no arb_t initialised yet)
+      free(L->mus);
+      free(L);
       return (Lfunc_t)NULL;
     }
   }
@@ -354,8 +358,6 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
   for (size_t i = 0; i < L->allocated_M; ++i)
     acb_init(L->ans[i]);
 
-  arb_init(L->ftwiddle_error);
-
   arb_clear(tmp);
 
 #ifdef BUTHE
@@ -395,7 +397,11 @@ Lfunc_t Lfunc_init(uint64_t degree, uint64_t conductor, double normalisation,
   Lp.gprec = 0; // We will try to do something sensible
   Lp.wprec = 0; // ditto
 
-  return Lfunc_init_advanced(&Lp, ecode);
+  // Lfunc_init_advanced copies Lp.mus into L->mus, so this scratch array is ours
+  // to free; otherwise it leaks (Lp is a stack local that goes out of scope).
+  Lfunc_t L = Lfunc_init_advanced(&Lp, ecode);
+  free(Lp.mus);
+  return L;
 }
 
 int64_t Lfunc_wprec(Lfunc_t Lf) {


### PR DESCRIPTION
## What

Adds an AddressSanitizer + UndefinedBehaviorSanitizer build, runs the `make check`
suite under it in CI, and fixes the memory leaks that pass surfaces.

Closes beads `lfunctions-6cb` (sanitizer build + CI) and `lfunctions-1du`
(pre-existing leaks in `Lfunc_init` / error-analysis temporaries).

## Sanitizer build (6cb)

- `configure.ac`: new `--enable-sanitize` that appends
  `-fsanitize=address,undefined -fno-omit-frame-pointer` to the final
  `LFUN_CFLAGS`/`LFUN_CXXFLAGS`. The Makefile link rules use the same flags, so
  they drive both compile and link. **Default off — the normal build is unchanged.**
- The regenerated `./configure` **is committed** (this repo ships a generated
  `configure` so building needs no autotools; at autoconf 2.71 — matching the
  committed file — the diff is just the +23 lines for the new option, no churn).
- `.github/workflows/ci.yml`: a separate `sanitizers` Linux job
  (`./configure --enable-sanitize` → `make` → `make check`) with
  `halt_on_error`/`abort_on_error` set so any finding fails the build loudly.

## Leak fixes (1du)

All were "definitely lost" per ASan/LSan (cross-checked with valgrind: 0
definitely/indirectly lost). No numeric-behaviour change — the `arb_overlaps`
asserts are untouched and still pass.

- `src/glfunc.c` `Lfunc_init`: free the scratch `Lp.mus` array after
  `Lfunc_init_advanced` copies it into `L->mus`.
- `src/glfunc.c` `Lfunc_init_advanced`: free `L` / `L->mus` on the `ERR_OOM` and
  `ERR_MU_HALF` early-return paths; drop a redundant `arb_init(L->ftwiddle_error)`.
- `src/error.c` `init_ftwiddle_error`: add `arb_clear(beta)` (heap-promoted by
  `arb_mul_ui`).
- `src/error.c` `djp_zeta`: set `init = true` (the cached constants were being
  re-initialised on every call) and make scratch `z` a per-call local that is
  cleared; the constants are recomputed identically.

## Verification

- **Sanitized:** `libasan.so.8` links into the binaries (sanitizer genuinely
  active), and sanitized `make check` passes with zero ASan/UBSan/leak findings.
- **Normal:** `./configure && make check` still passes; binaries link no `libasan`
  (sanitizer off by default).
