### PR TITLE
chore: refresh dangling smalljac.cpp comment references

### DIFF
--- a/include/lflint.h
+++ b/include/lflint.h
@@ -52,8 +52,8 @@ public:
   ZZ& operator*=(slong n)     { fmpz_mul_si(z, z, n); return *this; }
   ZZ& operator*=(ulong n)     { fmpz_mul_ui(z, z, n); return *this; }
 
-  // Non-negative remainder (0 <= r < |modulus|). Required by
-  // smalljac.cpp:203 (`disc % ZZ(4) != 1` for negative discriminants).
+  // Non-negative remainder (0 <= r < |modulus|), so e.g. disc % ZZ(4) stays
+  // in 0..3 even for a negative discriminant ((-5) % 3 == 1, not -2).
   ZZ operator%(const ZZ& m) const { ZZ r; fmpz_mod   (r.z, z, m.z); return r; }
   ZZ operator%(ulong n)     const { ZZ r; fmpz_mod_ui(r.z, z, n);   return r; }
 

--- a/test/lflint_test.cpp
+++ b/test/lflint_test.cpp
@@ -92,7 +92,8 @@ static void test_arithmetic() {
   x *= slong{2};
   assert(fmpz_get_si(x._fmpz()) == 72);
 
-  // ZZ *= ulong (fmpz_mul_ui) — added to avoid sign-narrowing at smalljac.cpp:301 `qn *= q`
+  // ZZ *= ulong (fmpz_mul_ui) — multiply by an unsigned value without
+  // narrowing it through slong (pattern `qn *= q`, q a ulong)
   ZZ y(slong{6});
   y *= ulong{7};
   assert(fmpz_get_si(y._fmpz()) == 42);
@@ -151,7 +152,7 @@ static void test_divisibility() {
   ZZ q = minus_twelve.divexact(slong{4});
   assert(fmpz_get_si(q._fmpz()) == -3);
 
-  // smalljac.cpp:202 pattern: `while(d.divisible(4)) d = d.divexact(4);`
+  // realistic usage — strip all factors of 4: `while (d.divisible(4)) d = d.divexact(4);`
   ZZ d(slong{-48});
   while (d.divisible(slong{4})) d = d.divexact(slong{4});
   assert(fmpz_get_si(d._fmpz()) == -3);
@@ -179,7 +180,7 @@ static void test_to_conversion() {
   assert(y.to<slong>()  == 1024);
   assert(u.to<ulong>()  == ulong{7});
   assert(y.to<double>() == 1024.0);
-  // smalljac.cpp:97 pattern: `(polynomial[i] % pol->mod.n).to<mp_limb_t>()`
+  // realistic usage — reduce mod n, then narrow: `(coeff % n).to<mp_limb_t>()`
   // mp_limb_t == ulong; same specialisation
   assert((y % ulong{17}).to<ulong>() == ulong{1024 % 17});
 }


### PR DESCRIPTION
Bead: **lfunctions-wrc** — close on merge.

Removes dangling references to the deleted `examples/smalljac.cpp` from comments, keeping only each comment's self-standing technical point (no "this used to live in smalljac" back-references):

- `include/lflint.h` — the `operator%` comment now states the non-negative-remainder contract directly (`(-5) % 3 == 1`, not `-2`; `disc % ZZ(4)` stays in `0..3` for a negative discriminant), with no smalljac citation.
- `test/lflint_test.cpp` — three test comments rewritten to describe what each case exercises (`*= ulong` without sign-narrowing; a strip-all-factors-of-4 `divisible`/`divexact` loop; reduce-mod-then-narrow `% ` + `.to<mp_limb_t>()`), dropping the `smalljac.cpp:NNN` line-number citations.

`examples/rational.c:6` ("for a smalljac curve") refers to the **external** smalljac CLI input format (still relevant for `lfunctions-4jd`), not the removed file, so it is left as-is.

Comment-only — no code or behaviour change.
