### PR TITLE
build: derive make check suite as a deny-list, not a hand-maintained allow-list

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -86,21 +86,21 @@ print-%:
 
 .PHONY: clean check configure
 
-# Curated regression suite. Exit code is the oracle (assertions are on by default).
+# Regression suite. Exit code is the oracle (assertions are on by default).
 # Stale/colliding g_<mu> caches poison results, so scrub them before the suite
 # and after each binary (different L-functions can share a g_<mu> filename).
-CHECK_BINS = \
-	build/test/dir_test1.exe \
-	build/test/gcache_validate_test.exe \
-	build/examples/ec_37.a1.exe \
-	build/examples/ec_389.a1.exe \
-	build/examples/ec_5077.a1.exe \
-	build/examples/tau.exe \
-	build/examples/cmf_7.3.b.a.exe \
-	build/examples/cmf_23.1.b.a.exe \
-	build/examples/cmf_25.12.a.a.exe \
-	build/examples/artin.exe \
-	build/examples/dir.exe
+#
+# Every test/ and examples/ binary runs under `make check` automatically --
+# drop in a new source file and it joins the suite, no edit here required.
+# CHECK_EXCLUDE is the deny-list: binaries that require command-line arguments
+# or input files (they assert on argc / print a usage message and exit nonzero
+# without args) and so cannot run unattended. Only add an entry here if a
+# binary needs arguments. (artin runs an embedded self-test when given none.)
+CHECK_EXCLUDE = \
+	examples/bound \
+	examples/rational
+
+CHECK_BINS = $(filter-out $(addprefix build/, $(addsuffix .exe, $(CHECK_EXCLUDE))), $(TESTS) $(EXECUTABLES))
 
 check: all
 	@rm -f g_[0-9]*


### PR DESCRIPTION
## Summary

`make check` selected its regression binaries from a hand-maintained `CHECK_BINS`
allow-list in `Makefile.in`. Every new test or example had to be added to that
list by hand — and some never were: `lflint_test` (80 asserts) and
`gcache_collision_test` (7 asserts) were committed but silently absent from the
suite.

This replaces the allow-list with a **deny-list**. `make check` now runs *every*
`test/` and `examples/` binary automatically, except a small `CHECK_EXCLUDE` of
binaries that require command-line arguments / input files (`bound`, `rational`)
and so cannot run unattended:

```make
CHECK_EXCLUDE = \
	examples/bound \
	examples/rational

CHECK_BINS = $(filter-out $(addprefix build/, $(addsuffix .exe, $(CHECK_EXCLUDE))), $(TESTS) $(EXECUTABLES))
```

Adding a new test/example now joins the suite with no `Makefile.in` edit, and
none can be silently forgotten. `artin` runs an embedded self-test when given no
arguments, so it is included rather than excluded.

## What changes in the suite

- **No coverage regression:** all 11 binaries from the previous hand-maintained
  list are retained.
- **Newly run** (committed, but omitted from the allow-list):
  - `test/lflint_test` (80 asserts)
  - `test/gcache_collision_test` (7 asserts)
  - `test/dir_test`, `test/dir_test_cpp` (0 asserts — harmless crash/assert coverage)

## Verification

- `./configure && make check` → **15/15 PASS**, ~27 s.
- Each binary run individually with no args (g-cache scrubbed between): all 15
  exit 0; the two excluded (`bound`, `rational`) abort / usage-exit without args,
  confirming the exclusion is correct.

## Notes

- Pure `Makefile.in` change; the `check:` recipe (g-cache scrub, exit-code
  oracle) is unchanged.
- Refs: bead `lfunctions-62y`.
