### PR TITLE
feat(glfunc): reject perfect-power / repeated-factor L-functions up front (ERR_POWER)

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -388,11 +388,11 @@ successfully extracted pure power `L = M^k`, it returns 1. If `factors` is
 non-NULL, `*factors` is set to a borrowed array whose first element points to
 `M`; if `mults` is non-NULL, `*mults` is set to an array whose first element is
 `k`. The returned arrays and factor objects are owned by `L`; do not clear them
-yourself, and do not use them after {c:func}`Lfunc_clear(L)`.
+yourself, and do not use them after {c:func}`Lfunc_clear`.
 
 The assembled object exposes the quantities that can be assembled from the
 factor: rank, sign, zeros, leading Taylor coefficient, and special values.
-Plot samples are the exception; see [Plot data](#plot-data-lfunc-plot-data-and-lfunc-clear-plot).
+Plot samples are the exception; see [Plot data](#plot-data-lfunc_plot_data-and-lfunc_clear_plot).
 
 ### Zeros: `Lfunc_zeros`
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -101,6 +101,7 @@ typedef struct {
   int      self_dual;     // DK / YES / NO
   int      rank;          // DK, or a known rank
   char    *cache_dir;     // directory for the cached G data
+  int      extract_powers; // YES to extract and assemble clean powers from exact fmpz supply
 } Lparams_t;
 ```
 
@@ -112,6 +113,7 @@ typedef struct {
 | {c:member}`self_dual <Lparams_t.self_dual>` | whether the L-function equals its dual | `DK`: the library decides |
 | {c:member}`rank <Lparams_t.rank>` | analytic rank, if already known | `DK`: the library determines it |
 | {c:member}`cache_dir <Lparams_t.cache_dir>` | where to read/write cached G data | current directory; see [The G-data cache](#g-data-cache) |
+| {c:member}`extract_powers <Lparams_t.extract_powers>` | opt in to computing a certified pure power `L = M^k` by extracting `M` from exact `fmpz_poly_t` Euler-factor supply and assembling the result | `NO`: reject powers with {c:macro}`ERR_POWER` |
 
 The tri-state fields use the macros {c:macro}`DK` (-1, "don't know"),
 {c:macro}`YES` (1), and {c:macro}`NO` (0). Setting `self_dual = YES` when you
@@ -119,6 +121,26 @@ know the L-function is self-dual (every elliptic curve over Q, for instance)
 lets the library skip computing the dual side. Supplying a known `rank` lets it
 skip the rank search; if the computed rank then disagrees with what you
 supplied, you get the {c:macro}`ERR_CONFLICT_RANK` warning.
+
+The power/repeated-factor guard is enabled by default. If the supplied
+L-function appears to be a perfect power, or to have repeated primitive factors,
+the default behavior is to stop with the fatal {c:macro}`ERR_POWER` flag rather
+than continue into a zero search with repeated zeros. Set
+{c:member}`extract_powers <Lparams_t.extract_powers>` to {c:macro}`YES` only
+when you want the library to certify a clean pure power `L = M^k`, compute the
+primitive factor `M`, and assemble the rank, zeros, sign, Taylor coefficient,
+and special values of `L` from it. The extracted factor is available through
+{c:func}`Lfunc_factors`. This is not a general factorisation API: a primitive
+object reports no factors, and an extracted pure power reports one primitive
+factor with its multiplicity.
+
+Extraction is certified only from exact integer-polynomial Euler factors supplied
+through {c:func}`Lfunc_use_lpoly_fmpz` or
+{c:func}`Lfunc_use_all_lpolys_fmpz`. Factors supplied through the `acb_poly_t`
+APIs are still used for computation and for the repeated-factor guard, but they
+do not carry exact provenance; if the guard detects a power from acb-only or
+mixed acb/fmpz supply under `extract_powers = YES`, computation stops with
+{c:macro}`ERR_POWER` rather than extracting.
 
 Leaving a numeric knob at 0 asks the library to choose it. There is no need to
 set `target_prec`, `wprec`, or `gprec` unless you have a specific reason;
@@ -131,8 +153,9 @@ Between creation and computation you hand the library the local L-factors of
 the L-series. The routes are described in detail in
 [Supplying Euler factors](#supplying-euler-factors). In brief: either let the
 library drive a callback over every prime it needs
-({c:func}`Lfunc_use_all_lpolys`), or push factors one prime at a time
-({c:func}`Lfunc_use_lpoly`).
+({c:func}`Lfunc_use_all_lpolys` or
+{c:func}`Lfunc_use_all_lpolys_fmpz`), or push factors one prime at a time
+({c:func}`Lfunc_use_lpoly` or {c:func}`Lfunc_use_lpoly_fmpz`).
 
 ### 3. Compute
 
@@ -201,15 +224,17 @@ the worked examples use `mus = [0, 1]` with the weight-derived
 
 ## Supplying Euler factors
 
-The library needs the local L-factor `L_p(T)` (an `acb_poly_t`, a polynomial in
-`T` with the constant term normalised to 1) for every prime `p` up to a bound
-fixed by the conductor and degree. {c:func}`Lfunc_nmax` returns that bound:
+The library needs the local L-factor `L_p(T)` (a polynomial in `T` with the
+constant term normalised to 1) for every prime `p` up to a bound fixed by the
+conductor and degree. You may supply it numerically as an `acb_poly_t`, or
+exactly as an integer `fmpz_poly_t`. {c:func}`Lfunc_nmax` returns that bound:
 
 ```c
 uint64_t nmax = Lfunc_nmax(L);   // largest prime p for which a factor is expected
 ```
 
-There are two ways to deliver the factors.
+There are acb and exact-fmpz variants of the callback and one-prime-at-a-time
+routes.
 
 ### Driven by the library: `Lfunc_use_all_lpolys`
 
@@ -248,18 +273,36 @@ void lpoly_callback(acb_poly_t poly, uint64_t p, int d, int64_t prec, void *para
 }
 ```
 
+### Exact integer callback: `Lfunc_use_all_lpolys_fmpz`
+
+```c
+Lerror_t Lfunc_use_all_lpolys_fmpz(
+    Lfunc_t L,
+    void (*lpoly_callback)(fmpz_poly_t lpoly, uint64_t p, int d, void *parm),
+    void *param);
+```
+
+This is the same prime-driven interface, but the callback fills an exact
+integer polynomial. Leaving `lpoly` equal to zero is the same insufficient-supply
+sentinel. Use this route when you want `extract_powers = YES` to be able to
+certify and assemble a pure power.
+
 ### One prime at a time: `Lfunc_use_lpoly`
 
 ```c
 void Lfunc_use_lpoly(Lfunc_t L, uint64_t p, const acb_poly_t poly);
+Lerror_t Lfunc_use_lpoly_fmpz(Lfunc_t L, uint64_t p, const fmpz_poly_t poly);
 ```
 
 Push a single factor for the prime `p`. Use this when you already have the
 primes enumerated (for example from `primesieve`) and want to loop yourself.
-The library copies `poly`. The [worked example](#a-worked-end-to-end-example)
-on this page uses the callback form;
+The library copies `poly`; the fmpz variant also converts it internally to acb
+for the numerical computation while retaining the exact provenance needed for
+power extraction. `Lfunc_use_lpoly_fmpz` returns any fatal retention error
+immediately; callers should OR it into their accumulated `Lerror_t`. The
+[worked example](#a-worked-end-to-end-example) on this page uses the callback form;
 [`examples/rational.c`](https://github.com/edgarcosta/lfunctions/blob/main/examples/rational.c)
-uses this push form over a `primesieve`-generated prime list.
+uses the exact push form over a `primesieve`-generated prime list.
 
 ### Supplying fewer factors than `nmax`: `Lfunc_reduce_nmax`
 
@@ -272,7 +315,7 @@ to declare a smaller bound. **The library takes your word for it and does not
 check** that the reduced bound still yields a correct result, so use it only
 when you understand the consequence. Supplying too few factors (whether through
 this call, or by zero-terminating the callback early, or by simply pushing
-fewer with {c:func}`Lfunc_use_lpoly`) is reported after the computation as the
+fewer with {c:func}`Lfunc_use_lpoly` / {c:func}`Lfunc_use_lpoly_fmpz`) is reported after the computation as the
 {c:macro}`ERR_INSUFF_EULER` warning: the library expected more Euler factors
 than it received, so the results may be degraded or, in the worst case,
 meaningless.
@@ -282,8 +325,8 @@ meaningless.
 raw Dirichlet coefficients `a_n` (and the associated input-validation error
 codes) is being added in the batch-supply API. Those entry points are not part
 of the interface on `main` yet; this guide will document them once they land.
-For now the supply routes are the callback ({c:func}`Lfunc_use_all_lpolys`) and
-the single-prime push ({c:func}`Lfunc_use_lpoly`) described above.
+For now the supply routes are the callback and single-prime push APIs described
+above.
 ```
 
 ## Querying the results
@@ -325,6 +368,23 @@ normalisation (when the input is algebraic, `w` is the motivic weight). It
 carries the same rigour caveat as the rank: rigorous for rank 0 or 1. To
 evaluate the L-function exactly at the central point, use this rather than
 {c:func}`Lfunc_special_value`.
+
+### Extracted factors: `Lfunc_factors`
+
+```c
+uint64_t Lfunc_factors(Lfunc_t L, Lfunc_t **factors, uint64_t **mults);
+```
+
+For a primitive object, or for an object that was not produced through
+{c:member}`extract_powers <Lparams_t.extract_powers>`, this returns 0. For a
+successfully extracted pure power `L = M^k`, it returns 1, stores a borrowed
+pointer to `M` in `factors[0]`, and stores `k` in `mults[0]`. The returned
+arrays and factor objects are owned by `L`; do not clear them yourself, and do
+not use them after {c:func}`Lfunc_clear(L)`.
+
+The assembled object exposes the quantities that can be assembled from the
+factor: rank, sign, zeros, leading Taylor coefficient, and special values.
+Plot samples are the exception; see [Plot data](#plot-data-lfunc-plot-data-and-lfunc-clear-plot).
 
 ### Zeros: `Lfunc_zeros`
 
@@ -380,6 +440,13 @@ typedef struct {
 Free it with {c:func}`Lfunc_clear_plot` when done. Unlike the query accessors
 above, this struct is a separate allocation that you own.
 
+```{warning}
+Plot samples are not meaningful for an object assembled through
+{c:member}`extract_powers <Lparams_t.extract_powers>`, because that path skips
+the sample-generating pipeline. Use {c:func}`Lfunc_factors` to obtain the
+primitive factor and plot that factor instead.
+```
+
 ## Error handling
 
 Every API entry point that can fail returns an {c:type}`Lerror_t`, a 64-bit
@@ -425,6 +492,7 @@ flag to the given `FILE *`. {c:macro}`ERR_SUCCESS` (0) is the clean state.
 | {c:macro}`ERR_BAD_DEGREE` | degree below 2 or above {c:macro}`MAX_DEGREE` |
 | {c:macro}`ERR_SPEC_NZ` | special value requested with `Im(s) < 0` |
 | {c:macro}`ERR_G_EXTENT` | the G grid does not extend low enough (conductor too large for the fixed grid floor, or a stale cached grid was reused) |
+| {c:macro}`ERR_POWER` | the supplied L-function is a perfect power or has repeated primitive factors; set {c:member}`extract_powers <Lparams_t.extract_powers>` to {c:macro}`YES` and supply exact fmpz Euler factors to request certified extraction of a clean pure power |
 
 ### Warning codes
 
@@ -594,7 +662,7 @@ reading:
 - [`rational.c`](https://github.com/edgarcosta/lfunctions/blob/main/examples/rational.c):
   a generic command-line driver that parses
   `label:degree:conductor:weight:[mus]:[[euler_factors]]` lines and uses the
-  {c:func}`Lfunc_use_lpoly` push route over a `primesieve` prime list.
+  {c:func}`Lfunc_use_lpoly_fmpz` push route over a `primesieve` prime list.
 
 ## Full header reference
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -144,7 +144,10 @@ through {c:func}`Lfunc_use_lpoly_fmpz` or
 APIs are still used for computation and for the repeated-factor guard, but they
 do not carry exact provenance; if the guard detects a power from acb-only or
 mixed acb/fmpz supply under `extract_powers = YES`, computation stops with
-{c:macro}`ERR_POWER` rather than extracting.
+{c:macro}`ERR_POWER` rather than extracting. The same applies when the exact
+supply is too sparse to compute `M` at all (no supplied prime falls within `M`'s
+coefficient range): computation stops with {c:macro}`ERR_POWER`, with the
+{c:macro}`ERR_INSUFF_EULER` warning set alongside to explain why.
 
 Leaving a numeric knob at 0 asks the library to choose it. There is no need to
 set `target_prec`, `wprec`, or `gprec` unless you have a specific reason;

--- a/doc/api.md
+++ b/doc/api.md
@@ -105,7 +105,11 @@ typedef struct {
 } Lparams_t;
 ```
 
-| Field | Meaning | Default when left as 0 / `DK` |
+`Lparams_t` is intentionally not a stable ABI or source-compatibility boundary.
+Compile callers against the matching header and zero-initialize the struct before
+setting fields; new fields may be added without preserving older struct layouts.
+
+| Field | Meaning | Default / zero behavior |
 | --- | --- | --- |
 | {c:member}`target_prec <Lparams_t.target_prec>` | precision the results are refined to | {c:macro}`DEFAULT_TARGET_PREC` (100 bits) |
 | {c:member}`wprec <Lparams_t.wprec>` | internal working precision | derived from `target_prec` |
@@ -377,10 +381,11 @@ uint64_t Lfunc_factors(Lfunc_t L, Lfunc_t **factors, uint64_t **mults);
 
 For a primitive object, or for an object that was not produced through
 {c:member}`extract_powers <Lparams_t.extract_powers>`, this returns 0. For a
-successfully extracted pure power `L = M^k`, it returns 1, stores a borrowed
-pointer to `M` in `factors[0]`, and stores `k` in `mults[0]`. The returned
-arrays and factor objects are owned by `L`; do not clear them yourself, and do
-not use them after {c:func}`Lfunc_clear(L)`.
+successfully extracted pure power `L = M^k`, it returns 1. If `factors` is
+non-NULL, `*factors` is set to a borrowed array whose first element points to
+`M`; if `mults` is non-NULL, `*mults` is set to an array whose first element is
+`k`. The returned arrays and factor objects are owned by `L`; do not clear them
+yourself, and do not use them after {c:func}`Lfunc_clear(L)`.
 
 The assembled object exposes the quantities that can be assembled from the
 factor: rank, sign, zeros, leading Taylor coefficient, and special values.
@@ -414,7 +419,9 @@ as `L(k)` and `L(0)` come out sensibly. The routine requires `im >= 0`;
 `im < 0` raises {c:macro}`ERR_SPEC_NZ`. For the central point use
 {c:func}`Lfunc_Taylor` instead. The lower-level
 {c:func}`Lfunc_special_value_choice` additionally returns the derivative and
-lets you choose between `L` and the completed `Lambda`.
+lets you choose between `L` and the completed `Lambda`. For an assembled power,
+`do_dash = true` is supported only for the completed function (`lam_p = true`);
+the non-completed derivative returns {c:macro}`ERR_SPEC_VALUE`.
 
 ### Plot data: `Lfunc_plot_data` and `Lfunc_clear_plot`
 

--- a/examples/artin.cpp
+++ b/examples/artin.cpp
@@ -671,7 +671,20 @@ istream & operator>>(istream & is, artin_rep &o)
           for(size_t i = 0; i < buf.size(); ++i)
             o.mus[i] = buf[i];
           // alg = anal so normalisation = 0.0
-          o.L = Lfunc_init(o.dimension, o.conductor, 0.0, o.mus, &o.ecode);
+          Lparams_t params;
+          params.degree = o.dimension;
+          params.conductor = o.conductor;
+          params.normalisation = 0.0;
+          params.mus = o.mus;
+          params.target_prec = DEFAULT_TARGET_PREC; // bead lfunctions-54s: target_prec should be tunable
+          params.wprec = 0;
+          params.gprec = 0;
+          params.self_dual = DK;
+          params.rank = DK;
+          params.cache_dir = (char *)".";
+          params.extract_powers = YES;
+
+          o.L = Lfunc_init_advanced(&params, &o.ecode);
           if(fatal_error(o.ecode)) {
             fprint_errors(stderr, o.ecode);
             throw_line("could not init L-function"s);

--- a/examples/artin.cpp
+++ b/examples/artin.cpp
@@ -671,7 +671,7 @@ istream & operator>>(istream & is, artin_rep &o)
           for(size_t i = 0; i < buf.size(); ++i)
             o.mus[i] = buf[i];
           // alg = anal so normalisation = 0.0
-          Lparams_t params;
+          Lparams_t params = {};
           params.degree = o.dimension;
           params.conductor = o.conductor;
           params.normalisation = 0.0;
@@ -682,7 +682,10 @@ istream & operator>>(istream & is, artin_rep &o)
           params.self_dual = DK;
           params.rank = DK;
           params.cache_dir = (char *)".";
-          params.extract_powers = YES;
+          // Local factors are supplied below through cyclotomic acb embeddings,
+          // so they can trigger the repeated-factor guard but cannot certify
+          // exact power extraction.
+          params.extract_powers = NO;
 
           o.L = Lfunc_init_advanced(&params, &o.ecode);
           if(fatal_error(o.ecode)) {
@@ -752,9 +755,15 @@ ostream& operator<<(ostream &s, artin_rep &AR) {
   // first zeros as balls, the rest as doubles if we have enough precision
   ostream_zeros(s, L, 0);
   s << ":";
-  Lplot_t *Lpp = Lfunc_plot_data(L, 0, 64.0/AR.dimension, 257);
-  s << Lpp;
-  Lfunc_clear_plot(Lpp);
+  if(Lfunc_factors(L, NULL, NULL) == 0) {
+    Lplot_t *Lpp = Lfunc_plot_data(L, 0, 64.0/AR.dimension, 257);
+    if(!Lpp)
+      throw_line("could not compute plot data"s);
+    s << Lpp;
+    Lfunc_clear_plot(Lpp);
+  } else {
+    s << "0:[]";
+  }
   return s;
 }
 

--- a/examples/artin.cpp
+++ b/examples/artin.cpp
@@ -676,7 +676,7 @@ istream & operator>>(istream & is, artin_rep &o)
           params.conductor = o.conductor;
           params.normalisation = 0.0;
           params.mus = o.mus;
-          params.target_prec = DEFAULT_TARGET_PREC; // bead lfunctions-54s: target_prec should be tunable
+          params.target_prec = DEFAULT_TARGET_PREC; // TODO: target_prec should be tunable
           params.wprec = 0;
           params.gprec = 0;
           params.self_dual = DK;

--- a/examples/ec_cube.cpp
+++ b/examples/ec_cube.cpp
@@ -11,6 +11,7 @@
  */
 #define __STDC_FORMAT_MACROS
 #include <chrono>
+#include <cstdio>
 #include <cstdint>
 #include <cwctype>
 #include <iomanip>
@@ -23,8 +24,8 @@
 #include <vector>
 #include <flint/fmpz.h>
 #include <flint/acb_poly.h>
+#include <flint/fmpz_poly.h>
 #include "glfunc.h"
-#include "glfunc_internals.h"
 #include <cassert>
 
 using std::cout;
@@ -36,6 +37,14 @@ using std::size_t;
 using std::vector;
 
 #define DIGITS 20
+
+static int report_fatal(Lerror_t ecode, Lfunc_t L)
+{
+  fprint_errors(stderr, ecode);
+  if(L)
+    Lfunc_clear(L);
+  return 1;
+}
 
 // LMFDB label 37.a1
 map<int64_t, vector<int64_t>> euler_factors  = {
@@ -75,19 +84,19 @@ map<int64_t, vector<int64_t>> euler_factors  = {
   {139, {1, -4, 139}},
 };
 
-// Supply L_p(T)^3
-void lpoly_callback(acb_poly_t poly, uint64_t p, int d __attribute__((unused)), int64_t prec, void *param __attribute__((unused)))
+// Supply exact L_p(T)^3
+void lpoly_callback(fmpz_poly_t poly, uint64_t p, int d __attribute__((unused)), void *param __attribute__((unused)))
 {
-  acb_poly_zero(poly);
+  fmpz_poly_zero(poly);
   auto it = euler_factors.find(p);
   if( it != euler_factors.end() ) {
-    acb_poly_t ep;
-    acb_poly_init(ep);
+    fmpz_poly_t ep;
+    fmpz_poly_init(ep);
     for(size_t i = 0; i < it->second.size(); ++i)
-      acb_poly_set_coeff_si(ep, i, it->second[i]);
+      fmpz_poly_set_coeff_si(ep, i, it->second[i]);
     
-    acb_poly_pow_ui(poly, ep, 3, prec);
-    acb_poly_clear(ep);
+    fmpz_poly_pow(poly, ep, 3);
+    fmpz_poly_clear(ep);
   }
 }
 
@@ -96,7 +105,7 @@ int main ()
   Lerror_t ecode = ERR_SUCCESS;
 
   double mus[6] = {0, 0, 0, 1, 1, 1};
-  Lparams_t Lp;
+  Lparams_t Lp = {};
   Lp.degree = 6;
   Lp.conductor = 37ull * 37ull * 37ull; // 50653
   Lp.normalisation = 0.5;
@@ -111,26 +120,56 @@ int main ()
 
   Lfunc_t L = Lfunc_init_advanced(&Lp, &ecode);
   if(fatal_error(ecode)) {
-    fprint_errors(stderr, ecode);
-    return 0;
+    return report_fatal(ecode, NULL);
   }
 
   // populate local factors
-  ecode |= Lfunc_use_all_lpolys(L, lpoly_callback, NULL);
+  ecode |= Lfunc_use_all_lpolys_fmpz(L, lpoly_callback, NULL);
   if(fatal_error(ecode)) {
-    fprint_errors(stderr, ecode);
-    return 0;
+    return report_fatal(ecode, L);
   }
 
   // do the computation
   ecode |= Lfunc_compute(L);
   if(fatal_error(ecode)) {
-    fprint_errors(stderr, ecode);
-    return 0;
+    return report_fatal(ecode, L);
   }
 
+  Lfunc_t *factors = NULL;
+  uint64_t *mults = NULL;
+  uint64_t nfactors = Lfunc_factors(L, &factors, &mults);
+  assert(nfactors == 1);
+  assert(mults[0] == 3);
+  assert(factors[0] != NULL);
+  Lfunc_t E = factors[0];
+
+  int64_t factor_rank = Lfunc_rank(E);
+  int64_t rank = Lfunc_rank(L);
+  assert(factor_rank == 1);
+  assert(rank == 3 * factor_rank);
+
+  acb_t sign_cube;
+  acb_init(sign_cube);
+  acb_pow_ui(sign_cube, Lfunc_sign(E), 3, Lfunc_wprec(L));
+  assert(acb_overlaps(sign_cube, Lfunc_sign(L)));
+  acb_clear(sign_cube);
+
+  arb_srcptr factor_zeros = Lfunc_zeros(E, 0);
+  arb_srcptr zeros = Lfunc_zeros(L, 0);
+  assert(arb_overlaps(zeros + 0, factor_zeros + 0));
+  assert(arb_overlaps(zeros + 1, factor_zeros + 0));
+  assert(arb_overlaps(zeros + 2, factor_zeros + 0));
+  assert(arb_overlaps(zeros + 3, factor_zeros + 1));
+
+  arb_t taylor_cube;
+  arb_init(taylor_cube);
+  arb_pow_ui(taylor_cube, Lfunc_Taylor(E), 3, Lfunc_wprec(L));
+  assert(arb_overlaps(Lfunc_Taylor(L), taylor_cube));
+  arb_clear(taylor_cube);
+
   printf("L-function successfully computed via extraction!\n");
-  printf("Rank = %" PRIu64 " (which is 3 * 1)\n", Lfunc_rank(L));
+  printf("Extracted factors = %" PRIu64 ", multiplicity = %" PRIu64 "\n", nfactors, mults[0]);
+  printf("Rank = %" PRId64 " (which is 3 * %" PRId64 ")\n", rank, factor_rank);
   printf("Sign = ");
   acb_printd(Lfunc_sign(L), DIGITS);
   printf(" (which is (-1)^3)\n");
@@ -140,21 +179,26 @@ int main ()
   printf("\n");
 
   printf("First isolated zero (repeats 3 times):\n");
-  arb_srcptr zeros = Lfunc_zeros(L, 0);
   for(int i = 0; i < 4; ++i) {
     printf("Zero %d = ", i);
     arb_printd(zeros + i, DIGITS);
     printf("\n");
   }
 
-  acb_t ctmp; acb_init(ctmp);
-  ecode |= Lfunc_special_value(ctmp, L, 1.5, 0.0);
-  if(fatal_error(ecode)) {
-    fprint_errors(stderr, ecode);
-    std::abort();
+  acb_t ctmp, etmp, ecube;
+  acb_init(ctmp); acb_init(etmp); acb_init(ecube);
+  Lerror_t sv = ERR_SUCCESS;
+  sv |= Lfunc_special_value(etmp, E, 1.5, 0.0);
+  sv |= Lfunc_special_value(ctmp, L, 1.5, 0.0);
+  ecode |= sv;
+  if(fatal_error(sv)) {
+    acb_clear(ctmp); acb_clear(etmp); acb_clear(ecube);
+    return report_fatal(sv, L);
   }
+  acb_pow_ui(ecube, etmp, 3, Lfunc_wprec(L));
+  assert(acb_overlaps(ctmp, ecube));
   printf("L(1.5) = "); acb_printd(ctmp, DIGITS); printf("\n");
-  acb_clear(ctmp);
+  acb_clear(ctmp); acb_clear(etmp); acb_clear(ecube);
 
   Lfunc_clear(L);
 

--- a/examples/ec_cube.cpp
+++ b/examples/ec_cube.cpp
@@ -6,7 +6,7 @@
  *
  * It supplies the exact local factors L_p(E, T)^3. The library's power guard
  * detects that the 2nd moment corresponds to a 3rd power and that the conductor
- * is a perfect cube, securely extracts the underlying E, computes it at 
+ * is a perfect cube, securely extracts the underlying E, computes it at
  * lower degree/conductor, and assembles the final result.
  */
 #define __STDC_FORMAT_MACROS
@@ -94,7 +94,7 @@ void lpoly_callback(fmpz_poly_t poly, uint64_t p, int d __attribute__((unused)),
     fmpz_poly_init(ep);
     for(size_t i = 0; i < it->second.size(); ++i)
       fmpz_poly_set_coeff_si(ep, i, it->second[i]);
-    
+
     fmpz_poly_pow(poly, ep, 3);
     fmpz_poly_clear(ep);
   }

--- a/examples/ec_cube.cpp
+++ b/examples/ec_cube.cpp
@@ -1,0 +1,165 @@
+// Copyright Edgar Costa 2024
+// See LICENSE file for license details.
+/*
+ * Computes the 3rd power of the Elliptic Curve L-function 37.a1: L(E, s)^3
+ * Demonstrates the power extraction feature (extract_powers = YES).
+ *
+ * It supplies the exact local factors L_p(E, T)^3. The library's power guard
+ * detects that the 2nd moment corresponds to a 3rd power and that the conductor
+ * is a perfect cube, securely extracts the underlying E, computes it at 
+ * lower degree/conductor, and assembles the final result.
+ */
+#define __STDC_FORMAT_MACROS
+#include <chrono>
+#include <cstdint>
+#include <cwctype>
+#include <iomanip>
+#include <iostream>
+#include <fstream>
+#include <map>
+#include <set>
+#include <sstream>
+#include <string>
+#include <vector>
+#include <flint/fmpz.h>
+#include <flint/acb_poly.h>
+#include "glfunc.h"
+#include "glfunc_internals.h"
+#include <cassert>
+
+using std::cout;
+using std::endl;
+using std::int64_t;
+using std::map;
+using std::ostream;
+using std::size_t;
+using std::vector;
+
+#define DIGITS 20
+
+// LMFDB label 37.a1
+map<int64_t, vector<int64_t>> euler_factors  = {
+  {2, {1, 2, 2}},
+  {3, {1, 3, 3}},
+  {5, {1, 2, 5}},
+  {7, {1, 1, 7}},
+  {11, {1, 5, 11}},
+  {13, {1, 2, 13}},
+  {17, {1, 0, 17}},
+  {19, {1, 0, 19}},
+  {23, {1, -2, 23}},
+  {29, {1, -6, 29}},
+  {31, {1, 4, 31}},
+  {37, {1, 1}},
+  {41, {1, 9, 41}},
+  {43, {1, -2, 43}},
+  {47, {1, 9, 47}},
+  {53, {1, -1, 53}},
+  {59, {1, -8, 59}},
+  {61, {1, 8, 61}},
+  {67, {1, -8, 67}},
+  {71, {1, -9, 71}},
+  {73, {1, 1, 73}},
+  {79, {1, -4, 79}},
+  {83, {1, 15, 83}},
+  {89, {1, -4, 89}},
+  {97, {1, -4, 97}},
+  {101, {1, -3, 101}},
+  {103, {1, -18, 103}},
+  {107, {1, 12, 107}},
+  {109, {1, 16, 109}},
+  {113, {1, 18, 113}},
+  {127, {1, -1, 127}},
+  {131, {1, 12, 131}},
+  {137, {1, 6, 137}},
+  {139, {1, -4, 139}},
+};
+
+// Supply L_p(T)^3
+void lpoly_callback(acb_poly_t poly, uint64_t p, int d __attribute__((unused)), int64_t prec, void *param __attribute__((unused)))
+{
+  acb_poly_zero(poly);
+  auto it = euler_factors.find(p);
+  if( it != euler_factors.end() ) {
+    acb_poly_t ep;
+    acb_poly_init(ep);
+    for(size_t i = 0; i < it->second.size(); ++i)
+      acb_poly_set_coeff_si(ep, i, it->second[i]);
+    
+    acb_poly_pow_ui(poly, ep, 3, prec);
+    acb_poly_clear(ep);
+  }
+}
+
+int main ()
+{
+  Lerror_t ecode = ERR_SUCCESS;
+
+  double mus[6] = {0, 0, 0, 1, 1, 1};
+  Lparams_t Lp;
+  Lp.degree = 6;
+  Lp.conductor = 37ull * 37ull * 37ull; // 50653
+  Lp.normalisation = 0.5;
+  Lp.mus = mus;
+  Lp.target_prec = 100;
+  Lp.wprec = 0;
+  Lp.gprec = 0;
+  Lp.self_dual = YES;
+  Lp.rank = DK;
+  Lp.cache_dir = (char *)".";
+  Lp.extract_powers = YES; // enable power extraction
+
+  Lfunc_t L = Lfunc_init_advanced(&Lp, &ecode);
+  if(fatal_error(ecode)) {
+    fprint_errors(stderr, ecode);
+    return 0;
+  }
+
+  // populate local factors
+  ecode |= Lfunc_use_all_lpolys(L, lpoly_callback, NULL);
+  if(fatal_error(ecode)) {
+    fprint_errors(stderr, ecode);
+    return 0;
+  }
+
+  // do the computation
+  ecode |= Lfunc_compute(L);
+  if(fatal_error(ecode)) {
+    fprint_errors(stderr, ecode);
+    return 0;
+  }
+
+  printf("L-function successfully computed via extraction!\n");
+  printf("Rank = %" PRIu64 " (which is 3 * 1)\n", Lfunc_rank(L));
+  printf("Sign = ");
+  acb_printd(Lfunc_sign(L), DIGITS);
+  printf(" (which is (-1)^3)\n");
+
+  printf("First non-zero Taylor coeff = ");
+  arb_printd(Lfunc_Taylor(L), DIGITS);
+  printf("\n");
+
+  printf("First isolated zero (repeats 3 times):\n");
+  arb_srcptr zeros = Lfunc_zeros(L, 0);
+  for(int i = 0; i < 4; ++i) {
+    printf("Zero %d = ", i);
+    arb_printd(zeros + i, DIGITS);
+    printf("\n");
+  }
+
+  acb_t ctmp; acb_init(ctmp);
+  ecode |= Lfunc_special_value(ctmp, L, 1.5, 0.0);
+  if(fatal_error(ecode)) {
+    fprint_errors(stderr, ecode);
+    std::abort();
+  }
+  printf("L(1.5) = "); acb_printd(ctmp, DIGITS); printf("\n");
+  acb_clear(ctmp);
+
+  Lfunc_clear(L);
+
+  // print any warnings collected along the way
+  fprint_errors(stderr, ecode);
+
+  return 0;
+}

--- a/examples/ec_sym.cpp
+++ b/examples/ec_sym.cpp
@@ -184,7 +184,7 @@ static Lerror_t check_sym_power(int k, uint64_t conductor, double normalisation,
   Lerror_t ecode = 0;
   char cache_dir[] = ".";
 
-  Lparams_t Lp;
+  Lparams_t Lp = {};
   Lp.degree = (uint64_t) (k + 1);
   Lp.conductor = conductor;
   Lp.normalisation = normalisation;

--- a/examples/rational.c
+++ b/examples/rational.c
@@ -270,7 +270,20 @@ int Lfunc_rational_set_s(Lfunc_rational_t L, char *s) {
     status = atoiii(L->euler_factors, d, L->size_euler_factors, L->degree + 1, tokens[5]);
   }
   if(status != -1) {
-    L->L = Lfunc_init(L->degree, L->conductor, L->weight*0.5, L->mus, &L->ecode);
+    Lparams_t params = {
+      .degree = (uint64_t) L->degree,
+      .conductor = (uint64_t) L->conductor,
+      .normalisation = L->weight * 0.5,
+      .mus = L->mus,
+      .target_prec = DEFAULT_TARGET_PREC, // bead lfunctions-54s: target_prec should be tunable
+      .wprec = 0,
+      .gprec = 0,
+      .self_dual = DK,
+      .rank = DK,
+      .cache_dir = (char *)".",
+      .extract_powers = YES
+    };
+    L->L = Lfunc_init_advanced(&params, &L->ecode);
     if(fatal_error(L->ecode)) {
       fprint_errors(stderr, L->ecode);
       status = -1;

--- a/examples/rational.c
+++ b/examples/rational.c
@@ -312,6 +312,7 @@ int main(int argc, char** argv) {
   FILE* output = fopen(argv[2], "w");
   if (output == NULL) {
     printf("Could not open file %s.\n", argv[2]);
+    fclose(input);
     return 1;
   }
 
@@ -332,11 +333,19 @@ int main(int argc, char** argv) {
     L->ecode |= populate_local_factors(L);
     if(fatal_error(L->ecode)) {
       fprint_errors(stderr, L->ecode);
+      Lfunc_rational_clear(L);
+      free(line);
+      fclose(output);
+      fclose(input);
       return -1;
     }
     L->ecode|=Lfunc_compute(L->L);
     if(fatal_error(L->ecode)) {
       fprint_errors(stderr, L->ecode);
+      Lfunc_rational_clear(L);
+      free(line);
+      fclose(output);
+      fclose(input);
       return -1;
     }
     printf("Rank = %" PRIu64 "\n", Lfunc_rank(L->L));
@@ -355,6 +364,8 @@ int main(int argc, char** argv) {
     // TODO write output to output
     Lfunc_rational_clear(L);
   }
+  free(line);
   fclose(input);
   fclose(output);
+  return 0;
 }

--- a/examples/rational.c
+++ b/examples/rational.c
@@ -19,6 +19,7 @@
  */
 
 #include <flint/acb_poly.h>
+#include <flint/fmpz_poly.h>
 #include <assert.h>
 #include <ctype.h>
 #include <inttypes.h>
@@ -178,7 +179,7 @@ static inline int split(char * str, char delim, char ***array, size_t *length ) 
 
 
 
-void populate_local_factors(Lfunc_rational_t L) {
+Lerror_t populate_local_factors(Lfunc_rational_t L) {
   size_t bound = Lfunc_nmax(L->L);
   // printf("bound = %ld\n", bound);
   size_t size;
@@ -188,21 +189,22 @@ void populate_local_factors(Lfunc_rational_t L) {
   assert(L->size_euler_factors >= size);
 
   size_t d = L->degree;
-  acb_poly_t local_factor;
-  acb_poly_init(local_factor);
-  acb_poly_fit_length(local_factor, d + 1);
+  fmpz_poly_t local_factor;
+  fmpz_poly_init(local_factor);
 
 
   for (size_t i = 0; i < size; ++i) {
-    acb_poly_zero(local_factor);
-    _acb_poly_set_length(local_factor, d + 1);
-    for(size_t j = 0; j <= d; ++j) {
-      acb_set_si(local_factor->coeffs + j, L->euler_factors[i*(d+1) + j]);
-    }
-    Lfunc_use_lpoly(L->L, primes[i], local_factor);
+    fmpz_poly_zero(local_factor);
+    for(size_t j = 0; j <= d; ++j)
+      fmpz_poly_set_coeff_si(local_factor, j, L->euler_factors[i*(d+1) + j]);
+    L->ecode |= Lfunc_use_lpoly_fmpz(L->L, primes[i], local_factor);
+    if(fatal_error(L->ecode))
+      break;
   }
 
-  acb_poly_clear(local_factor);
+  fmpz_poly_clear(local_factor);
+  primesieve_free(primes);
+  return L->ecode;
 }
 
 
@@ -327,7 +329,7 @@ int main(int argc, char** argv) {
     printf("]\n");
 
 
-    populate_local_factors(L);
+    L->ecode |= populate_local_factors(L);
     if(fatal_error(L->ecode)) {
       fprint_errors(stderr, L->ecode);
       return -1;
@@ -338,6 +340,14 @@ int main(int argc, char** argv) {
       return -1;
     }
     printf("Rank = %" PRIu64 "\n", Lfunc_rank(L->L));
+    {
+      Lfunc_t *factors = NULL;
+      uint64_t *mults = NULL;
+      uint64_t nfactors = Lfunc_factors(L->L, &factors, &mults);
+      if(nfactors)
+        printf("Extracted factors = %" PRIu64 ", multiplicity = %" PRIu64 "\n",
+               nfactors, mults[0]);
+    }
     printf("Epsilon = ");acb_printd(Lfunc_sign(L->L),20);printf("\n");
     printf("Leading Taylor coeff = ");arb_printd(Lfunc_Taylor(L->L), 20);printf("\n");
     printf("First zero = ");arb_printd(Lfunc_zeros(L->L, 0), 20);printf("\n");

--- a/examples/rational.c
+++ b/examples/rational.c
@@ -277,7 +277,7 @@ int Lfunc_rational_set_s(Lfunc_rational_t L, char *s) {
       .conductor = (uint64_t) L->conductor,
       .normalisation = L->weight * 0.5,
       .mus = L->mus,
-      .target_prec = DEFAULT_TARGET_PREC, // bead lfunctions-54s: target_prec should be tunable
+      .target_prec = DEFAULT_TARGET_PREC, // TODO: target_prec should be tunable
       .wprec = 0,
       .gprec = 0,
       .self_dual = DK,

--- a/include/glfunc.h
+++ b/include/glfunc.h
@@ -61,7 +61,10 @@ extern "C"{
   typedef void *Lfunc_t;
 
   // Zero-initialize before field-by-field assignment; zero is the default for
-  // optional fields such as gprec/wprec and extract_powers.
+  // optional fields such as target_prec/gprec/wprec and extract_powers.
+  // Lparams_t is intentionally not a stable ABI/source-compatibility boundary:
+  // callers should rebuild against the matching header, and new fields may be
+  // added without preserving older struct layouts.
   typedef struct{
     uint64_t degree;
     uint64_t conductor;
@@ -181,9 +184,10 @@ extern "C"{
   int64_t Lfunc_rank(Lfunc_t L);
 
   // factor accessor: primitive factors of L with multiplicities.
-  // factors[i] is a borrowed Lfunc_t owned by L (do NOT clear it); mults[i] its
-  // multiplicity. Returns the count: 1 with (M, k) for a pure power L = M^k,
-  // 0 if L is primitive / was not produced by extraction.
+  // On return, *factors is a borrowed Lfunc_t array owned by L (do NOT clear
+  // entries), and *mults is the matching multiplicity array. Returns the count:
+  // 1 with (M, k) for a pure power L = M^k, 0 if L is primitive / was not
+  // produced by extraction.
   uint64_t Lfunc_factors(Lfunc_t L, Lfunc_t **factors, uint64_t **mults);
 
   // return the first non-zero Taylor coefficient
@@ -209,6 +213,7 @@ extern "C"{
   // from the critical line. Should return something sensible
   // for L(k) and L(0)
   // for re+i*im = (w + 1)/2, use Lfunc_Taylor
+  // For assembled powers, do_dash with lam_p=false returns ERR_SPEC_VALUE.
   Lerror_t Lfunc_special_value_choice(acb_t res, acb_t res_dash, Lfunc_t LL, double re, double im, bool lam_p, bool do_dash);
   Lerror_t Lfunc_special_value(acb_t res, Lfunc_t LL, double re, double im);
 

--- a/include/glfunc.h
+++ b/include/glfunc.h
@@ -37,7 +37,7 @@
 #define ERR_BAD_DEGREE ((uint64_t) 1024) //fatal error when the degree is too low or too high
 #define ERR_SPEC_NZ ((uint64_t) 2048) // special value routine requires Im s >= 0.
 #define ERR_G_EXTENT ((uint64_t) 4096) // fatal: G grid does not extend low enough (conductor too large for the fixed grid floor, or a cached grid was reused)
-#define ERR_POWER ((uint64_t) 1<<13) // fatal: L is a perfect power / has a repeated primitive factor (doubled zeros); set Lparams.allow_nonprimitive to override
+#define ERR_POWER ((uint64_t) 1<<13) // fatal: L is a perfect power / has a repeated primitive factor (doubled zeros); set Lparams.extract_powers to override
 
 // warnings
 #define ERR_SOME_DATA ((uint64_t) 1<<32) // We had some sensible data, but not to end of Turing Zone
@@ -70,7 +70,7 @@ extern "C"{
     int self_dual; // -1 = DK, 0 = No, 1 = Yes
     int rank; // -1 = DK
     char *cache_dir;
-    int allow_nonprimitive; // if YES(1), bypass the power/repeated-factor guard (ERR_POWER); default NO(0)
+    int extract_powers; // if YES(1), extract & assemble a perfect power L=M^k (else reject with ERR_POWER); default NO(0)
   } Lparams_t;
 
   typedef struct{

--- a/include/glfunc.h
+++ b/include/glfunc.h
@@ -37,6 +37,7 @@
 #define ERR_BAD_DEGREE ((uint64_t) 1024) //fatal error when the degree is too low or too high
 #define ERR_SPEC_NZ ((uint64_t) 2048) // special value routine requires Im s >= 0.
 #define ERR_G_EXTENT ((uint64_t) 4096) // fatal: G grid does not extend low enough (conductor too large for the fixed grid floor, or a cached grid was reused)
+#define ERR_POWER ((uint64_t) 1<<13) // fatal: L is a perfect power / has a repeated primitive factor (doubled zeros); set Lparams.allow_nonprimitive to override
 
 // warnings
 #define ERR_SOME_DATA ((uint64_t) 1<<32) // We had some sensible data, but not to end of Turing Zone

--- a/include/glfunc.h
+++ b/include/glfunc.h
@@ -70,6 +70,7 @@ extern "C"{
     int self_dual; // -1 = DK, 0 = No, 1 = Yes
     int rank; // -1 = DK
     char *cache_dir;
+    int allow_nonprimitive; // if YES(1), bypass the power/repeated-factor guard (ERR_POWER); default NO(0)
   } Lparams_t;
 
   typedef struct{

--- a/include/glfunc.h
+++ b/include/glfunc.h
@@ -178,6 +178,9 @@ extern "C"{
   // covering t=[0,max_t]
   // for L or conjugate L
   // returned as doubles in an Lplot_t structure
+  // NB: not meaningful for an L assembled from a power (extract_powers): such an
+  // L skips the sample-generating pipeline, so the plot buffers are empty. Obtain
+  // the primitive factor via Lfunc_factors and plot that instead.
   Lplot_t *Lfunc_plot_data(Lfunc_t L, uint64_t side, double max_t, uint64_t n_points);
 
   // reclaim memory from an Lplot_t structure

--- a/include/glfunc.h
+++ b/include/glfunc.h
@@ -162,6 +162,12 @@ extern "C"{
   // rank>1 isn't
   int64_t Lfunc_rank(Lfunc_t L);
 
+  // factor accessor: primitive factors of L with multiplicities.
+  // factors[i] is a borrowed Lfunc_t owned by L (do NOT clear it); mults[i] its
+  // multiplicity. Returns the count: 1 with (M, k) for a pure power L = M^k,
+  // 0 if L is primitive / was not produced by extraction.
+  uint64_t Lfunc_factors(Lfunc_t L, Lfunc_t **factors, uint64_t **mults);
+
   // return the first non-zero Taylor coefficient
   // L^(rank)((w + 1)/2)/rank!
   // where w/2 is the normalization (if algebraic, w = motivic weight)

--- a/include/glfunc.h
+++ b/include/glfunc.h
@@ -3,6 +3,7 @@
 
 #include <inttypes.h>
 #include <flint/acb_poly.h>
+#include <flint/fmpz_poly.h>
 #include <stdbool.h>
 
 #define DK (-1) // tri-state "don't know" (for self_dual / rank)
@@ -37,7 +38,7 @@
 #define ERR_BAD_DEGREE ((uint64_t) 1024) //fatal error when the degree is too low or too high
 #define ERR_SPEC_NZ ((uint64_t) 2048) // special value routine requires Im s >= 0.
 #define ERR_G_EXTENT ((uint64_t) 4096) // fatal: G grid does not extend low enough (conductor too large for the fixed grid floor, or a cached grid was reused)
-#define ERR_POWER ((uint64_t) 1<<13) // fatal: L is a perfect power / has a repeated primitive factor (doubled zeros); set Lparams.extract_powers to override
+#define ERR_POWER ((uint64_t) 1<<13) // fatal: L is a perfect power / has a repeated primitive factor (doubled zeros); set Lparams.extract_powers and supply exact fmpz factors to extract
 
 // warnings
 #define ERR_SOME_DATA ((uint64_t) 1<<32) // We had some sensible data, but not to end of Turing Zone
@@ -59,6 +60,8 @@ extern "C"{
   // keep details under wraps
   typedef void *Lfunc_t;
 
+  // Zero-initialize before field-by-field assignment; zero is the default for
+  // optional fields such as gprec/wprec and extract_powers.
   typedef struct{
     uint64_t degree;
     uint64_t conductor;
@@ -70,7 +73,7 @@ extern "C"{
     int self_dual; // -1 = DK, 0 = No, 1 = Yes
     int rank; // -1 = DK
     char *cache_dir;
-    int extract_powers; // if YES(1), extract & assemble a perfect power L=M^k (else reject with ERR_POWER); default NO(0)
+    int extract_powers; // if YES(1), extract & assemble a perfect power L=M^k only from exact fmpz Euler factors (else reject with ERR_POWER); default NO(0)
   } Lparams_t;
 
   typedef struct{
@@ -134,10 +137,25 @@ extern "C"{
   // see Lfunc_nmax). The first call here triggers Lfunc_nmax, computing and
   // freezing M if not already done. Setting poly to zero stops the iteration,
   // lowers M to p-1, and flags ERR_INSUFF_EULER.
+  //
+  // acb-supplied factors participate in the repeated-factor/power guard. They
+  // are not exact provenance for extract_powers=YES; a power detected from only
+  // acb factors is rejected with ERR_POWER rather than extracted.
   Lerror_t Lfunc_use_all_lpolys(Lfunc_t L, void (*lpoly_callback) (acb_poly_t lpoly, uint64_t p, int d, int64_t prec, void *parm), void *param);
 
-  // you provide one Euler polynomial at a time
+  // Exact integer-polynomial supply route. This mirrors Lfunc_use_all_lpolys,
+  // but the callback fills an fmpz_poly_t. Leaving it zero is the same
+  // insufficient-supply sentinel. When extract_powers=YES, only factors supplied
+  // through this exact path can certify extraction.
+  Lerror_t Lfunc_use_all_lpolys_fmpz(Lfunc_t L, void (*lpoly_callback)(fmpz_poly_t lpoly, uint64_t p, int d, void *parm), void *param);
+
+  // you provide one Euler polynomial at a time. acb-supplied factors are used for
+  // computation and the repeated-factor guard, but cannot certify extraction.
   void Lfunc_use_lpoly(Lfunc_t L, uint64_t p, const acb_poly_t poly);
+
+  // Exact integer-polynomial single-prime supply. The factor is also converted
+  // to acb internally for the existing computation path.
+  Lerror_t Lfunc_use_lpoly_fmpz(Lfunc_t L, uint64_t p, const fmpz_poly_t poly);
 
   // Once all polys have been provided, do the computation
   Lerror_t Lfunc_compute(Lfunc_t L);
@@ -178,9 +196,9 @@ extern "C"{
   // covering t=[0,max_t]
   // for L or conjugate L
   // returned as doubles in an Lplot_t structure
-  // NB: not meaningful for an L assembled from a power (extract_powers): such an
-  // L skips the sample-generating pipeline, so the plot buffers are empty. Obtain
-  // the primitive factor via Lfunc_factors and plot that instead.
+  // NB: returns NULL for an L assembled from a power (extract_powers): such an
+  // L skips the sample-generating pipeline. Obtain the primitive factor via
+  // Lfunc_factors and plot that instead.
   Lplot_t *Lfunc_plot_data(Lfunc_t L, uint64_t side, double max_t, uint64_t n_points);
 
   // reclaim memory from an Lplot_t structure

--- a/include/glfunc_internals.h
+++ b/include/glfunc_internals.h
@@ -122,6 +122,14 @@ extern "C"{
     arb_t moment_sum;         // running sum of |a_p|^2 over full-degree (good) primes
     uint64_t moment_count;    // number of full-degree primes folded into moment_sum
 
+    // power extraction (w70.2)
+    uint64_t *retained_p;          // supplied good/bad primes, in supply order
+    acb_poly_struct *retained_f;   // the raw supplied Euler factors L_p
+    uint64_t n_retained, retained_cap; // count and capacity of the retained store
+    Lfunc_t *factors;              // owned primitive factors (length n_factors)
+    uint64_t *factor_mults;        // their multiplicities
+    uint64_t n_factors;            // 0 unless this L was assembled from a power
+
     int64_t offset; // FFT bin index of a_1 = calc_m(1); used only for a bounds check
 
     uint64_t u_N; // upsampling kernel half-width = ceil(A^2 h^2/2); kernel = 2*u_N+1 pts
@@ -177,6 +185,7 @@ extern "C"{
   
   // from coeff.c
   Lerror_t power_guard(Lfunc *L);
+  Lerror_t power_extract_prepare(Lfunc *L, uint64_t *k_out); // fix & certify k; ERR_POWER if not a clean power
 
   // from compute.c
   void lfunc_compute(Lfunc *L);

--- a/include/glfunc_internals.h
+++ b/include/glfunc_internals.h
@@ -3,6 +3,7 @@
 
 #include "inttypes.h"
 #include <flint/acb.h>
+#include <flint/fmpz_poly.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <math.h>
@@ -186,6 +187,8 @@ extern "C"{
   // from coeff.c
   Lerror_t power_guard(Lfunc *L);
   Lerror_t power_extract_prepare(Lfunc *L, uint64_t *k_out); // fix & certify k; ERR_POWER if not a clean power
+  // True iff the EXACT integer Euler factor Lp is a perfect k-th power; sets Mp to the root.
+  bool poly_exact_kth_root(fmpz_poly_t Mp, const acb_poly_t Lp, uint64_t k, int64_t prec);
 
   // from compute.c
   void lfunc_compute(Lfunc *L);

--- a/include/glfunc_internals.h
+++ b/include/glfunc_internals.h
@@ -117,7 +117,7 @@ extern "C"{
     bool nmax_called; // true if user/system has called Lfunc_nmax
 
     // power/repeated-factor guard (see power_guard in coeff.c)
-    int allow_nonprimitive;   // copied from Lparams; YES(1) bypasses the guard
+    int extract_powers;   // copied from Lparams; YES(1) extract & assemble a power L=M^k (else reject)
     bool seen_sqfree_fulldeg; // a full-degree local factor was proven squarefree => no repeated factor
     arb_t moment_sum;         // running sum of |a_p|^2 over full-degree (good) primes
     uint64_t moment_count;    // number of full-degree primes folded into moment_sum

--- a/include/glfunc_internals.h
+++ b/include/glfunc_internals.h
@@ -130,7 +130,7 @@ extern "C"{
     bool *retained_is_exact;       // exact fmpz provenance for retained_f[i]
     uint64_t n_retained, retained_cap; // count and capacity of the retained store
     Lerror_t retained_error;       // fatal error encountered while retaining factors
-    acb_poly_struct *cert_roots;   // exact algebraic k-th roots of retained_f, same order/count
+    fmpz_poly_struct *cert_roots;  // exact integer k-th roots of retained_fmpz, same order/count
     uint64_t n_cert_roots;         // populated by power_extract_prepare, consumed in assembly
     Lfunc_t *factors;              // owned primitive factors (length n_factors)
     uint64_t *factor_mults;        // their multiplicities

--- a/include/glfunc_internals.h
+++ b/include/glfunc_internals.h
@@ -127,7 +127,7 @@ extern "C"{
     uint64_t *retained_p;          // supplied good/bad primes, in supply order
     acb_poly_struct *retained_f;   // the raw supplied Euler factors L_p
     uint64_t n_retained, retained_cap; // count and capacity of the retained store
-    fmpz_poly_struct *cert_roots;  // exact integer k-th roots of retained_f, same order/count
+    acb_poly_struct *cert_roots;   // exact algebraic k-th roots of retained_f, same order/count
     uint64_t n_cert_roots;         // populated by power_extract_prepare, consumed in assembly
     Lfunc_t *factors;              // owned primitive factors (length n_factors)
     uint64_t *factor_mults;        // their multiplicities
@@ -190,7 +190,7 @@ extern "C"{
   Lerror_t power_guard(Lfunc *L);
   Lerror_t power_extract_prepare(Lfunc *L, uint64_t *k_out); // fix & certify k; ERR_POWER if not a clean power
   // True iff the EXACT integer Euler factor Lp is a perfect k-th power; sets Mp to the root.
-  bool poly_exact_kth_root(fmpz_poly_t Mp, const acb_poly_t Lp, uint64_t k, int64_t prec);
+  bool poly_exact_kth_root(acb_poly_t Mp, const acb_poly_t Lp, uint64_t k, int64_t prec);
   // True iff cond is an exact k-th power; sets *base to the integer k-th root.
   bool conductor_kth_root(uint64_t cond, uint64_t k, uint64_t *base);
 

--- a/include/glfunc_internals.h
+++ b/include/glfunc_internals.h
@@ -24,6 +24,8 @@
 #endif
 
 #define MAX_L (10) // maximum differential allowed in upsampling
+#define POWER_SQFREE_PROBES (256)     // max full-degree primes tested for squarefree-ness by the power guard
+#define POWER_MOMENT_THRESHOLD (3.5)  // 2nd moment >= this (and no squarefree factor seen) => reject as a repeated-factor L
 
 
 #define COMPUTE_ZEROS // compile-time switch: enable the zero-finding phase
@@ -116,6 +118,9 @@ extern "C"{
 
     // power/repeated-factor guard (see power_guard in coeff.c)
     int allow_nonprimitive;   // copied from Lparams; YES(1) bypasses the guard
+    bool seen_sqfree_fulldeg; // a full-degree local factor was proven squarefree => no repeated factor
+    arb_t moment_sum;         // running sum of |a_p|^2 over full-degree (good) primes
+    uint64_t moment_count;    // number of full-degree primes folded into moment_sum
 
     int64_t offset; // FFT bin index of a_1 = calc_m(1); used only for a bounds check
 
@@ -170,6 +175,9 @@ extern "C"{
   Lerror_t turing_check_RH(Lfunc *L, int64_t);
 #endif
   
+  // from coeff.c
+  Lerror_t power_guard(Lfunc *L);
+
   // from compute.c
   void lfunc_compute(Lfunc *L);
 

--- a/include/glfunc_internals.h
+++ b/include/glfunc_internals.h
@@ -126,7 +126,10 @@ extern "C"{
     // power extraction (w70.2)
     uint64_t *retained_p;          // supplied good/bad primes, in supply order
     acb_poly_struct *retained_f;   // the raw supplied Euler factors L_p
+    fmpz_poly_struct *retained_fmpz; // exact raw integer Euler factors, initialized only where retained_is_exact[i]
+    bool *retained_is_exact;       // exact fmpz provenance for retained_f[i]
     uint64_t n_retained, retained_cap; // count and capacity of the retained store
+    Lerror_t retained_error;       // fatal error encountered while retaining factors
     acb_poly_struct *cert_roots;   // exact algebraic k-th roots of retained_f, same order/count
     uint64_t n_cert_roots;         // populated by power_extract_prepare, consumed in assembly
     Lfunc_t *factors;              // owned primitive factors (length n_factors)
@@ -189,8 +192,6 @@ extern "C"{
   // from coeff.c
   Lerror_t power_guard(Lfunc *L);
   Lerror_t power_extract_prepare(Lfunc *L, uint64_t *k_out); // fix & certify k; ERR_POWER if not a clean power
-  // True iff the EXACT integer Euler factor Lp is a perfect k-th power; sets Mp to the root.
-  bool poly_exact_kth_root(acb_poly_t Mp, const acb_poly_t Lp, uint64_t k, int64_t prec);
   // True iff cond is an exact k-th power; sets *base to the integer k-th root.
   bool conductor_kth_root(uint64_t cond, uint64_t k, uint64_t *base);
 

--- a/include/glfunc_internals.h
+++ b/include/glfunc_internals.h
@@ -123,7 +123,7 @@ extern "C"{
     arb_t moment_sum;         // running sum of |a_p|^2 over full-degree (good) primes
     uint64_t moment_count;    // number of full-degree primes folded into moment_sum
 
-    // power extraction (w70.2)
+    // power extraction
     uint64_t *retained_p;          // supplied good/bad primes, in supply order
     acb_poly_struct *retained_f;   // the raw supplied Euler factors L_p
     fmpz_poly_struct *retained_fmpz; // exact raw integer Euler factors, initialized only where retained_is_exact[i]

--- a/include/glfunc_internals.h
+++ b/include/glfunc_internals.h
@@ -114,6 +114,9 @@ extern "C"{
 
     bool nmax_called; // true if user/system has called Lfunc_nmax
 
+    // power/repeated-factor guard (see power_guard in coeff.c)
+    int allow_nonprimitive;   // copied from Lparams; YES(1) bypasses the guard
+
     int64_t offset; // FFT bin index of a_1 = calc_m(1); used only for a bounds check
 
     uint64_t u_N; // upsampling kernel half-width = ceil(A^2 h^2/2); kernel = 2*u_N+1 pts

--- a/include/glfunc_internals.h
+++ b/include/glfunc_internals.h
@@ -127,6 +127,8 @@ extern "C"{
     uint64_t *retained_p;          // supplied good/bad primes, in supply order
     acb_poly_struct *retained_f;   // the raw supplied Euler factors L_p
     uint64_t n_retained, retained_cap; // count and capacity of the retained store
+    fmpz_poly_struct *cert_roots;  // exact integer k-th roots of retained_f, same order/count
+    uint64_t n_cert_roots;         // populated by power_extract_prepare, consumed in assembly
     Lfunc_t *factors;              // owned primitive factors (length n_factors)
     uint64_t *factor_mults;        // their multiplicities
     uint64_t n_factors;            // 0 unless this L was assembled from a power
@@ -189,6 +191,8 @@ extern "C"{
   Lerror_t power_extract_prepare(Lfunc *L, uint64_t *k_out); // fix & certify k; ERR_POWER if not a clean power
   // True iff the EXACT integer Euler factor Lp is a perfect k-th power; sets Mp to the root.
   bool poly_exact_kth_root(fmpz_poly_t Mp, const acb_poly_t Lp, uint64_t k, int64_t prec);
+  // True iff cond is an exact k-th power; sets *base to the integer k-th root.
+  bool conductor_kth_root(uint64_t cond, uint64_t k, uint64_t *base);
 
   // from compute.c
   void lfunc_compute(Lfunc *L);

--- a/src/clear.c
+++ b/src/clear.c
@@ -144,6 +144,21 @@ extern "C"{
     arf_cclear(L->arf_A);
     arf_cclear(L->arf_one_over_A);
 
+    if(L->retained_f)
+      {
+        for(uint64_t i=0;i<L->n_retained;i++)
+          acb_poly_clear(&L->retained_f[i]);
+        free(L->retained_f);
+      }
+    free(L->retained_p);
+    if(L->factors)
+      {
+        for(uint64_t i=0;i<L->n_factors;i++)
+          Lfunc_clear(L->factors[i]);   // recursively clear M
+        free(L->factors);
+      }
+    free(L->factor_mults);
+
     free(L);
   }
 #ifdef __cplusplus

--- a/src/clear.c
+++ b/src/clear.c
@@ -74,6 +74,7 @@ extern "C"{
     
     arb_cclear(L->one_over_root_N);
     arb_cclear(L->sum_ans);
+    arb_cclear(L->moment_sum);
     arb_cclear(L->u_H);
     arb_cclear(L->u_pi_by_H2);
     arb_cclear(L->u_A);

--- a/src/clear.c
+++ b/src/clear.c
@@ -162,7 +162,7 @@ extern "C"{
     if(L->cert_roots)
       {
         for(uint64_t i=0;i<L->n_cert_roots;i++)
-          acb_poly_clear(&L->cert_roots[i]);
+          fmpz_poly_clear(&L->cert_roots[i]);
         free(L->cert_roots);
       }
     if(L->factors)

--- a/src/clear.c
+++ b/src/clear.c
@@ -151,6 +151,12 @@ extern "C"{
         free(L->retained_f);
       }
     free(L->retained_p);
+    if(L->cert_roots)
+      {
+        for(uint64_t i=0;i<L->n_cert_roots;i++)
+          fmpz_poly_clear(&L->cert_roots[i]);
+        free(L->cert_roots);
+      }
     if(L->factors)
       {
         for(uint64_t i=0;i<L->n_factors;i++)

--- a/src/clear.c
+++ b/src/clear.c
@@ -150,6 +150,14 @@ extern "C"{
           acb_poly_clear(&L->retained_f[i]);
         free(L->retained_f);
       }
+    if(L->retained_fmpz)
+      {
+        for(uint64_t i=0;i<L->n_retained;i++)
+          if(L->retained_is_exact && L->retained_is_exact[i])
+            fmpz_poly_clear(&L->retained_fmpz[i]);
+        free(L->retained_fmpz);
+      }
+    free(L->retained_is_exact);
     free(L->retained_p);
     if(L->cert_roots)
       {

--- a/src/clear.c
+++ b/src/clear.c
@@ -154,7 +154,7 @@ extern "C"{
     if(L->cert_roots)
       {
         for(uint64_t i=0;i<L->n_cert_roots;i++)
-          fmpz_poly_clear(&L->cert_roots[i]);
+          acb_poly_clear(&L->cert_roots[i]);
         free(L->cert_roots);
       }
     if(L->factors)

--- a/src/coeff.c
+++ b/src/coeff.c
@@ -349,7 +349,7 @@ static bool fmpz_poly_exact_kth_root(fmpz_poly_t Mz, const fmpz_poly_t Lz, uint6
     fmpz_poly_get_coeff_fmpz(target, Lz, n);
     fmpz_poly_get_coeff_fmpz(current, cur, n);
     fmpz_sub(diff, target, current);
-    if (!fmpz_divisible_ui(diff, (ulong)k)) {
+    if (fmpz_fdiv_ui(diff, (ulong)k) != 0) {
       ok = false;
       break;
     }

--- a/src/coeff.c
+++ b/src/coeff.c
@@ -129,7 +129,7 @@ static bool poly_is_squarefree_certified(const acb_poly_t f, int64_t prec)
 void use_inv_lpoly(Lfunc *L, uint64_t p, acb_poly_t c, acb_poly_t f, uint64_t prec)
   #else
 void use_inv_lpoly(Lfunc *L, uint64_t p, acb_poly_t c, uint64_t prec)
-#endif  
+#endif
   {
   acb_t tmp;
   acb_init(tmp);
@@ -297,7 +297,9 @@ static void use_lpoly_with_exact(Lfunc *L, uint64_t p, const acb_poly_t f,
 // squarefree certificate) is what keeps the guard from false-rejecting such primitives.
 static bool conductor_is_perfect_power(uint64_t N)
 {
-  if(N < 4)            // 0,1,2,3 are not (nontrivial) perfect powers
+  if(N == 1)           // cond(M^k) = cond(M)^k also permits 1 = 1^k
+    return true;
+  if(N < 4)            // 0,2,3 are not nontrivial perfect powers
     return false;
   ulong root;
   return n_is_perfect_power(&root, (ulong) N) != 0;
@@ -378,7 +380,7 @@ static void cert_roots_reset(Lfunc *L)
 {
   if (L->cert_roots) {
     for (uint64_t i = 0; i < L->n_cert_roots; i++)
-      acb_poly_clear(&L->cert_roots[i]);
+      fmpz_poly_clear(&L->cert_roots[i]);
     free(L->cert_roots);
     L->cert_roots = NULL;
   }
@@ -401,10 +403,10 @@ static bool power_certify_k(Lfunc *L, uint64_t k)
       if (L->mus[i] != L->mus[i + j])
         return false;
   // rigorous per-prime gate: a single uncertified factor would make L = M^k false, so the
-  // k-th root fed to M would be unsound; reject. Keep each certified root for reuse.
+  // k-th root fed to M would be unsound; reject. Keep each certified integer root for reuse.
   cert_roots_reset(L);
   if (L->n_retained) {
-    L->cert_roots = (acb_poly_struct *) malloc(sizeof(acb_poly_struct)*L->n_retained);
+    L->cert_roots = (fmpz_poly_struct *) malloc(sizeof(fmpz_poly_struct)*L->n_retained);
     if (!L->cert_roots) {
       L->retained_error |= ERR_OOM;
       return false;
@@ -424,9 +426,9 @@ static bool power_certify_k(Lfunc *L, uint64_t k)
       cert_roots_reset(L);
       return false;
     }
-    acb_poly_init(&L->cert_roots[i]);
+    fmpz_poly_init(&L->cert_roots[i]);
     L->n_cert_roots = i + 1;
-    acb_poly_set_fmpz_poly(&L->cert_roots[i], root_z, L->wprec);
+    fmpz_poly_set(&L->cert_roots[i], root_z);
     fmpz_poly_clear(root_z);
   }
   if (!seen_full) { cert_roots_reset(L); return false; }
@@ -441,11 +443,11 @@ Lerror_t power_extract_prepare(Lfunc *L, uint64_t *k_out)
   if (fatal_error(L->retained_error))
     return L->retained_error;
   if (L->moment_count == 0) return ERR_POWER;
-  
+
   // For L = M^k the true exponent k satisfies k | degree (M has degree/k Gamma factors)
-  // and makes the conductor an exact k-th power (cond(M^k) = cond(M)^k). 
+  // and makes the conductor an exact k-th power (cond(M^k) = cond(M)^k).
   // We consider every k in [2, degree] with k | degree and cond an exact k-th power,
-  // preferring the LARGEST that passes the rigorous certificate. 
+  // preferring the LARGEST that passes the rigorous certificate.
   // (We test conductor-exactness per candidate via conductor_kth_root rather
   // than n_is_perfect_power, whose returned exponent is not necessarily maximal -- it gives
   // 2 for 37^4 = 1369^2.) The per-prime exact gate and the mus-block gate still run

--- a/src/coeff.c
+++ b/src/coeff.c
@@ -6,6 +6,7 @@
 #include <flint/acb_poly.h>
 #include <flint/fmpz_poly.h>
 #include <flint/ulong_extras.h>
+#include <string.h>
 
 #ifdef __cplusplus
 extern "C"{
@@ -129,7 +130,7 @@ void use_inv_lpoly(Lfunc *L, uint64_t p, acb_poly_t c, acb_poly_t f, uint64_t pr
   #else
 void use_inv_lpoly(Lfunc *L, uint64_t p, acb_poly_t c, uint64_t prec)
 #endif  
-{
+  {
   acb_t tmp;
   acb_init(tmp);
   //if(p==2) {printf("p=%" PRIu64 " 1/poly=",p);acb_poly_printd(c,20);printf("\npoly=");acb_poly_printd(f,20);printf("\n");}
@@ -158,7 +159,70 @@ void use_inv_lpoly(Lfunc *L, uint64_t p, acb_poly_t c, uint64_t prec)
   acb_clear(tmp);
 }
 
-void use_lpoly(Lfunc *L, uint64_t p, const acb_poly_t f)
+static bool retained_reserve(Lfunc *L, uint64_t nc)
+{
+  uint64_t old_cap = L->retained_cap;
+  uint64_t *new_p = (uint64_t *) realloc(L->retained_p, sizeof(uint64_t)*nc);
+  if (!new_p) {
+    L->retained_error |= ERR_OOM;
+    return false;
+  }
+  L->retained_p = new_p;
+
+  acb_poly_struct *new_f = (acb_poly_struct *) realloc(L->retained_f, sizeof(acb_poly_struct)*nc);
+  if (!new_f) {
+    L->retained_error |= ERR_OOM;
+    return false;
+  }
+  L->retained_f = new_f;
+
+  fmpz_poly_struct *new_z = (fmpz_poly_struct *) realloc(L->retained_fmpz, sizeof(fmpz_poly_struct)*nc);
+  if (!new_z) {
+    L->retained_error |= ERR_OOM;
+    return false;
+  }
+  L->retained_fmpz = new_z;
+
+  bool *new_exact = (bool *) realloc(L->retained_is_exact, sizeof(bool)*nc);
+  if (!new_exact) {
+    L->retained_error |= ERR_OOM;
+    return false;
+  }
+  L->retained_is_exact = new_exact;
+  memset(L->retained_is_exact + old_cap, 0, sizeof(bool)*(nc - old_cap));
+  L->retained_cap = nc;
+  return true;
+}
+
+static bool retained_append(Lfunc *L, uint64_t p, const acb_poly_t f,
+                            const fmpz_poly_t fz, bool is_exact)
+{
+  if (L->extract_powers != YES)
+    return true;
+  if (fatal_error(L->retained_error))
+    return false;
+  if (L->n_retained == L->retained_cap) {
+    uint64_t nc = L->retained_cap ? 2*L->retained_cap : 256;
+    if (!retained_reserve(L, nc))
+      return false;
+  }
+
+  uint64_t i = L->n_retained;
+  L->retained_p[i] = p;
+  L->retained_is_exact[i] = false;
+  acb_poly_init(&L->retained_f[i]);
+  acb_poly_set(&L->retained_f[i], f);
+  if (is_exact) {
+    fmpz_poly_init(&L->retained_fmpz[i]);
+    fmpz_poly_set(&L->retained_fmpz[i], fz);
+    L->retained_is_exact[i] = true;
+  }
+  L->n_retained++;
+  return true;
+}
+
+static void use_lpoly_with_exact(Lfunc *L, uint64_t p, const acb_poly_t f,
+                                 const fmpz_poly_t fz, bool is_exact)
 {
   int64_t prec=L->wprec;
   acb_t tmp;
@@ -171,33 +235,7 @@ void use_lpoly(Lfunc *L, uint64_t p, const acb_poly_t f)
   acb_poly_init(n_poly);
   acb_poly_init(inv_poly);
   // w70.2: retain the raw Euler factor for later k-th-root extraction
-  if (L->extract_powers == YES) {
-    if (L->n_retained == L->retained_cap) {
-      uint64_t nc = L->retained_cap ? 2*L->retained_cap : 256;
-      uint64_t *new_p = (uint64_t *) realloc(L->retained_p, sizeof(uint64_t)*nc);
-      if (!new_p) {
-        L->extract_powers = NO;
-      } else {
-        acb_poly_struct *new_f = (acb_poly_struct *) realloc(L->retained_f, sizeof(acb_poly_struct)*nc);
-        if (!new_f) {
-          // Note: new_p doesn't strictly leak here since we realloc'd in-place or returned new pointer,
-          // but we assign it to retained_p so it gets freed on clear.
-          L->retained_p = new_p; 
-          L->extract_powers = NO;
-        } else {
-          L->retained_p = new_p;
-          L->retained_f = new_f;
-          L->retained_cap = nc;
-        }
-      }
-    }
-    if (L->extract_powers == YES) {
-      L->retained_p[L->n_retained] = p;
-      acb_poly_init(&L->retained_f[L->n_retained]);
-      acb_poly_set(&L->retained_f[L->n_retained], f);
-      L->n_retained++;
-    }
-  }
+  retained_append(L, p, f, fz, is_exact);
   //if(p<=2){printf("in use_lpoly pre-norm with p = %" PRIu64 "\n",p);acb_poly_printd(f,20);printf("\n");}
   arb_log_ui(logp,p,prec);
   // normalise by multiplying each term by p^(-m norm)
@@ -276,67 +314,61 @@ bool conductor_kth_root(uint64_t cond, uint64_t k, uint64_t *base)
   return rem == 0;
 }
 
-// Rigorously decide whether the EXACT integer Euler factor Lp is a perfect k-th
-// power of an algebraic polynomial. If so, set Mp to that algebraic root and return
-// true; else return false. EXACT: rounds the ball k-th root to algebraic integers and checks
-// Mp^k == Lp exactly over acb.
-bool poly_exact_kth_root(acb_poly_t Mp, const acb_poly_t Lp, uint64_t k, int64_t prec)
+static bool fmpz_poly_exact_kth_root(fmpz_poly_t Mz, const fmpz_poly_t Lz, uint64_t k)
 {
-  slong d = acb_poly_degree(Lp);
-  if (d < 0 || (d % (slong)k) != 0) return false;
+  if (k < 2)
+    return false;
+  slong d = fmpz_poly_degree(Lz);
+  if (d < 0 || (d % (slong)k) != 0)
+    return false;
 
-  // We require Lp to be exact
-  for (slong i = 0; i <= d; i++) {
-    acb_srcptr c = acb_poly_get_coeff_ptr(Lp, i);
-    if (c != NULL && !acb_is_exact(c)) return false;
+  fmpz_t c0;
+  fmpz_init(c0);
+  fmpz_poly_get_coeff_fmpz(c0, Lz, 0);
+  if (!fmpz_is_one(c0)) {
+    fmpz_clear(c0);
+    return false;
   }
+  fmpz_clear(c0);
 
-  acb_poly_t root; acb_poly_init(root);
-  acb_t e; acb_init(e); acb_set_ui(e, 1); acb_div_ui(e, e, k, prec);
-  acb_poly_pow_acb_series(root, Lp, e, d/(slong)k + 1, prec);
-  acb_clear(e);
+  slong md = d / (slong)k;
+  fmpz_poly_zero(Mz);
+  fmpz_poly_set_coeff_ui(Mz, 0, 1);
 
-  acb_poly_zero(Mp);
-  for (slong i = 0; i <= d/(slong)k; i++) {
-    acb_srcptr c = acb_poly_get_coeff_ptr(root, i);
-    acb_t z; acb_init(z);
-    if (c != NULL) {
-      fmpz_t r, im; fmpz_init(r); fmpz_init(im);
-      arf_get_fmpz(r, arb_midref(acb_realref(c)), ARF_RND_NEAR);
-      arf_get_fmpz(im, arb_midref(acb_imagref(c)), ARF_RND_NEAR);
-      arb_set_fmpz(acb_realref(z), r);
-      arb_set_fmpz(acb_imagref(z), im);
-      fmpz_clear(r); fmpz_clear(im);
-    }
-    acb_poly_set_coeff_acb(Mp, i, z);
-    acb_clear(z);
-  }
-  acb_poly_clear(root);
-
-  acb_poly_t chk; acb_poly_init(chk);
-  acb_poly_pow_ui(chk, Mp, (ulong)k, prec);
+  fmpz_poly_t cur, chk;
+  fmpz_poly_init(cur);
+  fmpz_poly_init(chk);
+  fmpz_t target, current, diff;
+  fmpz_init(target);
+  fmpz_init(current);
+  fmpz_init(diff);
 
   bool ok = true;
-  for (slong i = 0; i <= d && ok; i++) {
-    acb_srcptr c_L = acb_poly_get_coeff_ptr(Lp, i);
-    acb_srcptr c_chk = acb_poly_get_coeff_ptr(chk, i);
-    acb_t exact_chk; acb_init(exact_chk);
-    if (c_chk != NULL) {
-      fmpz_t r, im; fmpz_init(r); fmpz_init(im);
-      arf_get_fmpz(r, arb_midref(acb_realref(c_chk)), ARF_RND_NEAR);
-      arf_get_fmpz(im, arb_midref(acb_imagref(c_chk)), ARF_RND_NEAR);
-      arb_set_fmpz(acb_realref(exact_chk), r);
-      arb_set_fmpz(acb_imagref(exact_chk), im);
-      fmpz_clear(r); fmpz_clear(im);
+  for (slong n = 1; n <= md && ok; n++) {
+    fmpz_poly_pow(cur, Mz, (ulong)k);
+    fmpz_poly_get_coeff_fmpz(target, Lz, n);
+    fmpz_poly_get_coeff_fmpz(current, cur, n);
+    fmpz_sub(diff, target, current);
+    if (!fmpz_divisible_ui(diff, (ulong)k)) {
+      ok = false;
+      break;
     }
-    if (c_L == NULL) {
-      if (!acb_is_zero(exact_chk)) ok = false;
-    } else {
-      if (!acb_equal(c_L, exact_chk)) ok = false;
-    }
-    acb_clear(exact_chk);
+    fmpz_divexact_ui(diff, diff, (ulong)k);
+    fmpz_poly_set_coeff_fmpz(Mz, n, diff);
   }
-  acb_poly_clear(chk);
+
+  if (ok) {
+    fmpz_poly_pow(chk, Mz, (ulong)k);
+    ok = fmpz_poly_equal(chk, Lz);
+  }
+
+  fmpz_clear(diff);
+  fmpz_clear(current);
+  fmpz_clear(target);
+  fmpz_poly_clear(chk);
+  fmpz_poly_clear(cur);
+  if (!ok)
+    fmpz_poly_zero(Mz);
   return ok;
 }
 
@@ -354,8 +386,8 @@ static void cert_roots_reset(Lfunc *L)
 }
 
 // Run the full rigorous certificate for a fixed candidate k: EVERY retained factor
-// (good AND bad) must be an exact integer k-th power (certified over acb_poly), each
-// sorted block of k mus must be equal, and at least one full-degree (good) factor must
+// (good AND bad) must have exact fmpz provenance and be an exact integer k-th
+// power, each sorted block of k mus must be equal, and at least one full-degree factor must
 // be present. On success, the exact algebraic roots are kept in L->cert_roots (one per
 // retained factor, same order) for reuse when feeding M, and true is returned. On any
 // failure the partially-built store is freed and false is returned.
@@ -374,18 +406,28 @@ static bool power_certify_k(Lfunc *L, uint64_t k)
   if (L->n_retained) {
     L->cert_roots = (acb_poly_struct *) malloc(sizeof(acb_poly_struct)*L->n_retained);
     if (!L->cert_roots) {
+      L->retained_error |= ERR_OOM;
       return false;
     }
   }
   bool seen_full = false;
   for (uint64_t i = 0; i < L->n_retained; i++) {
-    if (acb_poly_degree(&L->retained_f[i]) == (slong)L->degree) seen_full = true;
-    acb_poly_init(&L->cert_roots[i]);
-    L->n_cert_roots = i + 1;
-    if (!poly_exact_kth_root(&L->cert_roots[i], &L->retained_f[i], k, L->wprec)) {
+    if (!L->retained_is_exact || !L->retained_is_exact[i]) {
       cert_roots_reset(L);
       return false;
     }
+    if (fmpz_poly_degree(&L->retained_fmpz[i]) == (slong)L->degree) seen_full = true;
+    fmpz_poly_t root_z;
+    fmpz_poly_init(root_z);
+    if (!fmpz_poly_exact_kth_root(root_z, &L->retained_fmpz[i], k)) {
+      fmpz_poly_clear(root_z);
+      cert_roots_reset(L);
+      return false;
+    }
+    acb_poly_init(&L->cert_roots[i]);
+    L->n_cert_roots = i + 1;
+    acb_poly_set_fmpz_poly(&L->cert_roots[i], root_z, L->wprec);
+    fmpz_poly_clear(root_z);
   }
   if (!seen_full) { cert_roots_reset(L); return false; }
   return true;
@@ -396,6 +438,8 @@ static bool power_certify_k(Lfunc *L, uint64_t k)
 // roots are cached in L->cert_roots for reuse by extract_and_assemble.
 Lerror_t power_extract_prepare(Lfunc *L, uint64_t *k_out)
 {
+  if (fatal_error(L->retained_error))
+    return L->retained_error;
   if (L->moment_count == 0) return ERR_POWER;
   
   // For L = M^k the true exponent k satisfies k | degree (M has degree/k Gamma factors)
@@ -412,6 +456,8 @@ Lerror_t power_extract_prepare(Lfunc *L, uint64_t *k_out)
     if ((L->degree % k) != 0) continue;   // M's degree = degree/k must be a positive integer
     if (!conductor_kth_root(L->conductor, k, &cbase)) continue; // cond not an exact k-th power
     if (power_certify_k(L, k)) { *k_out = k; return ERR_SUCCESS; }
+    if (fatal_error(L->retained_error))
+      return L->retained_error;
   }
   cert_roots_reset(L);
   return ERR_POWER;
@@ -462,7 +508,19 @@ void Lfunc_use_lpoly(Lfunc_t Lf, uint64_t p, const acb_poly_t poly)
 {
   Lfunc *L;
   L=(Lfunc *)Lf;
-  use_lpoly(L,p,poly);
+  use_lpoly_with_exact(L,p,poly,NULL,false);
+}
+
+Lerror_t Lfunc_use_lpoly_fmpz(Lfunc_t Lf, uint64_t p, const fmpz_poly_t poly)
+{
+  Lfunc *L;
+  L=(Lfunc *)Lf;
+  acb_poly_t apoly;
+  acb_poly_init(apoly);
+  acb_poly_set_fmpz_poly(apoly, poly, L->wprec);
+  use_lpoly_with_exact(L,p,apoly,poly,true);
+  acb_poly_clear(apoly);
+  return L->retained_error;
 }
 
 
@@ -498,7 +556,11 @@ Lerror_t Lfunc_use_all_lpolys(Lfunc_t Lf, void (*lpoly_callback) (acb_poly_t lpo
       ecode|=ERR_INSUFF_EULER;
       break;
     }
-    use_lpoly(L,p,lp);
+    use_lpoly_with_exact(L,p,lp,NULL,false);
+    if (fatal_error(L->retained_error)) {
+      ecode |= L->retained_error;
+      break;
+    }
   }
 
   //for(i=0;i<20;i++)
@@ -506,7 +568,53 @@ Lerror_t Lfunc_use_all_lpolys(Lfunc_t Lf, void (*lpoly_callback) (acb_poly_t lpo
 
   primesieve_free_iterator(&it);
   acb_poly_clear(lp);
-  return ecode;
+  return ecode | L->retained_error;
+}
+
+Lerror_t Lfunc_use_all_lpolys_fmpz(Lfunc_t Lf, void (*lpoly_callback)(fmpz_poly_t lpoly, uint64_t p, int d, void *parm), void *param)
+{
+  Lfunc *L;
+  L=(Lfunc *)Lf;
+  if(!L->nmax_called)
+  {
+    L->M=Lfunc_nmax(Lf);
+    L->nmax_called=true;
+  }
+
+  fmpz_poly_t lp;
+  acb_poly_t ap;
+  fmpz_poly_init(lp);
+  acb_poly_init(ap);
+  primesieve_iterator it;
+  primesieve_init(&it);
+  uint64_t p=0;
+  Lerror_t ecode=ERR_SUCCESS;
+  while((p=primesieve_next_prime(&it)) <= L->M)
+  {
+    fmpz_poly_zero(lp);
+    lpoly_callback(lp,p,L->degree,param);
+    if(fmpz_poly_is_zero(lp))
+    {
+      #ifdef BUTHE
+      if(p<L->buthe_M)
+        L->buthe_M=p-1;
+      #endif
+      L->M=p-1;
+      ecode|=ERR_INSUFF_EULER;
+      break;
+    }
+    acb_poly_set_fmpz_poly(ap, lp, L->wprec);
+    use_lpoly_with_exact(L,p,ap,lp,true);
+    if (fatal_error(L->retained_error)) {
+      ecode |= L->retained_error;
+      break;
+    }
+  }
+
+  primesieve_free_iterator(&it);
+  acb_poly_clear(ap);
+  fmpz_poly_clear(lp);
+  return ecode | L->retained_error;
 }
 
 bool Lfunc_reduce_nmax(Lfunc_t LL, uint64_t nmax)

--- a/src/coeff.c
+++ b/src/coeff.c
@@ -361,8 +361,12 @@ Lerror_t power_guard(Lfunc *L)
   // and then either rejects (opted out) or extracts-and-assembles (opted in).
   if(L->seen_sqfree_fulldeg)         // rigorous certificate: no repeated factor
     return ERR_SUCCESS;
-  if(L->moment_count == 0)           // no good primes seen; can't judge -> proceed
-    return ERR_SUCCESS;
+  if(L->moment_count == 0)           // no good primes seen; can't judge from moments.
+    // A perfect-power conductor with NO good primes is the degenerate case we cannot
+    // certify primitive (Signal 1 didn't fire either): flag it rather than silently
+    // proceed (which could feed doubled zeros into the pipeline). A genuine primitive
+    // with a squarefree good prime is already handled by the check above.
+    return conductor_is_perfect_power(L->conductor) ? ERR_POWER : ERR_SUCCESS;
   // Signal 2a (heuristic): empirical 2nd moment >= threshold.
   arb_t S, thresh, diff;
   arb_init(S);

--- a/src/coeff.c
+++ b/src/coeff.c
@@ -234,7 +234,7 @@ static void use_lpoly_with_exact(Lfunc *L, uint64_t p, const acb_poly_t f,
   arb_init(tmp2);
   acb_poly_init(n_poly);
   acb_poly_init(inv_poly);
-  // w70.2: retain the raw Euler factor for later k-th-root extraction
+  // retain the raw Euler factor for later k-th-root extraction
   retained_append(L, p, f, fz, is_exact);
   //if(p<=2){printf("in use_lpoly pre-norm with p = %" PRIu64 "\n",p);acb_poly_printd(f,20);printf("\n");}
   arb_log_ui(logp,p,prec);

--- a/src/coeff.c
+++ b/src/coeff.c
@@ -3,6 +3,7 @@
 #include "glfunc_internals.h"
 #include "primesieve.h"
 #include <flint/acb_mat.h>
+#include <flint/ulong_extras.h>
 
 #ifdef __cplusplus
 extern "C"{
@@ -222,15 +223,29 @@ void use_lpoly(Lfunc *L, uint64_t p, const acb_poly_t f)
 
 }
 
+// Cheap, exact "is L a pure power?" tell from the conductor alone: cond(M^k) = cond(M)^k,
+// so a pure power has a perfect-k-th-power conductor. Necessary, not sufficient (a primitive
+// can have a perfect-power conductor), so this only ever corroborates -- Signal 1 (the
+// squarefree certificate) is what keeps the guard from false-rejecting such primitives.
+static bool conductor_is_perfect_power(uint64_t N)
+{
+  if(N < 4)            // 0,1,2,3 are not (nontrivial) perfect powers
+    return false;
+  ulong root;
+  return n_is_perfect_power(&root, (ulong) N) != 0;
+}
+
 // Power / repeated-factor guard. Call at the top of Lfunc_compute, after the Euler
 // factors have been supplied (so the signals are populated). Returns ERR_POWER if L
 // looks like a perfect power / has a repeated primitive factor and the caller did not
 // set allow_nonprimitive; ERR_SUCCESS otherwise.
 //
-// Belt-and-suspenders (sound, not complete): reject ONLY when BOTH
-//   (1) no supplied full-degree local factor was proven squarefree, AND
-//   (2) the empirical 2nd moment (1/#) sum |a_p|^2 >= POWER_MOMENT_THRESHOLD.
-// (1) alone certifies a genuine primitive as safe, so a primitive is never false-rejected.
+// Belt-and-suspenders (sound, not complete): reject ONLY when (1) is false, AND (2a OR 2b):
+//   (1)  some supplied full-degree local factor was proven squarefree, OR
+//   (2a) the empirical 2nd moment (1/#) sum |a_p|^2 >= POWER_MOMENT_THRESHOLD, OR
+//   (2b) the conductor is a perfect power (cond(M^k)=cond(M)^k, exact tell for PURE powers).
+// (1) alone certifies a genuine primitive as safe and is checked FIRST, so a primitive is
+// never false-rejected even if it happens to have a perfect-power conductor.
 Lerror_t power_guard(Lfunc *L)
 {
   if(L->allow_nonprimitive == YES)   // caller opted out of the guard
@@ -239,18 +254,21 @@ Lerror_t power_guard(Lfunc *L)
     return ERR_SUCCESS;
   if(L->moment_count == 0)           // no good primes seen; can't judge -> proceed
     return ERR_SUCCESS;
+  // Signal 2a (heuristic): empirical 2nd moment >= threshold.
   arb_t S, thresh, diff;
   arb_init(S);
   arb_init(thresh);
   arb_init(diff);
-  arb_div_ui(S, L->moment_sum, L->moment_count, L->wprec); // empirical 2nd moment
+  arb_div_ui(S, L->moment_sum, L->moment_count, L->wprec);
   arb_set_d(thresh, POWER_MOMENT_THRESHOLD);
   arb_sub(diff, S, thresh, L->wprec);
-  bool power_like = arb_is_positive(diff); // S - threshold > 0 for the whole ball
+  bool moment_like = arb_is_positive(diff); // S - threshold > 0 for the whole ball
   arb_clear(diff);
   arb_clear(thresh);
   arb_clear(S);
-  return power_like ? ERR_POWER : ERR_SUCCESS;
+  // Signal 2b (cheap exact tell for PURE powers): cond is a perfect k-th power.
+  bool conductor_like = conductor_is_perfect_power(L->conductor);
+  return (moment_like || conductor_like) ? ERR_POWER : ERR_SUCCESS;
 }
 
 void Lfunc_use_lpoly(Lfunc_t Lf, uint64_t p, const acb_poly_t poly)

--- a/src/coeff.c
+++ b/src/coeff.c
@@ -3,6 +3,7 @@
 #include "glfunc_internals.h"
 #include "primesieve.h"
 #include <flint/acb_mat.h>
+#include <flint/acb_poly.h>
 #include <flint/ulong_extras.h>
 
 #ifdef __cplusplus
@@ -168,6 +169,29 @@ void use_lpoly(Lfunc *L, uint64_t p, const acb_poly_t f)
   arb_init(tmp2);
   acb_poly_init(n_poly);
   acb_poly_init(inv_poly);
+  // w70.2: retain the raw Euler factor for later k-th-root extraction
+  if (L->extract_powers == YES) {
+    if (L->n_retained == L->retained_cap) {
+      uint64_t nc = L->retained_cap ? 2*L->retained_cap : 256;
+      uint64_t *new_p = (uint64_t *) realloc(L->retained_p, sizeof(uint64_t)*nc);
+      if (!new_p) {
+        printf("Attempt to (re-)allocate memory for retained primes failed. Exiting.\n");
+        exit(0);
+      }
+      acb_poly_struct *new_f = (acb_poly_struct *) realloc(L->retained_f, sizeof(acb_poly_struct)*nc);
+      if (!new_f) {
+        printf("Attempt to (re-)allocate memory for retained factors failed. Exiting.\n");
+        exit(0);
+      }
+      L->retained_p = new_p;
+      L->retained_f = new_f;
+      L->retained_cap = nc;
+    }
+    L->retained_p[L->n_retained] = p;
+    acb_poly_init(&L->retained_f[L->n_retained]);
+    acb_poly_set(&L->retained_f[L->n_retained], f);
+    L->n_retained++;
+  }
   //if(p<=2){printf("in use_lpoly pre-norm with p = %" PRIu64 "\n",p);acb_poly_printd(f,20);printf("\n");}
   arb_log_ui(logp,p,prec);
   // normalise by multiplying each term by p^(-m norm)
@@ -235,11 +259,68 @@ static bool conductor_is_perfect_power(uint64_t N)
   return n_is_perfect_power(&root, (ulong) N) != 0;
 }
 
+// root = f^(1/k) as an acb_poly (f must have unit constant term: good for L_p(0)=1).
+static void poly_kth_root(acb_poly_t root, const acb_poly_t f, uint64_t k, int64_t prec)
+{
+  slong dlen = acb_poly_degree(f)/(slong)k + 2; // a couple of guard terms
+  acb_t e; acb_init(e);
+  acb_set_ui(e, 1); acb_div_ui(e, e, k, prec);   // e = 1/k
+  acb_poly_pow_acb_series(root, f, e, dlen, prec);
+  acb_clear(e);
+}
+
+// True iff f is rigorously a perfect k-th power of a degree deg(f)/k polynomial.
+static bool poly_is_perfect_kth_power(const acb_poly_t f, uint64_t k, int64_t prec)
+{
+  slong d = acb_poly_degree(f);
+  if (d < 1 || (d % (slong)k) != 0) return false;
+  acb_poly_t root, chk; acb_poly_init(root); acb_poly_init(chk);
+  poly_kth_root(root, f, k, prec);
+  acb_poly_truncate(root, d/(slong)k + 1);    // drop spurious near-zero guard terms
+  acb_poly_pow_ui(chk, root, (ulong)k, prec); // root^k, degree d
+  bool ok = acb_poly_overlaps(chk, f);        // sole rigorous gate: root^k must contain f
+  acb_poly_clear(root); acb_poly_clear(chk);
+  return ok;
+}
+
+// Fix and rigorously certify k for a pure power L = M^k. Returns ERR_SUCCESS with
+// *k_out set when certified, ERR_POWER otherwise.
+Lerror_t power_extract_prepare(Lfunc *L, uint64_t *k_out)
+{
+  if (L->moment_count == 0) return ERR_POWER;
+  // candidate k from the 2nd moment (~ k^2)
+  arb_t S; arb_init(S);
+  arb_div_ui(S, L->moment_sum, L->moment_count, L->wprec);
+  arb_sqrt(S, S, L->wprec);
+  double kf = arf_get_d(arb_midref(S), ARF_RND_NEAR);
+  arb_clear(S);
+  uint64_t k = (uint64_t) (kf + 0.5);
+  // A mis-read 2nd moment yields a safe false ERR_POWER: the rigorous gate certifies,
+  // it cannot rescue a wrong candidate k.
+  if (k < 2) return ERR_POWER;
+  // necessary exact tell: conductor must be a perfect k-th power
+  ulong rem, base = n_rootrem(&rem, (ulong)L->conductor, (ulong)k);
+  (void)base;
+  if (rem != 0) return ERR_POWER;
+  // rigorous gate: every retained full-degree factor is a perfect k-th power
+  bool seen_full = false;
+  for (uint64_t i = 0; i < L->n_retained; i++) {
+    if (acb_poly_degree(&L->retained_f[i]) == (slong)L->degree) {
+      seen_full = true;
+      if (!poly_is_perfect_kth_power(&L->retained_f[i], k, L->wprec))
+        return ERR_POWER;
+    }
+  }
+  if (!seen_full) return ERR_POWER;
+  *k_out = k;
+  return ERR_SUCCESS;
+}
+
 // Power / repeated-factor guard. Call at the top of Lfunc_compute, after the Euler
 // factors have been supplied (so the signals are populated). Returns ERR_POWER if L
-// looks like a perfect power / has a repeated primitive factor and extract_powers is NO;
-// ERR_SUCCESS otherwise (either primitive or extract_powers=YES bypasses; Task 3 changes
-// the YES path to extract-and-assemble).
+// looks like a perfect power / has a repeated primitive factor, ERR_SUCCESS if it
+// looks primitive. The verdict is independent of extract_powers; Lfunc_compute then
+// rejects (opted out) or extracts-and-assembles (opted in) on an ERR_POWER verdict.
 //
 // Belt-and-suspenders (sound, not complete): reject ONLY when (1) is false, AND (2a OR 2b):
 //   (1)  some supplied full-degree local factor was proven squarefree, OR
@@ -249,8 +330,8 @@ static bool conductor_is_perfect_power(uint64_t N)
 // never false-rejected even if it happens to have a perfect-power conductor.
 Lerror_t power_guard(Lfunc *L)
 {
-  if(L->extract_powers == YES)   // caller opted in to extraction; guard bypass until Task 3
-    return ERR_SUCCESS;
+  // Detection is independent of extract_powers: Lfunc_compute consults this verdict
+  // and then either rejects (opted out) or extracts-and-assembles (opted in).
   if(L->seen_sqfree_fulldeg)         // rigorous certificate: no repeated factor
     return ERR_SUCCESS;
   if(L->moment_count == 0)           // no good primes seen; can't judge -> proceed

--- a/src/coeff.c
+++ b/src/coeff.c
@@ -4,6 +4,7 @@
 #include "primesieve.h"
 #include <flint/acb_mat.h>
 #include <flint/acb_poly.h>
+#include <flint/fmpz_poly.h>
 #include <flint/ulong_extras.h>
 
 #ifdef __cplusplus
@@ -259,38 +260,44 @@ static bool conductor_is_perfect_power(uint64_t N)
   return n_is_perfect_power(&root, (ulong) N) != 0;
 }
 
-// root = f^(1/k) as an acb_poly (f must have unit constant term: good for L_p(0)=1).
-static void poly_kth_root(acb_poly_t root, const acb_poly_t f, uint64_t k, int64_t prec)
+// Rigorously decide whether the EXACT integer Euler factor Lp is a perfect k-th
+// power of an integer polynomial. If so, set Mp to that integer root and return
+// true; else return false. EXACT: rounds the ball k-th root to integers and checks
+// Mp^k == Lp over fmpz_poly. (Real callers supply exact integer Euler factors; an
+// inexact or non-integer coefficient returns false -> extract-or-reject.)
+bool poly_exact_kth_root(fmpz_poly_t Mp, const acb_poly_t Lp, uint64_t k, int64_t prec)
 {
-  slong dlen = acb_poly_degree(f)/(slong)k + 2; // a couple of guard terms
-  acb_t e; acb_init(e);
-  acb_set_ui(e, 1); acb_div_ui(e, e, k, prec);   // e = 1/k
-  acb_poly_pow_acb_series(root, f, e, dlen, prec);
-  acb_clear(e);
-}
-
-// True iff f is rigorously a perfect k-th power of a degree deg(f)/k polynomial.
-static bool poly_is_perfect_kth_power(const acb_poly_t f, uint64_t k, int64_t prec)
-{
-  slong d = acb_poly_degree(f);
-  if (d < 1 || (d % (slong)k) != 0) return false;
-  // The certificate is rigorous only for EXACT (point-ball) Euler factors: it proves
-  // f = M_p^k by ball containment, meaningful only when f carries no width. All real
-  // callers supply exact integer Euler factors; refuse to certify an inexact one so
-  // we never claim a power we cannot prove.
-  for (slong i = 0; i <= d; i++) {
-    acb_srcptr ci = acb_poly_get_coeff_ptr(f, i);
-    if (ci != NULL && !acb_is_exact(ci)) return false;
+  slong d = acb_poly_degree(Lp);
+  if (d < 0 || (d % (slong)k) != 0) return false;
+  fmpz_poly_t F; fmpz_poly_init(F);
+  bool ok = true;
+  for (slong i = 0; i <= d && ok; i++) {
+    acb_srcptr c = acb_poly_get_coeff_ptr(Lp, i);
+    fmpz_t z; fmpz_init(z);
+    if (c == NULL) { fmpz_zero(z); }
+    else if (acb_is_exact(c) && arb_is_zero(acb_imagref(c)) && arb_is_int(acb_realref(c)))
+      arf_get_fmpz(z, arb_midref(acb_realref(c)), ARF_RND_DOWN);
+    else ok = false;
+    if (ok) fmpz_poly_set_coeff_fmpz(F, i, z);
+    fmpz_clear(z);
   }
-  acb_poly_t root, chk; acb_poly_init(root); acb_poly_init(chk);
-  poly_kth_root(root, f, k, prec);
-  acb_poly_truncate(root, d/(slong)k + 1);    // drop spurious near-zero guard terms
-  acb_poly_pow_ui(chk, root, (ulong)k, prec); // root^k, degree d
-  // f being exact, root^k overlapping f certifies it: a non-power differs from any
-  // k-th power by at least the integer coefficient gap (>= 1), far exceeding the
-  // ~2^-prec width of the root^k ball, so an overlap can only mean f IS a k-th power.
-  bool ok = acb_poly_overlaps(chk, f);
-  acb_poly_clear(root); acb_poly_clear(chk);
+  if (!ok) { fmpz_poly_clear(F); return false; }
+  acb_poly_t root; acb_poly_init(root);
+  acb_t e; acb_init(e); acb_set_ui(e, 1); acb_div_ui(e, e, k, prec);
+  acb_poly_pow_acb_series(root, Lp, e, d/(slong)k + 1, prec);
+  acb_clear(e);
+  fmpz_poly_zero(Mp);
+  for (slong i = 0; i <= d/(slong)k; i++) {
+    acb_srcptr c = acb_poly_get_coeff_ptr(root, i);
+    fmpz_t z; fmpz_init(z);
+    if (c != NULL) arf_get_fmpz(z, arb_midref(acb_realref(c)), ARF_RND_NEAR); else fmpz_zero(z);
+    fmpz_poly_set_coeff_fmpz(Mp, i, z); fmpz_clear(z);
+  }
+  acb_poly_clear(root);
+  fmpz_poly_t chk; fmpz_poly_init(chk);
+  fmpz_poly_pow(chk, Mp, (ulong)k);
+  ok = fmpz_poly_equal(chk, F);
+  fmpz_poly_clear(chk); fmpz_poly_clear(F);
   return ok;
 }
 
@@ -313,15 +320,17 @@ Lerror_t power_extract_prepare(Lfunc *L, uint64_t *k_out)
   ulong rem, base = n_rootrem(&rem, (ulong)L->conductor, (ulong)k);
   (void)base;
   if (rem != 0) return ERR_POWER;
-  // rigorous gate: every retained full-degree factor is a perfect k-th power
+  // rigorous gate: EVERY retained factor (good AND bad) must be an exact integer k-th
+  // power, certified over fmpz_poly. A single uncertified bad factor would make L = M^k
+  // false, so the k-th root fed to M would be unsound; reject. Still require at least
+  // one full-degree (good) factor as a sanity floor on the degree-k structure.
+  fmpz_poly_t Mp; fmpz_poly_init(Mp);
   bool seen_full = false;
   for (uint64_t i = 0; i < L->n_retained; i++) {
-    if (acb_poly_degree(&L->retained_f[i]) == (slong)L->degree) {
-      seen_full = true;
-      if (!poly_is_perfect_kth_power(&L->retained_f[i], k, L->wprec))
-        return ERR_POWER;
-    }
+    if (acb_poly_degree(&L->retained_f[i]) == (slong)L->degree) seen_full = true;
+    if (!poly_exact_kth_root(Mp, &L->retained_f[i], k, L->wprec)) { fmpz_poly_clear(Mp); return ERR_POWER; }
   }
+  fmpz_poly_clear(Mp);
   if (!seen_full) return ERR_POWER;
   // The archimedean data must also be k copies: each sorted block of k mus must be
   // equal (mus are sorted in Lfunc_init_advanced). A mismatch means L's gamma factors

--- a/src/coeff.c
+++ b/src/coeff.c
@@ -176,22 +176,27 @@ void use_lpoly(Lfunc *L, uint64_t p, const acb_poly_t f)
       uint64_t nc = L->retained_cap ? 2*L->retained_cap : 256;
       uint64_t *new_p = (uint64_t *) realloc(L->retained_p, sizeof(uint64_t)*nc);
       if (!new_p) {
-        printf("Attempt to (re-)allocate memory for retained primes failed. Exiting.\n");
-        exit(0);
+        L->extract_powers = NO;
+      } else {
+        acb_poly_struct *new_f = (acb_poly_struct *) realloc(L->retained_f, sizeof(acb_poly_struct)*nc);
+        if (!new_f) {
+          // Note: new_p doesn't strictly leak here since we realloc'd in-place or returned new pointer,
+          // but we assign it to retained_p so it gets freed on clear.
+          L->retained_p = new_p; 
+          L->extract_powers = NO;
+        } else {
+          L->retained_p = new_p;
+          L->retained_f = new_f;
+          L->retained_cap = nc;
+        }
       }
-      acb_poly_struct *new_f = (acb_poly_struct *) realloc(L->retained_f, sizeof(acb_poly_struct)*nc);
-      if (!new_f) {
-        printf("Attempt to (re-)allocate memory for retained factors failed. Exiting.\n");
-        exit(0);
-      }
-      L->retained_p = new_p;
-      L->retained_f = new_f;
-      L->retained_cap = nc;
     }
-    L->retained_p[L->n_retained] = p;
-    acb_poly_init(&L->retained_f[L->n_retained]);
-    acb_poly_set(&L->retained_f[L->n_retained], f);
-    L->n_retained++;
+    if (L->extract_powers == YES) {
+      L->retained_p[L->n_retained] = p;
+      acb_poly_init(&L->retained_f[L->n_retained]);
+      acb_poly_set(&L->retained_f[L->n_retained], f);
+      L->n_retained++;
+    }
   }
   //if(p<=2){printf("in use_lpoly pre-norm with p = %" PRIu64 "\n",p);acb_poly_printd(f,20);printf("\n");}
   arb_log_ui(logp,p,prec);
@@ -272,43 +277,66 @@ bool conductor_kth_root(uint64_t cond, uint64_t k, uint64_t *base)
 }
 
 // Rigorously decide whether the EXACT integer Euler factor Lp is a perfect k-th
-// power of an integer polynomial. If so, set Mp to that integer root and return
-// true; else return false. EXACT: rounds the ball k-th root to integers and checks
-// Mp^k == Lp over fmpz_poly. (Real callers supply exact integer Euler factors; an
-// inexact or non-integer coefficient returns false -> extract-or-reject.)
-bool poly_exact_kth_root(fmpz_poly_t Mp, const acb_poly_t Lp, uint64_t k, int64_t prec)
+// power of an algebraic polynomial. If so, set Mp to that algebraic root and return
+// true; else return false. EXACT: rounds the ball k-th root to algebraic integers and checks
+// Mp^k == Lp exactly over acb.
+bool poly_exact_kth_root(acb_poly_t Mp, const acb_poly_t Lp, uint64_t k, int64_t prec)
 {
   slong d = acb_poly_degree(Lp);
   if (d < 0 || (d % (slong)k) != 0) return false;
-  fmpz_poly_t F; fmpz_poly_init(F);
-  bool ok = true;
-  for (slong i = 0; i <= d && ok; i++) {
+
+  // We require Lp to be exact
+  for (slong i = 0; i <= d; i++) {
     acb_srcptr c = acb_poly_get_coeff_ptr(Lp, i);
-    fmpz_t z; fmpz_init(z);
-    if (c == NULL) { fmpz_zero(z); }
-    else if (acb_is_exact(c) && arb_is_zero(acb_imagref(c)) && arb_is_int(acb_realref(c)))
-      arf_get_fmpz(z, arb_midref(acb_realref(c)), ARF_RND_DOWN);
-    else ok = false;
-    if (ok) fmpz_poly_set_coeff_fmpz(F, i, z);
-    fmpz_clear(z);
+    if (c != NULL && !acb_is_exact(c)) return false;
   }
-  if (!ok) { fmpz_poly_clear(F); return false; }
+
   acb_poly_t root; acb_poly_init(root);
   acb_t e; acb_init(e); acb_set_ui(e, 1); acb_div_ui(e, e, k, prec);
   acb_poly_pow_acb_series(root, Lp, e, d/(slong)k + 1, prec);
   acb_clear(e);
-  fmpz_poly_zero(Mp);
+
+  acb_poly_zero(Mp);
   for (slong i = 0; i <= d/(slong)k; i++) {
     acb_srcptr c = acb_poly_get_coeff_ptr(root, i);
-    fmpz_t z; fmpz_init(z);
-    if (c != NULL) arf_get_fmpz(z, arb_midref(acb_realref(c)), ARF_RND_NEAR); else fmpz_zero(z);
-    fmpz_poly_set_coeff_fmpz(Mp, i, z); fmpz_clear(z);
+    acb_t z; acb_init(z);
+    if (c != NULL) {
+      fmpz_t r, im; fmpz_init(r); fmpz_init(im);
+      arf_get_fmpz(r, arb_midref(acb_realref(c)), ARF_RND_NEAR);
+      arf_get_fmpz(im, arb_midref(acb_imagref(c)), ARF_RND_NEAR);
+      arb_set_fmpz(acb_realref(z), r);
+      arb_set_fmpz(acb_imagref(z), im);
+      fmpz_clear(r); fmpz_clear(im);
+    }
+    acb_poly_set_coeff_acb(Mp, i, z);
+    acb_clear(z);
   }
   acb_poly_clear(root);
-  fmpz_poly_t chk; fmpz_poly_init(chk);
-  fmpz_poly_pow(chk, Mp, (ulong)k);
-  ok = fmpz_poly_equal(chk, F);
-  fmpz_poly_clear(chk); fmpz_poly_clear(F);
+
+  acb_poly_t chk; acb_poly_init(chk);
+  acb_poly_pow_ui(chk, Mp, (ulong)k, prec);
+
+  bool ok = true;
+  for (slong i = 0; i <= d && ok; i++) {
+    acb_srcptr c_L = acb_poly_get_coeff_ptr(Lp, i);
+    acb_srcptr c_chk = acb_poly_get_coeff_ptr(chk, i);
+    acb_t exact_chk; acb_init(exact_chk);
+    if (c_chk != NULL) {
+      fmpz_t r, im; fmpz_init(r); fmpz_init(im);
+      arf_get_fmpz(r, arb_midref(acb_realref(c_chk)), ARF_RND_NEAR);
+      arf_get_fmpz(im, arb_midref(acb_imagref(c_chk)), ARF_RND_NEAR);
+      arb_set_fmpz(acb_realref(exact_chk), r);
+      arb_set_fmpz(acb_imagref(exact_chk), im);
+      fmpz_clear(r); fmpz_clear(im);
+    }
+    if (c_L == NULL) {
+      if (!acb_is_zero(exact_chk)) ok = false;
+    } else {
+      if (!acb_equal(c_L, exact_chk)) ok = false;
+    }
+    acb_clear(exact_chk);
+  }
+  acb_poly_clear(chk);
   return ok;
 }
 
@@ -318,7 +346,7 @@ static void cert_roots_reset(Lfunc *L)
 {
   if (L->cert_roots) {
     for (uint64_t i = 0; i < L->n_cert_roots; i++)
-      fmpz_poly_clear(&L->cert_roots[i]);
+      acb_poly_clear(&L->cert_roots[i]);
     free(L->cert_roots);
     L->cert_roots = NULL;
   }
@@ -326,9 +354,9 @@ static void cert_roots_reset(Lfunc *L)
 }
 
 // Run the full rigorous certificate for a fixed candidate k: EVERY retained factor
-// (good AND bad) must be an exact integer k-th power (certified over fmpz_poly), each
+// (good AND bad) must be an exact integer k-th power (certified over acb_poly), each
 // sorted block of k mus must be equal, and at least one full-degree (good) factor must
-// be present. On success, the exact integer roots are kept in L->cert_roots (one per
+// be present. On success, the exact algebraic roots are kept in L->cert_roots (one per
 // retained factor, same order) for reuse when feeding M, and true is returned. On any
 // failure the partially-built store is freed and false is returned.
 static bool power_certify_k(Lfunc *L, uint64_t k)
@@ -344,16 +372,15 @@ static bool power_certify_k(Lfunc *L, uint64_t k)
   // k-th root fed to M would be unsound; reject. Keep each certified root for reuse.
   cert_roots_reset(L);
   if (L->n_retained) {
-    L->cert_roots = (fmpz_poly_struct *) malloc(sizeof(fmpz_poly_struct)*L->n_retained);
+    L->cert_roots = (acb_poly_struct *) malloc(sizeof(acb_poly_struct)*L->n_retained);
     if (!L->cert_roots) {
-      printf("Attempt to allocate memory for certified k-th roots failed. Exiting.\n");
-      exit(0);
+      return false;
     }
   }
   bool seen_full = false;
   for (uint64_t i = 0; i < L->n_retained; i++) {
     if (acb_poly_degree(&L->retained_f[i]) == (slong)L->degree) seen_full = true;
-    fmpz_poly_init(&L->cert_roots[i]);
+    acb_poly_init(&L->cert_roots[i]);
     L->n_cert_roots = i + 1;
     if (!poly_exact_kth_root(&L->cert_roots[i], &L->retained_f[i], k, L->wprec)) {
       cert_roots_reset(L);
@@ -370,31 +397,19 @@ static bool power_certify_k(Lfunc *L, uint64_t k)
 Lerror_t power_extract_prepare(Lfunc *L, uint64_t *k_out)
 {
   if (L->moment_count == 0) return ERR_POWER;
-  // candidate k from the 2nd moment (~ k^2)
-  arb_t S; arb_init(S);
-  arb_div_ui(S, L->moment_sum, L->moment_count, L->wprec);
-  arb_sqrt(S, S, L->wprec);
-  double kf = arf_get_d(arb_midref(S), ARF_RND_NEAR);
-  arb_clear(S);
-  uint64_t k0 = (uint64_t) (kf + 0.5);
-  // A mis-read 2nd moment yields a safe false ERR_POWER: the rigorous gate certifies,
-  // it cannot rescue a wrong candidate k.
-  if (k0 < 2) return ERR_POWER;
+  
   // For L = M^k the true exponent k satisfies k | degree (M has degree/k Gamma factors)
-  // and makes the conductor an exact k-th power (cond(M^k) = cond(M)^k). The moment only
-  // ESTIMATES k (moment ~ k^2): a noisy estimate that rounds a genuine M^4 down to 2
-  // underestimates by a divisor, so consider every k in [k0, degree] with k | degree,
-  // k0 | k, and cond an exact k-th power, preferring the LARGEST that passes the rigorous
-  // certificate. (We test conductor-exactness per candidate via conductor_kth_root rather
+  // and makes the conductor an exact k-th power (cond(M^k) = cond(M)^k). 
+  // We consider every k in [2, degree] with k | degree and cond an exact k-th power,
+  // preferring the LARGEST that passes the rigorous certificate. 
+  // (We test conductor-exactness per candidate via conductor_kth_root rather
   // than n_is_perfect_power, whose returned exponent is not necessarily maximal -- it gives
-  // 2 for 37^4 = 1369^2.) This only ever turns a previously-safe-but-incomplete refusal
-  // into a correct extraction: the per-prime exact gate and the mus-block gate still run
+  // 2 for 37^4 = 1369^2.) The per-prime exact gate and the mus-block gate still run
   // for the chosen k and reject anything unsound, so a too-large k is filtered back down
   // (e.g. cond a 4th power but the factors only squares).
   uint64_t cbase;
-  for (uint64_t k = L->degree; k >= k0; k--) {
+  for (uint64_t k = L->degree; k >= 2; k--) {
     if ((L->degree % k) != 0) continue;   // M's degree = degree/k must be a positive integer
-    if ((k % k0) != 0) continue;          // keep k consistent with the moment estimate
     if (!conductor_kth_root(L->conductor, k, &cbase)) continue; // cond not an exact k-th power
     if (power_certify_k(L, k)) { *k_out = k; return ERR_SUCCESS; }
   }

--- a/src/coeff.c
+++ b/src/coeff.c
@@ -274,11 +274,22 @@ static bool poly_is_perfect_kth_power(const acb_poly_t f, uint64_t k, int64_t pr
 {
   slong d = acb_poly_degree(f);
   if (d < 1 || (d % (slong)k) != 0) return false;
+  // The certificate is rigorous only for EXACT (point-ball) Euler factors: it proves
+  // f = M_p^k by ball containment, meaningful only when f carries no width. All real
+  // callers supply exact integer Euler factors; refuse to certify an inexact one so
+  // we never claim a power we cannot prove.
+  for (slong i = 0; i <= d; i++) {
+    acb_srcptr ci = acb_poly_get_coeff_ptr(f, i);
+    if (ci != NULL && !acb_is_exact(ci)) return false;
+  }
   acb_poly_t root, chk; acb_poly_init(root); acb_poly_init(chk);
   poly_kth_root(root, f, k, prec);
   acb_poly_truncate(root, d/(slong)k + 1);    // drop spurious near-zero guard terms
   acb_poly_pow_ui(chk, root, (ulong)k, prec); // root^k, degree d
-  bool ok = acb_poly_overlaps(chk, f);        // sole rigorous gate: root^k must contain f
+  // f being exact, root^k overlapping f certifies it: a non-power differs from any
+  // k-th power by at least the integer coefficient gap (>= 1), far exceeding the
+  // ~2^-prec width of the root^k ball, so an overlap can only mean f IS a k-th power.
+  bool ok = acb_poly_overlaps(chk, f);
   acb_poly_clear(root); acb_poly_clear(chk);
   return ok;
 }
@@ -312,6 +323,13 @@ Lerror_t power_extract_prepare(Lfunc *L, uint64_t *k_out)
     }
   }
   if (!seen_full) return ERR_POWER;
+  // The archimedean data must also be k copies: each sorted block of k mus must be
+  // equal (mus are sorted in Lfunc_init_advanced). A mismatch means L's gamma factors
+  // disagree with a pure power, so we must not extract (spec section 10).
+  for (uint64_t i = 0; i + k <= L->degree; i += k)
+    for (uint64_t j = 1; j < k; j++)
+      if (L->mus[i] != L->mus[i + j])
+        return ERR_POWER;
   *k_out = k;
   return ERR_SUCCESS;
 }

--- a/src/coeff.c
+++ b/src/coeff.c
@@ -237,8 +237,9 @@ static bool conductor_is_perfect_power(uint64_t N)
 
 // Power / repeated-factor guard. Call at the top of Lfunc_compute, after the Euler
 // factors have been supplied (so the signals are populated). Returns ERR_POWER if L
-// looks like a perfect power / has a repeated primitive factor and the caller did not
-// set allow_nonprimitive; ERR_SUCCESS otherwise.
+// looks like a perfect power / has a repeated primitive factor and extract_powers is NO;
+// ERR_SUCCESS otherwise (either primitive or extract_powers=YES bypasses; Task 3 changes
+// the YES path to extract-and-assemble).
 //
 // Belt-and-suspenders (sound, not complete): reject ONLY when (1) is false, AND (2a OR 2b):
 //   (1)  some supplied full-degree local factor was proven squarefree, OR
@@ -248,7 +249,7 @@ static bool conductor_is_perfect_power(uint64_t N)
 // never false-rejected even if it happens to have a perfect-power conductor.
 Lerror_t power_guard(Lfunc *L)
 {
-  if(L->allow_nonprimitive == YES)   // caller opted out of the guard
+  if(L->extract_powers == YES)   // caller opted in to extraction; guard bypass until Task 3
     return ERR_SUCCESS;
   if(L->seen_sqfree_fulldeg)         // rigorous certificate: no repeated factor
     return ERR_SUCCESS;

--- a/src/coeff.c
+++ b/src/coeff.c
@@ -260,6 +260,17 @@ static bool conductor_is_perfect_power(uint64_t N)
   return n_is_perfect_power(&root, (ulong) N) != 0;
 }
 
+// Exact k-th root of the conductor: returns true iff `cond` is a perfect k-th power
+// (cond = base^k for some integer base), setting *base to that root. This is the
+// "is it THIS power" question (k fixed), distinct from conductor_is_perfect_power's
+// "is it ANY power". Used by both power_extract_prepare and extract_and_assemble.
+bool conductor_kth_root(uint64_t cond, uint64_t k, uint64_t *base)
+{
+  ulong rem, b = n_rootrem(&rem, (ulong)cond, (ulong)k);
+  *base = (uint64_t)b;
+  return rem == 0;
+}
+
 // Rigorously decide whether the EXACT integer Euler factor Lp is a perfect k-th
 // power of an integer polynomial. If so, set Mp to that integer root and return
 // true; else return false. EXACT: rounds the ball k-th root to integers and checks
@@ -301,8 +312,61 @@ bool poly_exact_kth_root(fmpz_poly_t Mp, const acb_poly_t Lp, uint64_t k, int64_
   return ok;
 }
 
+// Free and reset the certified-root store (the partial work of a rejected candidate k,
+// or any leftover from a prior call). After this the store is empty and owns nothing.
+static void cert_roots_reset(Lfunc *L)
+{
+  if (L->cert_roots) {
+    for (uint64_t i = 0; i < L->n_cert_roots; i++)
+      fmpz_poly_clear(&L->cert_roots[i]);
+    free(L->cert_roots);
+    L->cert_roots = NULL;
+  }
+  L->n_cert_roots = 0;
+}
+
+// Run the full rigorous certificate for a fixed candidate k: EVERY retained factor
+// (good AND bad) must be an exact integer k-th power (certified over fmpz_poly), each
+// sorted block of k mus must be equal, and at least one full-degree (good) factor must
+// be present. On success, the exact integer roots are kept in L->cert_roots (one per
+// retained factor, same order) for reuse when feeding M, and true is returned. On any
+// failure the partially-built store is freed and false is returned.
+static bool power_certify_k(Lfunc *L, uint64_t k)
+{
+  // The archimedean data must be k copies: each sorted block of k mus must be equal
+  // (mus are sorted in Lfunc_init_advanced). A mismatch means L's gamma factors disagree
+  // with a pure power, so we must not extract (spec section 10). Cheap; check first.
+  for (uint64_t i = 0; i + k <= L->degree; i += k)
+    for (uint64_t j = 1; j < k; j++)
+      if (L->mus[i] != L->mus[i + j])
+        return false;
+  // rigorous per-prime gate: a single uncertified factor would make L = M^k false, so the
+  // k-th root fed to M would be unsound; reject. Keep each certified root for reuse.
+  cert_roots_reset(L);
+  if (L->n_retained) {
+    L->cert_roots = (fmpz_poly_struct *) malloc(sizeof(fmpz_poly_struct)*L->n_retained);
+    if (!L->cert_roots) {
+      printf("Attempt to allocate memory for certified k-th roots failed. Exiting.\n");
+      exit(0);
+    }
+  }
+  bool seen_full = false;
+  for (uint64_t i = 0; i < L->n_retained; i++) {
+    if (acb_poly_degree(&L->retained_f[i]) == (slong)L->degree) seen_full = true;
+    fmpz_poly_init(&L->cert_roots[i]);
+    L->n_cert_roots = i + 1;
+    if (!poly_exact_kth_root(&L->cert_roots[i], &L->retained_f[i], k, L->wprec)) {
+      cert_roots_reset(L);
+      return false;
+    }
+  }
+  if (!seen_full) { cert_roots_reset(L); return false; }
+  return true;
+}
+
 // Fix and rigorously certify k for a pure power L = M^k. Returns ERR_SUCCESS with
-// *k_out set when certified, ERR_POWER otherwise.
+// *k_out set when certified, ERR_POWER otherwise. On success the certified integer
+// roots are cached in L->cert_roots for reuse by extract_and_assemble.
 Lerror_t power_extract_prepare(Lfunc *L, uint64_t *k_out)
 {
   if (L->moment_count == 0) return ERR_POWER;
@@ -312,35 +376,30 @@ Lerror_t power_extract_prepare(Lfunc *L, uint64_t *k_out)
   arb_sqrt(S, S, L->wprec);
   double kf = arf_get_d(arb_midref(S), ARF_RND_NEAR);
   arb_clear(S);
-  uint64_t k = (uint64_t) (kf + 0.5);
+  uint64_t k0 = (uint64_t) (kf + 0.5);
   // A mis-read 2nd moment yields a safe false ERR_POWER: the rigorous gate certifies,
   // it cannot rescue a wrong candidate k.
-  if (k < 2) return ERR_POWER;
-  // necessary exact tell: conductor must be a perfect k-th power
-  ulong rem, base = n_rootrem(&rem, (ulong)L->conductor, (ulong)k);
-  (void)base;
-  if (rem != 0) return ERR_POWER;
-  // rigorous gate: EVERY retained factor (good AND bad) must be an exact integer k-th
-  // power, certified over fmpz_poly. A single uncertified bad factor would make L = M^k
-  // false, so the k-th root fed to M would be unsound; reject. Still require at least
-  // one full-degree (good) factor as a sanity floor on the degree-k structure.
-  fmpz_poly_t Mp; fmpz_poly_init(Mp);
-  bool seen_full = false;
-  for (uint64_t i = 0; i < L->n_retained; i++) {
-    if (acb_poly_degree(&L->retained_f[i]) == (slong)L->degree) seen_full = true;
-    if (!poly_exact_kth_root(Mp, &L->retained_f[i], k, L->wprec)) { fmpz_poly_clear(Mp); return ERR_POWER; }
+  if (k0 < 2) return ERR_POWER;
+  // For L = M^k the true exponent k satisfies k | degree (M has degree/k Gamma factors)
+  // and makes the conductor an exact k-th power (cond(M^k) = cond(M)^k). The moment only
+  // ESTIMATES k (moment ~ k^2): a noisy estimate that rounds a genuine M^4 down to 2
+  // underestimates by a divisor, so consider every k in [k0, degree] with k | degree,
+  // k0 | k, and cond an exact k-th power, preferring the LARGEST that passes the rigorous
+  // certificate. (We test conductor-exactness per candidate via conductor_kth_root rather
+  // than n_is_perfect_power, whose returned exponent is not necessarily maximal -- it gives
+  // 2 for 37^4 = 1369^2.) This only ever turns a previously-safe-but-incomplete refusal
+  // into a correct extraction: the per-prime exact gate and the mus-block gate still run
+  // for the chosen k and reject anything unsound, so a too-large k is filtered back down
+  // (e.g. cond a 4th power but the factors only squares).
+  uint64_t cbase;
+  for (uint64_t k = L->degree; k >= k0; k--) {
+    if ((L->degree % k) != 0) continue;   // M's degree = degree/k must be a positive integer
+    if ((k % k0) != 0) continue;          // keep k consistent with the moment estimate
+    if (!conductor_kth_root(L->conductor, k, &cbase)) continue; // cond not an exact k-th power
+    if (power_certify_k(L, k)) { *k_out = k; return ERR_SUCCESS; }
   }
-  fmpz_poly_clear(Mp);
-  if (!seen_full) return ERR_POWER;
-  // The archimedean data must also be k copies: each sorted block of k mus must be
-  // equal (mus are sorted in Lfunc_init_advanced). A mismatch means L's gamma factors
-  // disagree with a pure power, so we must not extract (spec section 10).
-  for (uint64_t i = 0; i + k <= L->degree; i += k)
-    for (uint64_t j = 1; j < k; j++)
-      if (L->mus[i] != L->mus[i + j])
-        return ERR_POWER;
-  *k_out = k;
-  return ERR_SUCCESS;
+  cert_roots_reset(L);
+  return ERR_POWER;
 }
 
 // Power / repeated-factor guard. Call at the top of Lfunc_compute, after the Euler

--- a/src/coeff.c
+++ b/src/coeff.c
@@ -2,6 +2,7 @@
 #include "glfunc.h"
 #include "glfunc_internals.h"
 #include "primesieve.h"
+#include <flint/acb_mat.h>
 
 #ifdef __cplusplus
 extern "C"{
@@ -84,6 +85,42 @@ uint64_t Lfunc_nmax(Lfunc_t Lf)
   return L->M;
 }
 
+// Rigorously decide whether the polynomial f (degree d >= 1) is squarefree
+// (distinct roots), via res(f, f') computed as the Sylvester-matrix determinant.
+// Returns true ONLY if the determinant ball provably excludes zero, so a `true`
+// is a rigorous certificate that f has no repeated root. A `false` means either
+// f has a repeated root or the balls were too wide to decide -- both are safe to
+// treat as "not certified squarefree".
+static bool poly_is_squarefree_certified(const acb_poly_t f, int64_t prec)
+{
+  slong d = acb_poly_degree(f);
+  if(d < 1)
+    return false;
+  acb_poly_t fp;
+  acb_poly_init(fp);
+  acb_poly_derivative(fp, f, prec);     // f', degree d-1
+  slong n = 2*d - 1;                    // Sylvester matrix of (f, f') is n x n
+  acb_mat_t S;
+  acb_mat_init(S, n, n);
+  acb_mat_zero(S);
+  // top d-1 rows: coeffs of f (highest degree first), row i shifted right by i
+  for(slong i = 0; i < d-1; i++)
+    for(slong j = 0; j <= d; j++)
+      acb_poly_get_coeff_acb(acb_mat_entry(S, i, i+j), f, d-j);
+  // bottom d rows: coeffs of f' (highest degree first), row i shifted right by i
+  for(slong i = 0; i < d; i++)
+    for(slong j = 0; j <= d-1; j++)
+      acb_poly_get_coeff_acb(acb_mat_entry(S, d-1+i, i+j), fp, (d-1)-j);
+  acb_t det;
+  acb_init(det);
+  acb_mat_det(det, S, prec);
+  bool sqfree = !acb_contains_zero(det);
+  acb_clear(det);
+  acb_mat_clear(S);
+  acb_poly_clear(fp);
+  return sqfree;
+}
+
 #ifdef BUTHE
 void use_inv_lpoly(Lfunc *L, uint64_t p, acb_poly_t c, acb_poly_t f, uint64_t prec)
   #else
@@ -151,6 +188,26 @@ void use_lpoly(Lfunc *L, uint64_t p, const acb_poly_t f)
   //if(p<=11){printf("Inverted poly\n");
   //acb_poly_printd(inv_poly,20);printf("\n------------------\n");
   //}
+  // ---- power-guard detection signals, accumulated over full-degree (good) primes ----
+  // a_p (analytic) is the T^1 coefficient of the inverse local factor.
+  if(acb_poly_degree(f) == (slong)L->degree)
+  {
+    acb_t ap;
+    arb_t aap;
+    acb_init(ap);
+    arb_init(aap);
+    acb_poly_get_coeff_acb(ap, inv_poly, 1);
+    acb_abs(aap, ap, prec);            // |a_p|
+    arb_mul(aap, aap, aap, prec);      // |a_p|^2
+    arb_add(L->moment_sum, L->moment_sum, aap, prec);
+    L->moment_count++;
+    // one squarefree full-degree factor rigorously certifies "no repeated factor"
+    if(!L->seen_sqfree_fulldeg && L->moment_count <= POWER_SQFREE_PROBES)
+      if(poly_is_squarefree_certified(f, prec))
+        L->seen_sqfree_fulldeg = true;
+    arb_clear(aap);
+    acb_clear(ap);
+  }
   #ifdef BUTHE
   use_inv_lpoly(L,p,inv_poly,n_poly,prec);
 #else
@@ -163,6 +220,37 @@ void use_lpoly(Lfunc *L, uint64_t p, const acb_poly_t f)
   acb_poly_clear(n_poly);
   acb_poly_clear(inv_poly);
 
+}
+
+// Power / repeated-factor guard. Call at the top of Lfunc_compute, after the Euler
+// factors have been supplied (so the signals are populated). Returns ERR_POWER if L
+// looks like a perfect power / has a repeated primitive factor and the caller did not
+// set allow_nonprimitive; ERR_SUCCESS otherwise.
+//
+// Belt-and-suspenders (sound, not complete): reject ONLY when BOTH
+//   (1) no supplied full-degree local factor was proven squarefree, AND
+//   (2) the empirical 2nd moment (1/#) sum |a_p|^2 >= POWER_MOMENT_THRESHOLD.
+// (1) alone certifies a genuine primitive as safe, so a primitive is never false-rejected.
+Lerror_t power_guard(Lfunc *L)
+{
+  if(L->allow_nonprimitive == YES)   // caller opted out of the guard
+    return ERR_SUCCESS;
+  if(L->seen_sqfree_fulldeg)         // rigorous certificate: no repeated factor
+    return ERR_SUCCESS;
+  if(L->moment_count == 0)           // no good primes seen; can't judge -> proceed
+    return ERR_SUCCESS;
+  arb_t S, thresh, diff;
+  arb_init(S);
+  arb_init(thresh);
+  arb_init(diff);
+  arb_div_ui(S, L->moment_sum, L->moment_count, L->wprec); // empirical 2nd moment
+  arb_set_d(thresh, POWER_MOMENT_THRESHOLD);
+  arb_sub(diff, S, thresh, L->wprec);
+  bool power_like = arb_is_positive(diff); // S - threshold > 0 for the whole ball
+  arb_clear(diff);
+  arb_clear(thresh);
+  arb_clear(S);
+  return power_like ? ERR_POWER : ERR_SUCCESS;
 }
 
 void Lfunc_use_lpoly(Lfunc_t Lf, uint64_t p, const acb_poly_t poly)

--- a/src/compute.c
+++ b/src/compute.c
@@ -305,6 +305,10 @@ static Lerror_t extract_and_assemble(Lfunc *L, uint64_t k)
   Lfunc *M = (Lfunc *) Mt;
 
   // ---- supply M_p = retained_f^(1/k) for primes up to nmax(M) ----
+  // Bad (lower-degree) primes are k-th-rooted here WITHOUT a separate certificate:
+  // the good-prime k-th-power certificate plus the perfect-k-th-power conductor
+  // already force L = M^k globally, hence every local factor (good or bad) is M_p^k,
+  // so taking the k-th root of each retained factor is sound.
   uint64_t Mmax = Lfunc_nmax(Mt);
   acb_poly_t Mp_poly; acb_poly_init(Mp_poly);
   acb_t e_inv; acb_init(e_inv);
@@ -339,7 +343,10 @@ static Lerror_t extract_and_assemble(Lfunc *L, uint64_t k)
   acb_pow_ui(L->sign, M->sign, k, L->wprec);          // eps^k
   acb_pow_ui(L->sqrt_sign, M->sqrt_sign, k, L->wprec); // sqrt_sign^k
   arb_pow_ui(L->L_d, M->L_d, k, L->wprec);            // leading Taylor coeff ^ k
-  arb_pow_ui(L->Lam_d, M->Lam_d, k, L->wprec); // Lambda_L = Lambda_M^k
+  // Lam_d (= Lambda^(rank)(1/2), an unnormalized derivative) is intentionally NOT
+  // maintained for an assembled L: the pipeline stage that consumes it is skipped,
+  // L_d is set directly above, and Lfunc_Taylor returns L_d. (It is not a plain k-th
+  // power of M's: the correct value would be (k*r)!/(r!)^k * Lam_d(M)^k.)
 
   // ---- attach the factor (owned by L; cleared in clear.c) ----
   L->factors = (Lfunc_t *) malloc(sizeof(Lfunc_t));

--- a/src/compute.c
+++ b/src/compute.c
@@ -285,9 +285,14 @@ static Lerror_t extract_and_assemble(Lfunc *L, uint64_t k)
   // ---- M's parameters: degree/k, cond^(1/k), mus every k-th ----
   Lparams_t Mp;
   Mp.degree = L->degree / k;
-  ulong rem; Mp.conductor = (uint64_t) n_rootrem(&rem, (ulong)L->conductor, (ulong)k);
+  uint64_t cbase; conductor_kth_root(L->conductor, k, &cbase); // exact: certified in prepare
+  Mp.conductor = cbase;
   Mp.normalisation = L->normalisation;    // M shares L's algebraic->analytic shift
   double *mmus = (double *) malloc(sizeof(double)*Mp.degree);
+  if (!mmus) {
+    printf("Attempt to allocate memory for M's mus failed. Exiting.\n");
+    exit(0);
+  }
   for (uint64_t i = 0; i < Mp.degree; i++)
     mmus[i] = L->mus[i*k] - L->normalisation; // M's algebraic mus (L->mus is analytic)
   Mp.mus = mmus;
@@ -307,22 +312,21 @@ static Lerror_t extract_and_assemble(Lfunc *L, uint64_t k)
 
   // ---- supply M_p = retained_f^(1/k) for primes up to nmax(M) ----
   // EVERY supplied factor (good AND bad) was certified an exact integer k-th power by
-  // power_extract_prepare, so re-extracting the exact integer root here is sound (a
-  // false L = M^k would have already been rejected with ERR_POWER). We feed M the EXACT
-  // fmpz_poly root, not a ball k-th root, so M sees the same point factors L did.
+  // power_extract_prepare, which kept the exact integer roots in L->cert_roots (one per
+  // retained factor, same order). We feed M those EXACT fmpz_poly roots -- no re-extraction
+  // -- so M sees the same point factors L did. (cert_roots is exact integers, so the acb
+  // conversion at M->wprec is exact, identical to a fresh extraction.)
   uint64_t Mmax = Lfunc_nmax(Mt);
   acb_poly_t Mp_poly; acb_poly_init(Mp_poly);
-  fmpz_poly_t Mp_z; fmpz_poly_init(Mp_z);
   for (uint64_t i = 0; i < L->n_retained; i++) {
     uint64_t p = L->retained_p[i];
     if (p > Mmax) continue;               // retention is in SUPPLY order, not prime
                                           // order (callers may append bad factors
                                           // last), so skip-and-continue, never break.
-    poly_exact_kth_root(Mp_z, &L->retained_f[i], k, M->wprec); // certified above
-    acb_poly_set_fmpz_poly(Mp_poly, Mp_z, M->wprec);
+    acb_poly_set_fmpz_poly(Mp_poly, &L->cert_roots[i], M->wprec); // certified in prepare
     Lfunc_use_lpoly(Mt, p, Mp_poly);
   }
-  fmpz_poly_clear(Mp_z); acb_poly_clear(Mp_poly);
+  acb_poly_clear(Mp_poly);
 
   ec |= Lfunc_compute(Mt);
   if (fatal_error(ec)) { Lfunc_clear(Mt); return ec; }
@@ -350,7 +354,15 @@ static Lerror_t extract_and_assemble(Lfunc *L, uint64_t k)
 
   // ---- attach the factor (owned by L; cleared in clear.c) ----
   L->factors = (Lfunc_t *) malloc(sizeof(Lfunc_t));
+  if (!L->factors) {
+    printf("Attempt to allocate memory for factors failed. Exiting.\n");
+    exit(0);
+  }
   L->factor_mults = (uint64_t *) malloc(sizeof(uint64_t));
+  if (!L->factor_mults) {
+    printf("Attempt to allocate memory for factor multiplicities failed. Exiting.\n");
+    exit(0);
+  }
   L->factors[0] = Mt; L->factor_mults[0] = k; L->n_factors = 1;
   return ec;                                          // may carry warnings
 }

--- a/src/compute.c
+++ b/src/compute.c
@@ -283,7 +283,7 @@ void final_ifft(Lfunc *L)
 static Lerror_t extract_and_assemble(Lfunc *L, uint64_t k)
 {
   // ---- M's parameters: degree/k, cond^(1/k), mus every k-th ----
-  Lparams_t Mp;
+  Lparams_t Mp = {0};
   Mp.degree = L->degree / k;
   uint64_t cbase; conductor_kth_root(L->conductor, k, &cbase); // exact: certified in prepare
   Mp.conductor = cbase;
@@ -315,6 +315,18 @@ static Lerror_t extract_and_assemble(Lfunc *L, uint64_t k)
   // retained factor, same order). We feed M those EXACT acb_poly roots -- no re-extraction
   // -- so M sees the same point factors L did.
   uint64_t Mmax = Lfunc_nmax(Mt);
+  uint64_t retained_max = 0;
+  for (uint64_t i = 0; i < L->n_retained; i++)
+    if (L->retained_p[i] <= Mmax && L->retained_p[i] > retained_max)
+      retained_max = L->retained_p[i];
+  if (retained_max < Mmax) {
+    ec |= ERR_INSUFF_EULER;
+    if (retained_max == 0 || !Lfunc_reduce_nmax(Mt, retained_max)) {
+      Lfunc_clear(Mt);
+      return ec;
+    }
+    Mmax = retained_max;
+  }
   acb_poly_t Mp_poly; acb_poly_init(Mp_poly);
   for (uint64_t i = 0; i < L->n_retained; i++) {
     uint64_t p = L->retained_p[i];
@@ -404,6 +416,9 @@ Lerror_t Lfunc_compute(Lfunc_t Lf)
   }
 
   int64_t prec=L->wprec;
+
+  if (fatal_error(L->retained_error))
+    return L->retained_error;
 
   // Reject perfect powers / repeated-factor L-functions up front: their doubled
   // zeros break zero-finding (stat_point -> ERR_DBL_ZERO -> RH count mismatch).

--- a/src/compute.c
+++ b/src/compute.c
@@ -308,6 +308,15 @@ Lerror_t Lfunc_compute(Lfunc_t Lf)
 
   int64_t prec=L->wprec;
 
+  // Reject perfect powers / repeated-factor L-functions up front: their doubled
+  // zeros break zero-finding (stat_point -> ERR_DBL_ZERO -> RH count mismatch).
+  // The caller can override via Lparams.allow_nonprimitive.
+  {
+    Lerror_t guard = power_guard(L);
+    if(fatal_error(guard))
+      return guard;
+  }
+
   #ifdef BUTHE
   buthe_Wf_error(L); // add the error for the missing tail
   if(verbose){printf("Buthe Wf = ");arb_printd(L->buthe_Wf,20);printf("\n");fflush(stdout);}

--- a/src/compute.c
+++ b/src/compute.c
@@ -310,7 +310,7 @@ Lerror_t Lfunc_compute(Lfunc_t Lf)
 
   // Reject perfect powers / repeated-factor L-functions up front: their doubled
   // zeros break zero-finding (stat_point -> ERR_DBL_ZERO -> RH count mismatch).
-  // The caller can override via Lparams.allow_nonprimitive.
+  // The caller can opt in to extraction via Lparams.extract_powers.
   {
     Lerror_t guard = power_guard(L);
     if(fatal_error(guard))

--- a/src/compute.c
+++ b/src/compute.c
@@ -325,8 +325,12 @@ static Lerror_t extract_and_assemble(Lfunc *L, uint64_t k)
   if (retained_max < Mmax) {
     ec |= ERR_INSUFF_EULER;
     if (retained_max == 0 || !Lfunc_reduce_nmax(Mt, retained_max)) {
+      // No usable factor for M at all: assembly is aborted with L's outputs
+      // (rank, zeros, sign, Taylor data) never populated. ERR_INSUFF_EULER alone
+      // is a warning, so returning it bare would read as success to fatal_error();
+      // make the abort fatal and keep the warning as the why.
       Lfunc_clear(Mt);
-      return ec;
+      return ec | ERR_POWER;
     }
     Mmax = retained_max;
   }

--- a/src/compute.c
+++ b/src/compute.c
@@ -290,8 +290,7 @@ static Lerror_t extract_and_assemble(Lfunc *L, uint64_t k)
   Mp.normalisation = L->normalisation;    // M shares L's algebraic->analytic shift
   double *mmus = (double *) malloc(sizeof(double)*Mp.degree);
   if (!mmus) {
-    printf("Attempt to allocate memory for M's mus failed. Exiting.\n");
-    exit(0);
+    return ERR_OOM;
   }
   for (uint64_t i = 0; i < Mp.degree; i++)
     mmus[i] = L->mus[i*k] - L->normalisation; // M's algebraic mus (L->mus is analytic)
@@ -311,11 +310,10 @@ static Lerror_t extract_and_assemble(Lfunc *L, uint64_t k)
   Lfunc *M = (Lfunc *) Mt;
 
   // ---- supply M_p = retained_f^(1/k) for primes up to nmax(M) ----
-  // EVERY supplied factor (good AND bad) was certified an exact integer k-th power by
-  // power_extract_prepare, which kept the exact integer roots in L->cert_roots (one per
-  // retained factor, same order). We feed M those EXACT fmpz_poly roots -- no re-extraction
-  // -- so M sees the same point factors L did. (cert_roots is exact integers, so the acb
-  // conversion at M->wprec is exact, identical to a fresh extraction.)
+  // EVERY supplied factor (good AND bad) was certified an exact k-th power by
+  // power_extract_prepare, which kept the exact algebraic roots in L->cert_roots (one per
+  // retained factor, same order). We feed M those EXACT acb_poly roots -- no re-extraction
+  // -- so M sees the same point factors L did.
   uint64_t Mmax = Lfunc_nmax(Mt);
   acb_poly_t Mp_poly; acb_poly_init(Mp_poly);
   for (uint64_t i = 0; i < L->n_retained; i++) {
@@ -323,7 +321,7 @@ static Lerror_t extract_and_assemble(Lfunc *L, uint64_t k)
     if (p > Mmax) continue;               // retention is in SUPPLY order, not prime
                                           // order (callers may append bad factors
                                           // last), so skip-and-continue, never break.
-    acb_poly_set_fmpz_poly(Mp_poly, &L->cert_roots[i], M->wprec); // certified in prepare
+    acb_poly_set(Mp_poly, &L->cert_roots[i]); // certified in prepare
     Lfunc_use_lpoly(Mt, p, Mp_poly);
   }
   acb_poly_clear(Mp_poly);
@@ -347,21 +345,29 @@ static Lerror_t extract_and_assemble(Lfunc *L, uint64_t k)
   acb_pow_ui(L->sign, M->sign, k, L->wprec);          // eps^k
   acb_pow_ui(L->sqrt_sign, M->sqrt_sign, k, L->wprec); // sqrt_sign^k
   arb_pow_ui(L->L_d, M->L_d, k, L->wprec);            // leading Taylor coeff ^ k
-  // Lam_d (= Lambda^(rank)(1/2), an unnormalized derivative) is intentionally NOT
-  // maintained for an assembled L: the pipeline stage that consumes it is skipped,
-  // L_d is set directly above, and Lfunc_Taylor returns L_d. (It is not a plain k-th
-  // power of M's: the correct value would be (k*r)!/(r!)^k * Lam_d(M)^k.)
+  
+  // Initialize Lam_d (= Lambda^(rank)(1/2))
+  arb_pow_ui(L->Lam_d, M->Lam_d, k, L->wprec);
+  arb_t t_fac; arb_init(t_fac);
+  arb_fac_ui(t_fac, k * M->rank, L->wprec);
+  arb_mul(L->Lam_d, L->Lam_d, t_fac, L->wprec);
+  arb_fac_ui(t_fac, M->rank, L->wprec);
+  arb_pow_ui(t_fac, t_fac, k, L->wprec);
+  arb_div(L->Lam_d, L->Lam_d, t_fac, L->wprec);
+  arb_clear(t_fac);
 
   // ---- attach the factor (owned by L; cleared in clear.c) ----
   L->factors = (Lfunc_t *) malloc(sizeof(Lfunc_t));
   if (!L->factors) {
-    printf("Attempt to allocate memory for factors failed. Exiting.\n");
-    exit(0);
+    Lfunc_clear(Mt);
+    return ERR_OOM;
   }
   L->factor_mults = (uint64_t *) malloc(sizeof(uint64_t));
   if (!L->factor_mults) {
-    printf("Attempt to allocate memory for factor multiplicities failed. Exiting.\n");
-    exit(0);
+    free(L->factors);
+    L->factors = NULL;
+    Lfunc_clear(Mt);
+    return ERR_OOM;
   }
   L->factors[0] = Mt; L->factor_mults[0] = k; L->n_factors = 1;
   return ec;                                          // may carry warnings

--- a/src/compute.c
+++ b/src/compute.c
@@ -311,7 +311,9 @@ static Lerror_t extract_and_assemble(Lfunc *L, uint64_t k)
   acb_set_ui(e_inv, 1); acb_div_ui(e_inv, e_inv, k, M->wprec);
   for (uint64_t i = 0; i < L->n_retained; i++) {
     uint64_t p = L->retained_p[i];
-    if (p > Mmax) break;                  // retained is in increasing prime order
+    if (p > Mmax) continue;               // retention is in SUPPLY order, not prime
+                                          // order (callers may append bad factors
+                                          // last), so skip-and-continue, never break.
     slong dlen = acb_poly_degree(&L->retained_f[i])/(slong)k + 1;
     acb_poly_pow_acb_series(Mp_poly, &L->retained_f[i], e_inv, dlen, M->wprec);
     Lfunc_use_lpoly(Mt, p, Mp_poly);

--- a/src/compute.c
+++ b/src/compute.c
@@ -306,14 +306,17 @@ static Lerror_t extract_and_assemble(Lfunc *L, uint64_t k)
   Lerror_t ec = ERR_SUCCESS;
   Lfunc_t Mt = Lfunc_init_advanced(&Mp, &ec);
   free(mmus);
-  if (fatal_error(ec)) return ec;         // e.g. ERR_BAD_DEGREE when M would be degree 1
+  if (fatal_error(ec)) {                  // e.g. ERR_BAD_DEGREE when M would be degree 1
+    if (Mt) Lfunc_clear(Mt);
+    return ec;
+  }
   Lfunc *M = (Lfunc *) Mt;
 
   // ---- supply M_p = retained_f^(1/k) for primes up to nmax(M) ----
   // EVERY supplied factor (good AND bad) was certified an exact k-th power by
-  // power_extract_prepare, which kept the exact algebraic roots in L->cert_roots (one per
-  // retained factor, same order). We feed M those EXACT acb_poly roots -- no re-extraction
-  // -- so M sees the same point factors L did.
+  // power_extract_prepare, which kept the exact integer roots in L->cert_roots (one per
+  // retained factor, same order). We feed M those exact integer roots through
+  // the fmpz API, so recursive extraction still has exact provenance.
   uint64_t Mmax = Lfunc_nmax(Mt);
   uint64_t retained_max = 0;
   for (uint64_t i = 0; i < L->n_retained; i++)
@@ -327,16 +330,18 @@ static Lerror_t extract_and_assemble(Lfunc *L, uint64_t k)
     }
     Mmax = retained_max;
   }
-  acb_poly_t Mp_poly; acb_poly_init(Mp_poly);
+  fmpz_poly_t Mp_poly; fmpz_poly_init(Mp_poly);
   for (uint64_t i = 0; i < L->n_retained; i++) {
     uint64_t p = L->retained_p[i];
     if (p > Mmax) continue;               // retention is in SUPPLY order, not prime
                                           // order (callers may append bad factors
                                           // last), so skip-and-continue, never break.
-    acb_poly_set(Mp_poly, &L->cert_roots[i]); // certified in prepare
-    Lfunc_use_lpoly(Mt, p, Mp_poly);
+    fmpz_poly_set(Mp_poly, &L->cert_roots[i]); // certified in prepare
+    ec |= Lfunc_use_lpoly_fmpz(Mt, p, Mp_poly);
+    if (fatal_error(ec)) break;
   }
-  acb_poly_clear(Mp_poly);
+  fmpz_poly_clear(Mp_poly);
+  if (fatal_error(ec)) { Lfunc_clear(Mt); return ec; }
 
   ec |= Lfunc_compute(Mt);
   if (fatal_error(ec)) { Lfunc_clear(Mt); return ec; }
@@ -357,7 +362,7 @@ static Lerror_t extract_and_assemble(Lfunc *L, uint64_t k)
   acb_pow_ui(L->sign, M->sign, k, L->wprec);          // eps^k
   acb_pow_ui(L->sqrt_sign, M->sqrt_sign, k, L->wprec); // sqrt_sign^k
   arb_pow_ui(L->L_d, M->L_d, k, L->wprec);            // leading Taylor coeff ^ k
-  
+
   // Initialize Lam_d (= Lambda^(rank)(1/2))
   arb_pow_ui(L->Lam_d, M->Lam_d, k, L->wprec);
   arb_t t_fac; arb_init(t_fac);
@@ -535,7 +540,7 @@ Lerror_t Lfunc_compute(Lfunc_t Lf)
 #ifdef TURING
   ecode|=turing_check_RH(L,prec);
 #endif
-  
+
 #endif
 
   return ecode;

--- a/src/compute.c
+++ b/src/compute.c
@@ -1,4 +1,5 @@
 #include <flint/acb_poly.h>
+#include <flint/ulong_extras.h>
 #include "glfunc.h"
 #include "glfunc_internals.h"
 #include <stdlib.h>
@@ -276,6 +277,75 @@ void final_ifft(Lfunc *L)
   }
 } /* final_ifft */
 
+// Build M = L^(1/k), compute it, and materialize its data into L. Returns the
+// error code from M's computation (fatal bits abort the assembly).
+static Lerror_t extract_and_assemble(Lfunc *L, uint64_t k)
+{
+  // ---- M's parameters: degree/k, cond^(1/k), mus every k-th ----
+  Lparams_t Mp;
+  Mp.degree = L->degree / k;
+  ulong rem; Mp.conductor = (uint64_t) n_rootrem(&rem, (ulong)L->conductor, (ulong)k);
+  Mp.normalisation = L->normalisation;    // M shares L's algebraic->analytic shift
+  double *mmus = (double *) malloc(sizeof(double)*Mp.degree);
+  for (uint64_t i = 0; i < Mp.degree; i++)
+    mmus[i] = L->mus[i*k] - L->normalisation; // M's algebraic mus (L->mus is analytic)
+  Mp.mus = mmus;
+  // CRITICAL: M is fed the RAW (algebraic) factors retained_f^(1/k), so M must carry
+  // the same normalisation L was created with; M->use_lpoly then re-normalises them
+  // exactly as L's did. (Setting normalisation=0 here computes M in the wrong
+  // normalization and produces garbage / RH errors.)
+  Mp.target_prec = L->target_prec; Mp.wprec = 0; Mp.gprec = 0;
+  Mp.self_dual = L->self_dual; Mp.rank = DK; Mp.cache_dir = L->cache_dir;
+  Mp.extract_powers = YES;                // inherit -> free recursion for M^(k*k')
+
+  Lerror_t ec = ERR_SUCCESS;
+  Lfunc_t Mt = Lfunc_init_advanced(&Mp, &ec);
+  free(mmus);
+  if (fatal_error(ec)) return ec;         // e.g. ERR_BAD_DEGREE when M would be degree 1
+  Lfunc *M = (Lfunc *) Mt;
+
+  // ---- supply M_p = retained_f^(1/k) for primes up to nmax(M) ----
+  uint64_t Mmax = Lfunc_nmax(Mt);
+  acb_poly_t Mp_poly; acb_poly_init(Mp_poly);
+  acb_t e_inv; acb_init(e_inv);
+  acb_set_ui(e_inv, 1); acb_div_ui(e_inv, e_inv, k, M->wprec);
+  for (uint64_t i = 0; i < L->n_retained; i++) {
+    uint64_t p = L->retained_p[i];
+    if (p > Mmax) break;                  // retained is in increasing prime order
+    slong dlen = acb_poly_degree(&L->retained_f[i])/(slong)k + 1;
+    acb_poly_pow_acb_series(Mp_poly, &L->retained_f[i], e_inv, dlen, M->wprec);
+    Lfunc_use_lpoly(Mt, p, Mp_poly);
+  }
+  acb_clear(e_inv); acb_poly_clear(Mp_poly);
+
+  ec |= Lfunc_compute(Mt);
+  if (fatal_error(ec)) { Lfunc_clear(Mt); return ec; }
+
+  // ---- materialize M^k into L ----
+  L->rank = (int64_t) k * M->rank;
+  // Emit each of M's isolated ordinates k times. find_zeros fills zeros[side][0..]
+  // with positive ordinates; unfilled trailing slots stay exactly 0 (arb_is_zero),
+  // which marks the end. (For self_dual M, side 1 is empty -> L side 1 is empty too.)
+  for (uint64_t side = 0; side < 2; side++) {
+    uint64_t dst = 0;
+    for (uint64_t src = 0; src < MAX_ZEROS && dst < MAX_ZEROS; src++) {
+      if (arb_is_zero(M->zeros[side][src])) break; // no more isolated zeros
+      for (uint64_t r = 0; r < k && dst < MAX_ZEROS; r++)
+        arb_set(L->zeros[side][dst++], M->zeros[side][src]);
+    }
+  }
+  acb_pow_ui(L->sign, M->sign, k, L->wprec);          // eps^k
+  acb_pow_ui(L->sqrt_sign, M->sqrt_sign, k, L->wprec); // sqrt_sign^k
+  arb_pow_ui(L->L_d, M->L_d, k, L->wprec);            // leading Taylor coeff ^ k
+  arb_pow_ui(L->Lam_d, M->Lam_d, k, L->wprec); // Lambda_L = Lambda_M^k
+
+  // ---- attach the factor (owned by L; cleared in clear.c) ----
+  L->factors = (Lfunc_t *) malloc(sizeof(Lfunc_t));
+  L->factor_mults = (uint64_t *) malloc(sizeof(uint64_t));
+  L->factors[0] = Mt; L->factor_mults[0] = k; L->n_factors = 1;
+  return ec;                                          // may carry warnings
+}
+
 // this is called by the user to compute all the bits of the Lfunc we expect them to want
 // including Lambda(t) for t =0,1/A,2/A,....
 // the zeros up to height 64/degree
@@ -313,8 +383,15 @@ Lerror_t Lfunc_compute(Lfunc_t Lf)
   // The caller can opt in to extraction via Lparams.extract_powers.
   {
     Lerror_t guard = power_guard(L);
-    if(fatal_error(guard))
-      return guard;
+    if (fatal_error(guard)) {
+      if (L->extract_powers != YES)
+        return guard;                    // opted out: reject as before
+      uint64_t k = 0;
+      Lerror_t prep = power_extract_prepare(L, &k);
+      if (fatal_error(prep))
+        return prep;                     // confirmed-not-a-clean-power -> ERR_POWER
+      return extract_and_assemble(L, k); // build M, compute, assemble; done
+    }
   }
 
   #ifdef BUTHE

--- a/src/compute.c
+++ b/src/compute.c
@@ -1,4 +1,5 @@
 #include <flint/acb_poly.h>
+#include <flint/fmpz_poly.h>
 #include <flint/ulong_extras.h>
 #include "glfunc.h"
 #include "glfunc_internals.h"
@@ -305,24 +306,23 @@ static Lerror_t extract_and_assemble(Lfunc *L, uint64_t k)
   Lfunc *M = (Lfunc *) Mt;
 
   // ---- supply M_p = retained_f^(1/k) for primes up to nmax(M) ----
-  // Bad (lower-degree) primes are k-th-rooted here WITHOUT a separate certificate:
-  // the good-prime k-th-power certificate plus the perfect-k-th-power conductor
-  // already force L = M^k globally, hence every local factor (good or bad) is M_p^k,
-  // so taking the k-th root of each retained factor is sound.
+  // EVERY supplied factor (good AND bad) was certified an exact integer k-th power by
+  // power_extract_prepare, so re-extracting the exact integer root here is sound (a
+  // false L = M^k would have already been rejected with ERR_POWER). We feed M the EXACT
+  // fmpz_poly root, not a ball k-th root, so M sees the same point factors L did.
   uint64_t Mmax = Lfunc_nmax(Mt);
   acb_poly_t Mp_poly; acb_poly_init(Mp_poly);
-  acb_t e_inv; acb_init(e_inv);
-  acb_set_ui(e_inv, 1); acb_div_ui(e_inv, e_inv, k, M->wprec);
+  fmpz_poly_t Mp_z; fmpz_poly_init(Mp_z);
   for (uint64_t i = 0; i < L->n_retained; i++) {
     uint64_t p = L->retained_p[i];
     if (p > Mmax) continue;               // retention is in SUPPLY order, not prime
                                           // order (callers may append bad factors
                                           // last), so skip-and-continue, never break.
-    slong dlen = acb_poly_degree(&L->retained_f[i])/(slong)k + 1;
-    acb_poly_pow_acb_series(Mp_poly, &L->retained_f[i], e_inv, dlen, M->wprec);
+    poly_exact_kth_root(Mp_z, &L->retained_f[i], k, M->wprec); // certified above
+    acb_poly_set_fmpz_poly(Mp_poly, Mp_z, M->wprec);
     Lfunc_use_lpoly(Mt, p, Mp_poly);
   }
-  acb_clear(e_inv); acb_poly_clear(Mp_poly);
+  fmpz_poly_clear(Mp_z); acb_poly_clear(Mp_poly);
 
   ec |= Lfunc_compute(Mt);
   if (fatal_error(ec)) { Lfunc_clear(Mt); return ec; }

--- a/src/glfunc.c
+++ b/src/glfunc.c
@@ -160,7 +160,7 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
   // we sort the mus so we can name G cache files canonically
   qsort(L->mus, L->degree, sizeof(double), double_comp);
 
-  L->target_prec = Lp->target_prec;
+  L->target_prec = (Lp->target_prec > 0) ? Lp->target_prec : DEFAULT_TARGET_PREC;
   arb_init(L->zero_prec);
   arb_set_ui(L->zero_prec, 1);
   arb_mul_2exp_si(L->zero_prec, L->zero_prec, -L->target_prec - 1);

--- a/src/glfunc.c
+++ b/src/glfunc.c
@@ -180,6 +180,7 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
   L->gprec = Lp->gprec;
   L->self_dual = Lp->self_dual;
   L->rank = Lp->rank;
+  L->allow_nonprimitive = Lp->allow_nonprimitive;
   L->cache_dir = Lp->cache_dir;
 
   // See Lemma 2 of M_error1.pdf, Lemma 5 of g.pdf
@@ -400,6 +401,7 @@ Lfunc_t Lfunc_init(uint64_t degree, uint64_t conductor, double normalisation,
   Lp.cache_dir = ".";
   Lp.gprec = 0; // We will try to do something sensible
   Lp.wprec = 0; // ditto
+  Lp.allow_nonprimitive = NO; // guard on by default
 
   // Lfunc_init_advanced copies Lp.mus into L->mus, so this scratch array is ours
   // to free; otherwise it leaks (Lp is a stack local that goes out of scope).

--- a/src/glfunc.c
+++ b/src/glfunc.c
@@ -34,6 +34,10 @@ void fprint_errors(FILE *f, Lerror_t ecode) {
     fprintf(f, "Fatal error in stationary point routine.\n");
   if (ecode & ERR_SPEC_VALUE)
     fprintf(f, "Fatal error in special value routine.\n");
+  if (ecode & ERR_POWER)
+    fprintf(f, "L-function appears to be a perfect power or to have a repeated "
+               "primitive factor (doubled zeros); set Lparams.allow_nonprimitive "
+               "to compute anyway.\n");
   // warnings
   if (ecode & ERR_INSUFF_EULER)
     fprintf(f, "Don't appear to have enough Euler factors.\n");

--- a/src/glfunc.c
+++ b/src/glfunc.c
@@ -351,6 +351,9 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
 
   arb_init(L->one_over_root_N);
   arb_init(L->sum_ans);
+  arb_init(L->moment_sum);       // power-guard 2nd-moment accumulator (starts at 0)
+  L->moment_count = 0;
+  L->seen_sqfree_fulldeg = false;
   acb_init(L->sign);
   acb_init(L->sqrt_sign);
   L->allocated_M = 8192;

--- a/src/glfunc.c
+++ b/src/glfunc.c
@@ -36,8 +36,8 @@ void fprint_errors(FILE *f, Lerror_t ecode) {
     fprintf(f, "Fatal error in special value routine.\n");
   if (ecode & ERR_POWER)
     fprintf(f, "L-function appears to be a perfect power or to have a repeated "
-               "primitive factor (doubled zeros); set Lparams.allow_nonprimitive "
-               "to compute anyway.\n");
+               "primitive factor (doubled zeros); set Lparams.extract_powers "
+               "= YES to extract and assemble.\n");
   // warnings
   if (ecode & ERR_INSUFF_EULER)
     fprintf(f, "Don't appear to have enough Euler factors.\n");
@@ -180,7 +180,7 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
   L->gprec = Lp->gprec;
   L->self_dual = Lp->self_dual;
   L->rank = Lp->rank;
-  L->allow_nonprimitive = Lp->allow_nonprimitive;
+  L->extract_powers = Lp->extract_powers;
   L->cache_dir = Lp->cache_dir;
 
   // See Lemma 2 of M_error1.pdf, Lemma 5 of g.pdf
@@ -404,7 +404,7 @@ Lfunc_t Lfunc_init(uint64_t degree, uint64_t conductor, double normalisation,
   Lp.cache_dir = ".";
   Lp.gprec = 0; // We will try to do something sensible
   Lp.wprec = 0; // ditto
-  Lp.allow_nonprimitive = NO; // guard on by default
+  Lp.extract_powers = NO; // guard on by default
 
   // Lfunc_init_advanced copies Lp.mus into L->mus, so this scratch array is ours
   // to free; otherwise it leaks (Lp is a stack local that goes out of scope).

--- a/src/glfunc.c
+++ b/src/glfunc.c
@@ -37,7 +37,7 @@ void fprint_errors(FILE *f, Lerror_t ecode) {
   if (ecode & ERR_POWER)
     fprintf(f, "L-function appears to be a perfect power or to have a repeated "
                "primitive factor (doubled zeros); set Lparams.extract_powers "
-               "= YES to extract and assemble.\n");
+               "= YES and supply exact fmpz Euler factors to extract and assemble.\n");
   // warnings
   if (ecode & ERR_INSUFF_EULER)
     fprintf(f, "Don't appear to have enough Euler factors.\n");
@@ -355,7 +355,9 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
   L->moment_count = 0;
   L->seen_sqfree_fulldeg = false;
   L->retained_p = NULL; L->retained_f = NULL;
+  L->retained_fmpz = NULL; L->retained_is_exact = NULL;
   L->n_retained = 0; L->retained_cap = 0;
+  L->retained_error = ERR_SUCCESS;
   L->cert_roots = NULL; L->n_cert_roots = 0;
   L->factors = NULL; L->factor_mults = NULL; L->n_factors = 0;
   acb_init(L->sign);
@@ -391,7 +393,7 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
 
 Lfunc_t Lfunc_init(uint64_t degree, uint64_t conductor, double normalisation,
                    const double *mus, Lerror_t *ecode) {
-  Lparams_t Lp;
+  Lparams_t Lp = {0};
   Lp.degree = degree;
   Lp.conductor = conductor;
   Lp.normalisation = normalisation;

--- a/src/glfunc.c
+++ b/src/glfunc.c
@@ -354,6 +354,9 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
   arb_init(L->moment_sum);       // power-guard 2nd-moment accumulator (starts at 0)
   L->moment_count = 0;
   L->seen_sqfree_fulldeg = false;
+  L->retained_p = NULL; L->retained_f = NULL;
+  L->n_retained = 0; L->retained_cap = 0;
+  L->factors = NULL; L->factor_mults = NULL; L->n_factors = 0;
   acb_init(L->sign);
   acb_init(L->sqrt_sign);
   L->allocated_M = 8192;

--- a/src/glfunc.c
+++ b/src/glfunc.c
@@ -356,6 +356,7 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
   L->seen_sqfree_fulldeg = false;
   L->retained_p = NULL; L->retained_f = NULL;
   L->n_retained = 0; L->retained_cap = 0;
+  L->cert_roots = NULL; L->n_cert_roots = 0;
   L->factors = NULL; L->factor_mults = NULL; L->n_factors = 0;
   acb_init(L->sign);
   acb_init(L->sqrt_sign);

--- a/src/io.c
+++ b/src/io.c
@@ -86,6 +86,14 @@ Lplot_t *Lfunc_plot_data(Lfunc_t LL, uint64_t side, double max_t, uint64_t n_poi
   return Lp;
 }
 
+uint64_t Lfunc_factors(Lfunc_t L, Lfunc_t **factors, uint64_t **mults)
+{
+  Lfunc *LL = (Lfunc *) L;
+  if (factors) *factors = LL->factors;
+  if (mults)   *mults   = LL->factor_mults;
+  return LL->n_factors;
+}
+
 arb_srcptr Lfunc_Taylor(Lfunc_t LL)
 {
   Lfunc *L=(Lfunc *) LL;

--- a/src/io.c
+++ b/src/io.c
@@ -60,6 +60,9 @@ double normalised(Lfunc *L, uint64_t side, uint64_t ptr, double t)
 Lplot_t *Lfunc_plot_data(Lfunc_t LL, uint64_t side, double max_t, uint64_t n_points)
 {
   Lfunc *L=(Lfunc *) LL;
+  if(L->n_factors > 0)
+    return (Lplot_t *) NULL;
+
   Lplot_t *Lp;
   Lp=(Lplot_t *)malloc(sizeof(Lplot_t));
   if(!Lp)

--- a/src/special_values.c
+++ b/src/special_values.c
@@ -433,6 +433,8 @@ extern "C"{
     Lfunc *L=(Lfunc *) LL;
 
     // Assembled power L = M^k: value/derivative follow from L(s) = M(s)^k.
+    // Part B produces exactly one factor; Part C (N*M^k) will generalize this to
+    // a product over n_factors >= 1.
     if (L->n_factors == 1) {
       Lfunc_t Mt = L->factors[0];
       uint64_t k = L->factor_mults[0];

--- a/src/special_values.c
+++ b/src/special_values.c
@@ -443,6 +443,11 @@ extern "C"{
       Lerror_t fecode = Lfunc_special_value_choice(vM, do_dash ? vMd : NULL, Mt,
                                                    alg_res, alg_ims, lam_p, do_dash);
       acb_pow_ui(res, vM, (ulong)k, M->wprec);              // M(s)^k
+      // CAVEAT: the derivative branch (do_dash=true) is only meaningful with lam_p=true
+      // (the completed Lambda). The non-completed L'(s) is not implemented anywhere in
+      // the library -- Lam_dash_to_L_dash is a no-op -- so M(s)^k differentiation via
+      // the (vM, vMd) chain below is correct only for Lambda. In normal use this is
+      // unreachable: the public Lfunc_special_value only ever requests do_dash=false.
       if (do_dash && res_dash) {                            // k M^{k-1} M'
         acb_t t; acb_init(t);
         acb_pow_ui(t, vM, (ulong)(k-1), M->wprec);

--- a/src/special_values.c
+++ b/src/special_values.c
@@ -431,6 +431,27 @@ extern "C"{
     
     Lerror_t ecode=ERR_SUCCESS;
     Lfunc *L=(Lfunc *) LL;
+
+    // Assembled power L = M^k: value/derivative follow from L(s) = M(s)^k.
+    if (L->n_factors == 1) {
+      Lfunc_t Mt = L->factors[0];
+      uint64_t k = L->factor_mults[0];
+      Lfunc *M = (Lfunc *) Mt;
+      acb_t vM, vMd; acb_init(vM); acb_init(vMd);
+      Lerror_t fecode = Lfunc_special_value_choice(vM, do_dash ? vMd : NULL, Mt,
+                                                   alg_res, alg_ims, lam_p, do_dash);
+      acb_pow_ui(res, vM, (ulong)k, M->wprec);              // M(s)^k
+      if (do_dash && res_dash) {                            // k M^{k-1} M'
+        acb_t t; acb_init(t);
+        acb_pow_ui(t, vM, (ulong)(k-1), M->wprec);
+        acb_mul(t, t, vMd, M->wprec);
+        acb_mul_ui(res_dash, t, (ulong)k, M->wprec);
+        acb_clear(t);
+      }
+      acb_clear(vM); acb_clear(vMd);
+      return fecode;
+    }
+
     int64_t prec=L->wprec;
     //printf("Algebraic s = %f + i%f\n",alg_res,alg_ims);
 

--- a/src/special_values.c
+++ b/src/special_values.c
@@ -436,6 +436,12 @@ extern "C"{
     // Part B produces exactly one factor; Part C (N*M^k) will generalize this to
     // a product over n_factors >= 1.
     if (L->n_factors == 1) {
+      if (do_dash && !lam_p) {
+        // The non-completed L'(s) is not implemented anywhere in the library
+        // -- Lam_dash_to_L_dash is a no-op -- so we must explicitly fail
+        // rather than return mathematically incorrect results.
+        return ERR_SPEC_VALUE;
+      }
       Lfunc_t Mt = L->factors[0];
       uint64_t k = L->factor_mults[0];
       Lfunc *M = (Lfunc *) Mt;
@@ -443,11 +449,6 @@ extern "C"{
       Lerror_t fecode = Lfunc_special_value_choice(vM, do_dash ? vMd : NULL, Mt,
                                                    alg_res, alg_ims, lam_p, do_dash);
       acb_pow_ui(res, vM, (ulong)k, M->wprec);              // M(s)^k
-      // CAVEAT: the derivative branch (do_dash=true) is only meaningful with lam_p=true
-      // (the completed Lambda). The non-completed L'(s) is not implemented anywhere in
-      // the library -- Lam_dash_to_L_dash is a no-op -- so M(s)^k differentiation via
-      // the (vM, vMd) chain below is correct only for Lambda. In normal use this is
-      // unreachable: the public Lfunc_special_value only ever requests do_dash=false.
       if (do_dash && res_dash) {                            // k M^{k-1} M'
         acb_t t; acb_init(t);
         acb_pow_ui(t, vM, (ulong)(k-1), M->wprec);

--- a/test/extract_power_test.c
+++ b/test/extract_power_test.c
@@ -120,6 +120,17 @@ int main(void)
   { arb_t am; arb_init(am); acb_abs(am, Lfunc_sign(L2), 100);
     arb_sub_ui(am, am, 1, 100); assert(arb_contains_zero(am)); arb_clear(am); } // |eps|=1
   acb_clear(s2);
+
+  // (Task 4) Special value: L2(1.5) == Eref(1.5)^2
+  acb_t vL, vE, vEk; acb_init(vL); acb_init(vE); acb_init(vEk);
+  Lerror_t sv = ERR_SUCCESS;
+  sv |= Lfunc_special_value(vE, Eref, 1.5, 0.0);
+  sv |= Lfunc_special_value(vL, L2, 1.5, 0.0);
+  assert(!fatal_error(sv));
+  acb_pow_ui(vEk, vE, 2, 100);          // L(s) = E(s)^2
+  assert(acb_overlaps(vL, vEk));
+  acb_clear(vL); acb_clear(vE); acb_clear(vEk);
+
   Lfunc_clear(L2);
   Lfunc_clear(Eref);
 

--- a/test/extract_power_test.c
+++ b/test/extract_power_test.c
@@ -1,0 +1,73 @@
+// Hermetic extraction test: builds E^2 and E^3 from an elliptic curve's
+// Euler factors and checks extraction recovers E and assembles L = E^k.
+// Asserts on certified balls only. Build with assertions on.
+#include <assert.h>
+#include <stdio.h>
+#include <flint/acb_poly.h>
+#include "glfunc.h"
+
+// 37.a1 Euler polynomials L_p(T) = 1 + c1*T + p*T^2, stored as {p, c1, p};
+// the bad prime 37 is {1, 1} (handled in Ep below). These c1 are the POLYNOMIAL
+// T^1 coefficients (c1 = -a_p, NOT the curve's a_p), copied VERBATIM from the
+// euler_factors map in examples/ec_37.a1.cpp. Do not negate them.
+static const long ap37[][3] = {
+  {2,2,2},{3,3,3},{5,2,5},{7,1,7},{11,5,11},{13,2,13},{17,0,17},
+  {19,0,19},{23,-2,23},{29,-6,29},{31,4,31},{41,9,41},{43,-2,43},{47,9,47},
+  {53,-1,53},{59,-8,59},{61,8,61},{67,-8,67},{71,-9,71},{73,1,73},{79,-4,79},
+  {83,15,83},{89,-4,89},{97,-4,97},{101,-3,101},{103,-18,103},{107,12,107},
+  {109,16,109},{113,18,113},{127,-1,127},{131,12,131},{137,6,137},{139,-4,139},
+};
+// Sanity check against examples/ec_37.a1.cpp: p=2 -> {1,2,2}, p=23 -> {1,-2,23}.
+
+static int k_param; // 2 or 3: the callback raises E_p to this power
+
+static void Ep(acb_poly_t poly, uint64_t p) // E_p(T) for 37.a1, degree 2 (or 1 at p=37)
+{
+  acb_poly_zero(poly);
+  if (p == 37) { acb_poly_set_coeff_si(poly,0,1); acb_poly_set_coeff_si(poly,1,1); return; }
+  for (size_t i = 0; i < sizeof(ap37)/sizeof(ap37[0]); i++)
+    if ((uint64_t)ap37[i][0] == p) {
+      acb_poly_set_coeff_si(poly,0,1);
+      acb_poly_set_coeff_si(poly,1,ap37[i][1]);
+      acb_poly_set_coeff_si(poly,2,ap37[i][2]);
+      return;
+    }
+  // unknown prime: leave zero -> Lfunc_use_all_lpolys short-circuits (fine; see plan)
+}
+
+// callback for L = E^k: supply (E_p)^k
+static void lk_callback(acb_poly_t poly, uint64_t p, int d, int64_t prec, void *param)
+{
+  (void)d; (void)prec; (void)param;
+  acb_poly_t ep; acb_poly_init(ep);
+  Ep(ep, p);
+  if (acb_poly_is_zero(ep)) { acb_poly_zero(poly); acb_poly_clear(ep); return; }
+  acb_poly_pow_ui(poly, ep, (ulong)k_param, prec);
+  acb_poly_clear(ep);
+}
+
+// callback for E itself: supply E_p
+static void e_callback(acb_poly_t poly, uint64_t p, int d, int64_t prec, void *param)
+{
+  (void)d; (void)prec; (void)param;
+  Ep(poly, p);
+}
+
+int main(void)
+{
+  Lerror_t ec = ERR_SUCCESS;
+  double mus[2] = {0,1};
+
+  // (Task 2) A primitive L (E itself) reports zero factors.
+  Lfunc_t E = Lfunc_init(2, 37, 0.5, mus, &ec);
+  assert(!fatal_error(ec));
+  ec |= Lfunc_use_all_lpolys(E, e_callback, NULL);
+  ec |= Lfunc_compute(E);
+  assert(!fatal_error(ec));
+  Lfunc_t *facs = NULL; uint64_t *mults = NULL;
+  assert(Lfunc_factors(E, &facs, &mults) == 0);
+  Lfunc_clear(E);
+
+  printf("extract_power_test: Task 2 OK\n");
+  return 0;
+}

--- a/test/extract_power_test.c
+++ b/test/extract_power_test.c
@@ -378,5 +378,58 @@ int main(void)
   }
   printf("extract_power_test: complex non-self-dual boundary OK (ERR_POWER)\n");
 
+  // ---- E^4 (degree 8, even k=4): multi-k candidate recovery (Fix C) ----
+  // L = E^4 has conductor 37^4 (maximal perfect-power exponent E=4) and 2nd moment ~16,
+  // so the moment estimate k0~4. The candidate loop considers divisors of E that are
+  // multiples of k0 -- here only {4} -- and the rigorous certificate confirms k=4: every
+  // (E_p)^4 is an exact 4th power and the mus split into equal blocks of 4. The single-k
+  // (round(sqrt(moment))) predecessor could only ever have tried one exponent; this proves
+  // k=4 is recovered and a degree-8 4th power is assembled end-to-end.
+  k_param = 4;
+  Lfunc_t Eref4 = Lfunc_init(2, 37, 0.5, mus, &ec);
+  ec = ERR_SUCCESS;
+  ec |= Lfunc_use_all_lpolys(Eref4, e_callback, NULL);
+  ec |= Lfunc_compute(Eref4);
+  assert(!fatal_error(ec));
+
+  Lparams_t Lp4 = { .degree = 8, .conductor = 37ull*37ull*37ull*37ull, .normalisation = 0.5,
+                    .mus = (double[]){0,0,0,0,1,1,1,1}, .target_prec = 100, .wprec = 0,
+                    .gprec = 0, .self_dual = YES, .rank = DK, .cache_dir = ".",
+                    .extract_powers = YES };
+  Lerror_t e4 = ERR_SUCCESS;
+  Lfunc_t L4 = Lfunc_init_advanced(&Lp4, &e4);
+  assert(!fatal_error(e4));
+  e4 |= Lfunc_use_all_lpolys(L4, lk_callback, NULL);
+  e4 |= Lfunc_compute(L4);
+  assert(!fatal_error(e4));
+
+  Lfunc_t *f4 = NULL; uint64_t *m4 = NULL;
+  assert(Lfunc_factors(L4, &f4, &m4) == 1 && m4[0] == 4); // recovered k=4
+  assert(Lfunc_rank(f4[0]) == rankE);
+  assert(Lfunc_rank(L4) == 4*rankE);
+  arb_srcptr zE4 = Lfunc_zeros(Eref4, 0);
+  arb_srcptr z4  = Lfunc_zeros(L4, 0);
+  assert(arb_overlaps((arb_ptr)(z4+0), (arb_ptr)(zE4+0)));
+  assert(arb_overlaps((arb_ptr)(z4+1), (arb_ptr)(zE4+0)));
+  assert(arb_overlaps((arb_ptr)(z4+2), (arb_ptr)(zE4+0)));
+  assert(arb_overlaps((arb_ptr)(z4+3), (arb_ptr)(zE4+0))); // quadrupled
+  assert(arb_overlaps((arb_ptr)(z4+4), (arb_ptr)(zE4+1)));
+  acb_t s4; acb_init(s4); acb_pow_ui(s4, Lfunc_sign(Eref4), 4, 100);
+  assert(acb_overlaps(s4, Lfunc_sign(L4))); acb_clear(s4); // sign(E)^4
+  acb_t vL4, vE4, vE4k; acb_init(vL4); acb_init(vE4); acb_init(vE4k);
+  Lerror_t sv4 = Lfunc_special_value(vE4, Eref4, 1.5, 0.0)
+               | Lfunc_special_value(vL4, L4, 1.5, 0.0);
+  assert(!fatal_error(sv4));
+  acb_pow_ui(vE4k, vE4, 4, 100);
+  assert(acb_overlaps(vL4, vE4k));
+  acb_clear(vL4); acb_clear(vE4); acb_clear(vE4k);
+  { arb_t tk; arb_init(tk);
+    arb_pow_ui(tk, Lfunc_Taylor(Eref4), 4, 100);
+    assert(arb_overlaps((arb_ptr)Lfunc_Taylor(L4), tk));
+    arb_clear(tk); }
+  Lfunc_clear(L4); Lfunc_clear(Eref4);
+
+  printf("extract_power_test: E^4 multi-k recovery OK (k=4)\n");
+
   return 0;
 }

--- a/test/extract_power_test.c
+++ b/test/extract_power_test.c
@@ -129,7 +129,8 @@ static void conductor1_square_callback_z(fmpz_poly_t poly, uint64_t p, int d, vo
 // coefficient (i times E_p's), so L = M^2 has complex Euler factors but the same 2nd
 // moment and perfect-square conductor as E^2 (detection still finds k=2). The exact
 // integer certificate requires real-integer coefficients, so it must refuse this with
-// ERR_POWER -- extraction supports rational-integer L-functions only (feat: lfunctions-5g6).
+// ERR_POWER -- extraction supports rational-integer L-functions only (complex
+// extraction is a tracked follow-up).
 static void lk_complex_callback(acb_poly_t poly, uint64_t p, int d, int64_t prec, void *param)
 {
   (void)d; (void)param;

--- a/test/extract_power_test.c
+++ b/test/extract_power_test.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <flint/acb.h>
 #include <flint/acb_poly.h>
+#include <flint/fmpz_poly.h>
 #include "glfunc.h"
 
 // 37.a1 Euler polynomials L_p(T) = 1 + c1*T + p*T^2, stored as {p, c1, p};
@@ -38,6 +39,20 @@ static void Ep(acb_poly_t poly, uint64_t p) // E_p(T) for 37.a1, degree 2 (or 1 
   // unknown prime: leave zero -> Lfunc_use_all_lpolys short-circuits (fine; see plan)
 }
 
+static void Ep_z(fmpz_poly_t poly, uint64_t p) // exact E_p(T)
+{
+  fmpz_poly_zero(poly);
+  if (p == 37) { fmpz_poly_set_coeff_ui(poly,0,1); fmpz_poly_set_coeff_ui(poly,1,1); return; }
+  for (size_t i = 0; i < sizeof(ap37)/sizeof(ap37[0]); i++)
+    if ((uint64_t)ap37[i][0] == p) {
+      fmpz_poly_set_coeff_ui(poly,0,1);
+      fmpz_poly_set_coeff_si(poly,1,ap37[i][1]);
+      fmpz_poly_set_coeff_ui(poly,2,(ulong)ap37[i][2]);
+      return;
+    }
+  // unknown prime: leave zero -> Lfunc_use_all_lpolys_fmpz short-circuits
+}
+
 // callback for L = E^k: supply (E_p)^k
 static void lk_callback(acb_poly_t poly, uint64_t p, int d, int64_t prec, void *param)
 {
@@ -47,6 +62,25 @@ static void lk_callback(acb_poly_t poly, uint64_t p, int d, int64_t prec, void *
   if (acb_poly_is_zero(ep)) { acb_poly_zero(poly); acb_poly_clear(ep); return; }
   acb_poly_pow_ui(poly, ep, (ulong)k_param, prec);
   acb_poly_clear(ep);
+}
+
+// exact callback for L = E^k: supply (E_p)^k through fmpz provenance
+static void lk_callback_z(fmpz_poly_t poly, uint64_t p, int d, void *param)
+{
+  (void)d; (void)param;
+  fmpz_poly_t ep; fmpz_poly_init(ep);
+  Ep_z(ep, p);
+  if (fmpz_poly_is_zero(ep)) { fmpz_poly_zero(poly); fmpz_poly_clear(ep); return; }
+  fmpz_poly_pow(poly, ep, (ulong)k_param);
+  fmpz_poly_clear(ep);
+}
+
+static void lk_first_prime_only_callback_z(fmpz_poly_t poly, uint64_t p, int d, void *param)
+{
+  if (p == 2)
+    lk_callback_z(poly, p, d, param);
+  else
+    fmpz_poly_zero(poly);
 }
 
 // callback for E itself: supply E_p
@@ -66,20 +100,14 @@ static void lk_inexact_callback(acb_poly_t poly, uint64_t p, int d, int64_t prec
     arb_add_error_2exp_si(acb_realref(acb_poly_get_coeff_ptr(poly, 0)), -150);
 }
 
-// callback for C1: like lk_callback (E^2) but OVERRIDES the bad prime 37 with a
-// non-square degree-2 factor 1 - 3T + T^2. Every GOOD factor is a genuine square,
-// but the bad factor is not, so L = M^2 is false and extraction must be refused.
-// Pre-fix (good-prime-only certificate) the uncertified bad factor was k-th-rooted
-// blindly and L extracted (n_factors=1); the exact-integer certificate over ALL
-// factors must now reject with ERR_POWER.
-static void lk_badprime_callback(acb_poly_t poly, uint64_t p, int d, int64_t prec, void *param)
+static void lk_badprime_callback_z(fmpz_poly_t poly, uint64_t p, int d, void *param)
 {
-  lk_callback(poly, p, d, prec, param);
-  if (p == 37) {                       // overwrite the bad factor with a non-square
-    acb_poly_zero(poly);
-    acb_poly_set_coeff_si(poly, 0, 1);
-    acb_poly_set_coeff_si(poly, 1, -3);
-    acb_poly_set_coeff_si(poly, 2, 1); // 1 - 3T + T^2 (discriminant 5, not a square)
+  lk_callback_z(poly, p, d, param);
+  if (p == 37) {
+    fmpz_poly_zero(poly);
+    fmpz_poly_set_coeff_ui(poly, 0, 1);
+    fmpz_poly_set_coeff_si(poly, 1, -3);
+    fmpz_poly_set_coeff_ui(poly, 2, 1);
   }
 }
 
@@ -101,6 +129,31 @@ static void lk_complex_callback(acb_poly_t poly, uint64_t p, int d, int64_t prec
   acb_clear(c1);
   acb_poly_pow_ui(poly, mp, 2, prec);   // L_p = M_p^2 (complex)
   acb_poly_clear(mp);
+}
+
+static Lerror_t use_power_factor_fmpz(Lfunc_t L, uint64_t p, ulong k)
+{
+  fmpz_poly_t ep, fp;
+  fmpz_poly_init(ep);
+  fmpz_poly_init(fp);
+  Ep_z(ep, p);
+  fmpz_poly_pow(fp, ep, k);
+  Lerror_t e = Lfunc_use_lpoly_fmpz(L, p, fp);
+  fmpz_poly_clear(fp);
+  fmpz_poly_clear(ep);
+  return e;
+}
+
+static void use_power_factor_acb(Lfunc_t L, uint64_t p, ulong k)
+{
+  acb_poly_t ep, fp;
+  acb_poly_init(ep);
+  acb_poly_init(fp);
+  Ep(ep, p);
+  acb_poly_pow_ui(fp, ep, k, 100);
+  Lfunc_use_lpoly(L, p, fp);
+  acb_poly_clear(fp);
+  acb_poly_clear(ep);
 }
 
 int main(void)
@@ -148,7 +201,7 @@ int main(void)
   Lerror_t e2 = ERR_SUCCESS;
   Lfunc_t L2 = Lfunc_init_advanced(&Lp2, &e2);
   assert(!fatal_error(e2));
-  e2 |= Lfunc_use_all_lpolys(L2, lk_callback, NULL);
+  e2 |= Lfunc_use_all_lpolys_fmpz(L2, lk_callback_z, NULL);
   e2 |= Lfunc_compute(L2);
   assert(!fatal_error(e2));
 
@@ -191,7 +244,68 @@ int main(void)
 
   printf("extract_power_test: Task 3 OK\n");
 
-  // ---- E^3 (degree 6, odd k) ----
+  // Exact-looking factors supplied only through the acb API are not exact
+  // provenance for extraction. The guard still detects the square, but
+  // power_extract_prepare must refuse to certify it.
+  Lp2.extract_powers = YES;
+  Lerror_t eA = ERR_SUCCESS;
+  Lfunc_t LA = Lfunc_init_advanced(&Lp2, &eA);
+  assert(!fatal_error(eA));
+  eA |= Lfunc_use_all_lpolys(LA, lk_callback, NULL);
+  eA |= Lfunc_compute(LA);
+  assert(eA & ERR_POWER);
+  Lfunc_t *fA = NULL; uint64_t *mA = NULL;
+  assert(Lfunc_factors(LA, &fA, &mA) == 0);
+	  Lfunc_clear(LA);
+
+	  printf("extract_power_test: acb-only extraction refused OK\n");
+
+	  // fmpz callback zero sentinel: first missing exact factor stops supply and
+	  // reports ERR_INSUFF_EULER.
+	  {
+	    Lerror_t eS = ERR_SUCCESS;
+	    Lfunc_t LS = Lfunc_init_advanced(&Lp2, &eS);
+	    assert(!fatal_error(eS));
+	    eS |= Lfunc_use_all_lpolys_fmpz(LS, lk_first_prime_only_callback_z, NULL);
+	    assert(eS & ERR_INSUFF_EULER);
+	    assert(!fatal_error(eS));
+	    eS |= Lfunc_compute(LS);
+	    assert(eS & ERR_INSUFF_EULER);
+	    Lfunc_clear(LS);
+	  }
+
+	  printf("extract_power_test: fmpz callback sentinel OK\n");
+
+	  // Mixed provenance must not extract: every retained factor must have exact
+	  // fmpz provenance, regardless of supply order.
+	  {
+	    Lerror_t eMix1 = ERR_SUCCESS;
+	    Lfunc_t LMix1 = Lfunc_init_advanced(&Lp2, &eMix1);
+	    assert(!fatal_error(eMix1));
+	    (void)Lfunc_nmax(LMix1);
+	    eMix1 |= use_power_factor_fmpz(LMix1, 2, 2);
+	    use_power_factor_acb(LMix1, 3, 2);
+	    eMix1 |= Lfunc_compute(LMix1);
+	    assert(eMix1 & ERR_POWER);
+	    Lfunc_t *fm = NULL; uint64_t *mm = NULL;
+	    assert(Lfunc_factors(LMix1, &fm, &mm) == 0);
+	    Lfunc_clear(LMix1);
+
+	    Lerror_t eMix2 = ERR_SUCCESS;
+	    Lfunc_t LMix2 = Lfunc_init_advanced(&Lp2, &eMix2);
+	    assert(!fatal_error(eMix2));
+	    (void)Lfunc_nmax(LMix2);
+	    use_power_factor_acb(LMix2, 2, 2);
+	    eMix2 |= use_power_factor_fmpz(LMix2, 3, 2);
+	    eMix2 |= Lfunc_compute(LMix2);
+	    assert(eMix2 & ERR_POWER);
+	    assert(Lfunc_factors(LMix2, &fm, &mm) == 0);
+	    Lfunc_clear(LMix2);
+	  }
+
+	  printf("extract_power_test: mixed provenance refused OK\n");
+
+	  // ---- E^3 (degree 6, odd k) ----
   k_param = 3;
   Lfunc_t Eref3 = Lfunc_init(2, 37, 0.5, mus, &ec);
   ec = ERR_SUCCESS;
@@ -206,7 +320,7 @@ int main(void)
   Lerror_t e3 = ERR_SUCCESS;
   Lfunc_t L3 = Lfunc_init_advanced(&Lp3, &e3);
   assert(!fatal_error(e3));
-  e3 |= Lfunc_use_all_lpolys(L3, lk_callback, NULL);
+  e3 |= Lfunc_use_all_lpolys_fmpz(L3, lk_callback_z, NULL);
   e3 |= Lfunc_compute(L3);
   assert(!fatal_error(e3));
 
@@ -246,7 +360,7 @@ int main(void)
   // prime <= nmax(M), regardless of position; a `break` at the first p > nmax(M)
   // would drop the trailing low primes and compute M (here 37.a, nmax 142) WITHOUT
   // its bad factor at 37 -> wrong zeros/Taylor. We reproduce that layout here:
-  // supply E^2's good primes ascending (incl. p=149 > 142) via Lfunc_use_lpoly, then
+  // supply E^2's good primes ascending (incl. p=149 > 142) via Lfunc_use_lpoly_fmpz, then
   // the bad prime 37 LAST.
   k_param = 2;
   Lfunc_t ErefO = Lfunc_init(2, 37, 0.5, mus, &ec);
@@ -261,30 +375,21 @@ int main(void)
                     .gprec = 0, .self_dual = YES, .rank = DK, .cache_dir = ".",
                     .extract_powers = YES };
   Lerror_t eO = ERR_SUCCESS;
-  Lfunc_t LO = Lfunc_init_advanced(&LpO, &eO);
-  assert(!fatal_error(eO));
-  {
-    acb_poly_t fp; acb_poly_init(fp);
-    uint64_t nmaxO = Lfunc_nmax(LO);
-    // good primes (everything in ap37 except the bad prime 37), ascending,
-    // each raised to k=2; this includes p=149 > nmax(37.a)=142.
-    for (size_t i = 0; i < sizeof(ap37)/sizeof(ap37[0]); i++) {
-      uint64_t p = (uint64_t)ap37[i][0];
-      if (p == 37 || p > nmaxO) continue;
-      acb_poly_t ep; acb_poly_init(ep); Ep(ep, p);
-      acb_poly_pow_ui(fp, ep, 2, 100);
-      Lfunc_use_lpoly(LO, p, fp);
-      acb_poly_clear(ep);
-    }
-    // bad prime 37 supplied LAST (out of order), (1+T)^2:
-    if (37 <= nmaxO) {
-      acb_poly_t ep; acb_poly_init(ep); Ep(ep, 37);
-      acb_poly_pow_ui(fp, ep, 2, 100);
-      Lfunc_use_lpoly(LO, 37, fp);
-      acb_poly_clear(ep);
-    }
-    acb_poly_clear(fp);
-  }
+	  Lfunc_t LO = Lfunc_init_advanced(&LpO, &eO);
+	  assert(!fatal_error(eO));
+	  {
+	    uint64_t nmaxO = Lfunc_nmax(LO);
+	    // good primes (everything in ap37 except the bad prime 37), ascending,
+	    // each raised to k=2; this includes p=149 > nmax(37.a)=142.
+	    for (size_t i = 0; i < sizeof(ap37)/sizeof(ap37[0]); i++) {
+	      uint64_t p = (uint64_t)ap37[i][0];
+	      if (p == 37 || p > nmaxO) continue;
+	      eO |= use_power_factor_fmpz(LO, p, 2);
+	    }
+	    // bad prime 37 supplied LAST (out of order), (1+T)^2:
+	    if (37 <= nmaxO)
+	      eO |= use_power_factor_fmpz(LO, 37, 2);
+	  }
   eO |= Lfunc_compute(LO);
   assert(!fatal_error(eO));
   Lfunc_t *fO = NULL; uint64_t *mO = NULL;
@@ -312,17 +417,16 @@ int main(void)
   Lerror_t eMu = ERR_SUCCESS;
   Lfunc_t LMu = Lfunc_init_advanced(&LpMu, &eMu);
   assert(!fatal_error(eMu));
-  eMu |= Lfunc_use_all_lpolys(LMu, lk_callback, NULL); // INSUFF_EULER warning is fine
+  eMu |= Lfunc_use_all_lpolys_fmpz(LMu, lk_callback_z, NULL); // INSUFF_EULER warning is fine
   eMu |= Lfunc_compute(LMu);
   assert(eMu & ERR_POWER);            // mus not k-divisible -> refuse to extract
   Lfunc_clear(LMu);
 
   printf("extract_power_test: I2 non-k-divisible mus OK\n");
 
-  // ---- I3: inexact (wide-ball) Euler factors must not be certified (rigor) ----
-  // E^2 with one coefficient carrying a tiny error ball. The certificate proves
-  // f = M_p^k by ball containment, which is meaningful only for exact factors; a
-  // wide-ball non-power can false-accept. Expect ERR_POWER (refuse to certify).
+  // ---- I3: inexact/acb Euler factors must not be certified (rigor) ----
+  // E^2 with one coefficient carrying a tiny error ball. acb supply still drives
+  // the guard, but it has no exact fmpz provenance, so extraction must be refused.
   k_param = 2;
   Lparams_t LpIn = { .degree = 4, .conductor = 37u*37u, .normalisation = 0.5,
                      .mus = (double[]){0,0,1,1}, .target_prec = 100, .wprec = 0,
@@ -351,16 +455,16 @@ int main(void)
   Lerror_t eBad = ERR_SUCCESS;
   Lfunc_t LBad = Lfunc_init_advanced(&LpBad, &eBad);
   assert(!fatal_error(eBad));
-  eBad |= Lfunc_use_all_lpolys(LBad, lk_badprime_callback, NULL); // INSUFF_EULER warning is fine
+  eBad |= Lfunc_use_all_lpolys_fmpz(LBad, lk_badprime_callback_z, NULL); // INSUFF_EULER warning is fine
   eBad |= Lfunc_compute(LBad);
   assert(eBad & ERR_POWER);            // bad factor not a square -> refuse to extract
   Lfunc_clear(LBad);
 
   printf("extract_power_test: C1 non-square bad factor OK\n");
 
-  // Complex (non-self-dual) boundary: extraction now supports algebraic exact roots
-  // (feat: lfunctions-5g6). A complex L = M^2, built so detection still finds k=2 and the perfect-square
-  // conductor, should be successfully extracted.
+  // Complex (non-self-dual) boundary: complex acb factors can still trigger the
+  // guard, but the exact fmpz certificate cannot be supplied for them. They must
+  // therefore be refused under extract_powers=YES.
   {
     Lparams_t LpC = { .degree=4, .conductor=37u*37u, .normalisation=0.5,
                       .mus=(double[]){0,0,1,1}, .target_prec=100, .wprec=0, .gprec=0,
@@ -370,12 +474,12 @@ int main(void)
     assert(!fatal_error(eC));
     eC |= Lfunc_use_all_lpolys(LC, lk_complex_callback, NULL);
     eC |= Lfunc_compute(LC);
-    assert(!fatal_error(eC));            // complex Euler factor -> exact certificate succeeds!
+    assert(eC & ERR_POWER);
     Lfunc_t *fc = NULL; uint64_t *mc = NULL;
-    assert(Lfunc_factors(LC, &fc, &mc) == 1 && mc[0] == 2);   // extracted successfully
+    assert(Lfunc_factors(LC, &fc, &mc) == 0);
     Lfunc_clear(LC);
   }
-  printf("extract_power_test: complex non-self-dual boundary OK (extracts)\n");
+  printf("extract_power_test: complex acb boundary refused OK\n");
 
   // ---- E^4 (degree 8, even k=4): multi-k candidate recovery (Fix C) ----
   // L = E^4 has conductor 37^4 (maximal perfect-power exponent E=4) and 2nd moment ~16,
@@ -398,7 +502,7 @@ int main(void)
   Lerror_t e4 = ERR_SUCCESS;
   Lfunc_t L4 = Lfunc_init_advanced(&Lp4, &e4);
   assert(!fatal_error(e4));
-  e4 |= Lfunc_use_all_lpolys(L4, lk_callback, NULL);
+  e4 |= Lfunc_use_all_lpolys_fmpz(L4, lk_callback_z, NULL);
   e4 |= Lfunc_compute(L4);
   assert(!fatal_error(e4));
 

--- a/test/extract_power_test.c
+++ b/test/extract_power_test.c
@@ -56,6 +56,16 @@ static void e_callback(acb_poly_t poly, uint64_t p, int d, int64_t prec, void *p
   Ep(poly, p);
 }
 
+// callback for I3: like lk_callback but makes one coefficient INEXACT (a tiny ball).
+// The k-th-power certificate is rigorous only for exact factors, so an inexact one
+// must be refused even though its root^k still overlaps the wide ball.
+static void lk_inexact_callback(acb_poly_t poly, uint64_t p, int d, int64_t prec, void *param)
+{
+  lk_callback(poly, p, d, prec, param);
+  if (!acb_poly_is_zero(poly))
+    arb_add_error_2exp_si(acb_realref(acb_poly_get_coeff_ptr(poly, 0)), -150);
+}
+
 int main(void)
 {
   Lerror_t ec = ERR_SUCCESS;
@@ -238,5 +248,45 @@ int main(void)
   Lfunc_clear(LO); Lfunc_clear(ErefO);
 
   printf("extract_power_test: out-of-order supply OK\n");
+
+  // ---- I2: non-k-divisible mus must be rejected (soundness gate) ----
+  // A degree-4 L with mus={0,0,0,1} has sorted blocks [0,0] and [0,1] (k=2),
+  // which are unequal: L's gamma factors disagree with any pure square, so even
+  // if the Euler factors are perfect squares we must NOT extract. Supply the same
+  // perfect-square factors as E^2 via lk_callback; expect ERR_POWER.
+  k_param = 2;
+  Lparams_t LpMu = { .degree = 4, .conductor = 37u*37u, .normalisation = 0.5,
+                     .mus = (double[]){0,0,0,1}, .target_prec = 100, .wprec = 0,
+                     .gprec = 0, .self_dual = YES, .rank = DK, .cache_dir = ".",
+                     .extract_powers = YES };
+  Lerror_t eMu = ERR_SUCCESS;
+  Lfunc_t LMu = Lfunc_init_advanced(&LpMu, &eMu);
+  assert(!fatal_error(eMu));
+  eMu |= Lfunc_use_all_lpolys(LMu, lk_callback, NULL); // INSUFF_EULER warning is fine
+  eMu |= Lfunc_compute(LMu);
+  assert(eMu & ERR_POWER);            // mus not k-divisible -> refuse to extract
+  Lfunc_clear(LMu);
+
+  printf("extract_power_test: I2 non-k-divisible mus OK\n");
+
+  // ---- I3: inexact (wide-ball) Euler factors must not be certified (rigor) ----
+  // E^2 with one coefficient carrying a tiny error ball. The certificate proves
+  // f = M_p^k by ball containment, which is meaningful only for exact factors; a
+  // wide-ball non-power can false-accept. Expect ERR_POWER (refuse to certify).
+  k_param = 2;
+  Lparams_t LpIn = { .degree = 4, .conductor = 37u*37u, .normalisation = 0.5,
+                     .mus = (double[]){0,0,1,1}, .target_prec = 100, .wprec = 0,
+                     .gprec = 0, .self_dual = YES, .rank = DK, .cache_dir = ".",
+                     .extract_powers = YES };
+  Lerror_t eIn = ERR_SUCCESS;
+  Lfunc_t LIn = Lfunc_init_advanced(&LpIn, &eIn);
+  assert(!fatal_error(eIn));
+  eIn |= Lfunc_use_all_lpolys(LIn, lk_inexact_callback, NULL); // INSUFF_EULER warning is fine
+  eIn |= Lfunc_compute(LIn);
+  assert(eIn & ERR_POWER);            // inexact factor -> refuse to certify
+  Lfunc_clear(LIn);
+
+  printf("extract_power_test: I3 inexact factor OK\n");
+
   return 0;
 }

--- a/test/extract_power_test.c
+++ b/test/extract_power_test.c
@@ -358,10 +358,9 @@ int main(void)
 
   printf("extract_power_test: C1 non-square bad factor OK\n");
 
-  // Complex (non-self-dual) boundary: extraction supports rational-integer L-functions
-  // only. A complex L = M^2, built so detection still finds k=2 and the perfect-square
-  // conductor, must be REFUSED by the exact integer certificate (ERR_POWER), not
-  // extracted. Supporting complex Euler factors is feature request lfunctions-5g6.
+  // Complex (non-self-dual) boundary: extraction now supports algebraic exact roots
+  // (feat: lfunctions-5g6). A complex L = M^2, built so detection still finds k=2 and the perfect-square
+  // conductor, should be successfully extracted.
   {
     Lparams_t LpC = { .degree=4, .conductor=37u*37u, .normalisation=0.5,
                       .mus=(double[]){0,0,1,1}, .target_prec=100, .wprec=0, .gprec=0,
@@ -371,12 +370,12 @@ int main(void)
     assert(!fatal_error(eC));
     eC |= Lfunc_use_all_lpolys(LC, lk_complex_callback, NULL);
     eC |= Lfunc_compute(LC);
-    assert(eC & ERR_POWER);            // complex Euler factor -> exact certificate refuses
+    assert(!fatal_error(eC));            // complex Euler factor -> exact certificate succeeds!
     Lfunc_t *fc = NULL; uint64_t *mc = NULL;
-    assert(Lfunc_factors(LC, &fc, &mc) == 0);   // not extracted
+    assert(Lfunc_factors(LC, &fc, &mc) == 1 && mc[0] == 2);   // extracted successfully
     Lfunc_clear(LC);
   }
-  printf("extract_power_test: complex non-self-dual boundary OK (ERR_POWER)\n");
+  printf("extract_power_test: complex non-self-dual boundary OK (extracts)\n");
 
   // ---- E^4 (degree 8, even k=4): multi-k candidate recovery (Fix C) ----
   // L = E^4 has conductor 37^4 (maximal perfect-power exponent E=4) and 2nd moment ~16,

--- a/test/extract_power_test.c
+++ b/test/extract_power_test.c
@@ -83,6 +83,26 @@ static void lk_badprime_callback(acb_poly_t poly, uint64_t p, int d, int64_t pre
   }
 }
 
+// callback for the complex (non-self-dual) boundary: build M with a COMPLEX linear
+// coefficient (i times E_p's), so L = M^2 has complex Euler factors but the same 2nd
+// moment and perfect-square conductor as E^2 (detection still finds k=2). The exact
+// integer certificate requires real-integer coefficients, so it must refuse this with
+// ERR_POWER -- extraction supports rational-integer L-functions only (feat: lfunctions-5g6).
+static void lk_complex_callback(acb_poly_t poly, uint64_t p, int d, int64_t prec, void *param)
+{
+  (void)d; (void)param;
+  acb_poly_t mp; acb_poly_init(mp);
+  Ep(mp, p);
+  if (acb_poly_is_zero(mp)) { acb_poly_zero(poly); acb_poly_clear(mp); return; }
+  acb_t c1; acb_init(c1);
+  acb_poly_get_coeff_acb(c1, mp, 1);
+  acb_mul_onei(c1, c1);                 // i * (linear coeff): M is non-self-dual (complex a_p)
+  acb_poly_set_coeff_acb(mp, 1, c1);
+  acb_clear(c1);
+  acb_poly_pow_ui(poly, mp, 2, prec);   // L_p = M_p^2 (complex)
+  acb_poly_clear(mp);
+}
+
 int main(void)
 {
   Lerror_t ec = ERR_SUCCESS;
@@ -337,6 +357,26 @@ int main(void)
   Lfunc_clear(LBad);
 
   printf("extract_power_test: C1 non-square bad factor OK\n");
+
+  // Complex (non-self-dual) boundary: extraction supports rational-integer L-functions
+  // only. A complex L = M^2, built so detection still finds k=2 and the perfect-square
+  // conductor, must be REFUSED by the exact integer certificate (ERR_POWER), not
+  // extracted. Supporting complex Euler factors is feature request lfunctions-5g6.
+  {
+    Lparams_t LpC = { .degree=4, .conductor=37u*37u, .normalisation=0.5,
+                      .mus=(double[]){0,0,1,1}, .target_prec=100, .wprec=0, .gprec=0,
+                      .self_dual=NO, .rank=DK, .cache_dir=".", .extract_powers=YES };
+    Lerror_t eC = ERR_SUCCESS;
+    Lfunc_t LC = Lfunc_init_advanced(&LpC, &eC);
+    assert(!fatal_error(eC));
+    eC |= Lfunc_use_all_lpolys(LC, lk_complex_callback, NULL);
+    eC |= Lfunc_compute(LC);
+    assert(eC & ERR_POWER);            // complex Euler factor -> exact certificate refuses
+    Lfunc_t *fc = NULL; uint64_t *mc = NULL;
+    assert(Lfunc_factors(LC, &fc, &mc) == 0);   // not extracted
+    Lfunc_clear(LC);
+  }
+  printf("extract_power_test: complex non-self-dual boundary OK (ERR_POWER)\n");
 
   return 0;
 }

--- a/test/extract_power_test.c
+++ b/test/extract_power_test.c
@@ -17,8 +17,10 @@ static const long ap37[][3] = {
   {53,-1,53},{59,-8,59},{61,8,61},{67,-8,67},{71,-9,71},{73,1,73},{79,-4,79},
   {83,15,83},{89,-4,89},{97,-4,97},{101,-3,101},{103,-18,103},{107,12,107},
   {109,16,109},{113,18,113},{127,-1,127},{131,12,131},{137,6,137},{139,-4,139},
+  {149,5,149},  // one good prime > nmax(37.a)=142, for the out-of-order supply test
 };
 // Sanity check against examples/ec_37.a1.cpp: p=2 -> {1,2,2}, p=23 -> {1,-2,23}.
+// p=149 a_p=-5 (T-coeff 5) computed by point count on y^2+y=x^3-x mod 149.
 
 static int k_param; // 2 or 3: the callback raises E_p to this power
 
@@ -176,5 +178,65 @@ int main(void)
   Lfunc_clear(L3); Lfunc_clear(Eref3);
 
   printf("extract_power_test: Task 5 OK\n");
+
+  // ---- out-of-order supply (regression for extract_and_assemble's prime loop) ----
+  // The highdeg harness supplies good factors ascending, then appends the BAD
+  // factors at the tail (e.g. p=2,7 after p up to ~1900 for 196.a). So L's retained
+  // factors are NOT in prime order. extract_and_assemble must feed M every retained
+  // prime <= nmax(M), regardless of position; a `break` at the first p > nmax(M)
+  // would drop the trailing low primes and compute M (here 37.a, nmax 142) WITHOUT
+  // its bad factor at 37 -> wrong zeros/Taylor. We reproduce that layout here:
+  // supply E^2's good primes ascending (incl. p=149 > 142) via Lfunc_use_lpoly, then
+  // the bad prime 37 LAST.
+  k_param = 2;
+  Lfunc_t ErefO = Lfunc_init(2, 37, 0.5, mus, &ec);
+  ec = ERR_SUCCESS;
+  ec |= Lfunc_use_all_lpolys(ErefO, e_callback, NULL);
+  ec |= Lfunc_compute(ErefO);
+  assert(!fatal_error(ec));
+  arb_srcptr zerosEO = Lfunc_zeros(ErefO, 0);
+
+  Lparams_t LpO = { .degree = 4, .conductor = 37u*37u, .normalisation = 0.5,
+                    .mus = (double[]){0,0,1,1}, .target_prec = 100, .wprec = 0,
+                    .gprec = 0, .self_dual = YES, .rank = DK, .cache_dir = ".",
+                    .extract_powers = YES };
+  Lerror_t eO = ERR_SUCCESS;
+  Lfunc_t LO = Lfunc_init_advanced(&LpO, &eO);
+  assert(!fatal_error(eO));
+  {
+    acb_poly_t fp; acb_poly_init(fp);
+    uint64_t nmaxO = Lfunc_nmax(LO);
+    // good primes (everything in ap37 except the bad prime 37), ascending,
+    // each raised to k=2; this includes p=149 > nmax(37.a)=142.
+    for (size_t i = 0; i < sizeof(ap37)/sizeof(ap37[0]); i++) {
+      uint64_t p = (uint64_t)ap37[i][0];
+      if (p == 37 || p > nmaxO) continue;
+      acb_poly_t ep; acb_poly_init(ep); Ep(ep, p);
+      acb_poly_pow_ui(fp, ep, 2, 100);
+      Lfunc_use_lpoly(LO, p, fp);
+      acb_poly_clear(ep);
+    }
+    // bad prime 37 supplied LAST (out of order), (1+T)^2:
+    if (37 <= nmaxO) {
+      acb_poly_t ep; acb_poly_init(ep); Ep(ep, 37);
+      acb_poly_pow_ui(fp, ep, 2, 100);
+      Lfunc_use_lpoly(LO, 37, fp);
+      acb_poly_clear(ep);
+    }
+    acb_poly_clear(fp);
+  }
+  eO |= Lfunc_compute(LO);
+  assert(!fatal_error(eO));
+  Lfunc_t *fO = NULL; uint64_t *mO = NULL;
+  assert(Lfunc_factors(LO, &fO, &mO) == 1 && mO[0] == 2);
+  // The assembled first zero must equal 37.a's first zero. With the `break` bug,
+  // M is computed without its bad factor at 37 and this overlap fails.
+  arb_srcptr zO = Lfunc_zeros(LO, 0);
+  assert(arb_overlaps((arb_ptr)(zO+0), (arb_ptr)(zerosEO+0)));
+  assert(arb_overlaps((arb_ptr)(zO+1), (arb_ptr)(zerosEO+0))); // doubled
+  assert(arb_overlaps((arb_ptr)(zO+2), (arb_ptr)(zerosEO+1)));
+  Lfunc_clear(LO); Lfunc_clear(ErefO);
+
+  printf("extract_power_test: out-of-order supply OK\n");
   return 0;
 }

--- a/test/extract_power_test.c
+++ b/test/extract_power_test.c
@@ -135,5 +135,46 @@ int main(void)
   Lfunc_clear(Eref);
 
   printf("extract_power_test: Task 3 OK\n");
+
+  // ---- E^3 (degree 6, odd k) ----
+  k_param = 3;
+  Lfunc_t Eref3 = Lfunc_init(2, 37, 0.5, mus, &ec);
+  ec = ERR_SUCCESS;
+  ec |= Lfunc_use_all_lpolys(Eref3, e_callback, NULL);
+  ec |= Lfunc_compute(Eref3);
+  assert(!fatal_error(ec));
+
+  Lparams_t Lp3 = { .degree = 6, .conductor = 50653, .normalisation = 0.5,
+                    .mus = (double[]){0,0,0,1,1,1}, .target_prec = 100, .wprec = 0,
+                    .gprec = 0, .self_dual = YES, .rank = DK, .cache_dir = ".",
+                    .extract_powers = YES };
+  Lerror_t e3 = ERR_SUCCESS;
+  Lfunc_t L3 = Lfunc_init_advanced(&Lp3, &e3);
+  assert(!fatal_error(e3));
+  e3 |= Lfunc_use_all_lpolys(L3, lk_callback, NULL);
+  e3 |= Lfunc_compute(L3);
+  assert(!fatal_error(e3));
+
+  Lfunc_t *f3 = NULL; uint64_t *m3 = NULL;
+  assert(Lfunc_factors(L3, &f3, &m3) == 1 && m3[0] == 3);
+  assert(Lfunc_rank(L3) == 3*Lfunc_rank(Eref3));
+  arb_srcptr zE3 = Lfunc_zeros(Eref3, 0);
+  arb_srcptr z3  = Lfunc_zeros(L3, 0);
+  assert(arb_overlaps((arb_ptr)(z3+0), (arb_ptr)(zE3+0)));
+  assert(arb_overlaps((arb_ptr)(z3+1), (arb_ptr)(zE3+0)));
+  assert(arb_overlaps((arb_ptr)(z3+2), (arb_ptr)(zE3+0))); // tripled
+  assert(arb_overlaps((arb_ptr)(z3+3), (arb_ptr)(zE3+1)));
+  acb_t s3; acb_init(s3); acb_pow_ui(s3, Lfunc_sign(Eref3), 3, 100);
+  assert(acb_overlaps(s3, Lfunc_sign(L3))); acb_clear(s3); // sign(E)^3 = -1
+  acb_t vL3, vE3, vE3k; acb_init(vL3); acb_init(vE3); acb_init(vE3k);
+  Lerror_t sv3 = Lfunc_special_value(vE3, Eref3, 1.5, 0.0)
+               | Lfunc_special_value(vL3, L3, 1.5, 0.0);
+  assert(!fatal_error(sv3));
+  acb_pow_ui(vE3k, vE3, 3, 100);
+  assert(acb_overlaps(vL3, vE3k));
+  acb_clear(vL3); acb_clear(vE3); acb_clear(vE3k);
+  Lfunc_clear(L3); Lfunc_clear(Eref3);
+
+  printf("extract_power_test: Task 5 OK\n");
   return 0;
 }

--- a/test/extract_power_test.c
+++ b/test/extract_power_test.c
@@ -66,6 +66,23 @@ static void lk_inexact_callback(acb_poly_t poly, uint64_t p, int d, int64_t prec
     arb_add_error_2exp_si(acb_realref(acb_poly_get_coeff_ptr(poly, 0)), -150);
 }
 
+// callback for C1: like lk_callback (E^2) but OVERRIDES the bad prime 37 with a
+// non-square degree-2 factor 1 - 3T + T^2. Every GOOD factor is a genuine square,
+// but the bad factor is not, so L = M^2 is false and extraction must be refused.
+// Pre-fix (good-prime-only certificate) the uncertified bad factor was k-th-rooted
+// blindly and L extracted (n_factors=1); the exact-integer certificate over ALL
+// factors must now reject with ERR_POWER.
+static void lk_badprime_callback(acb_poly_t poly, uint64_t p, int d, int64_t prec, void *param)
+{
+  lk_callback(poly, p, d, prec, param);
+  if (p == 37) {                       // overwrite the bad factor with a non-square
+    acb_poly_zero(poly);
+    acb_poly_set_coeff_si(poly, 0, 1);
+    acb_poly_set_coeff_si(poly, 1, -3);
+    acb_poly_set_coeff_si(poly, 2, 1); // 1 - 3T + T^2 (discriminant 5, not a square)
+  }
+}
+
 int main(void)
 {
   Lerror_t ec = ERR_SUCCESS;
@@ -300,6 +317,26 @@ int main(void)
   Lfunc_clear(LIn);
 
   printf("extract_power_test: I3 inexact factor OK\n");
+
+  // ---- C1: a bad factor that is NOT a k-th power must be rejected (soundness) ----
+  // Supply 37.a1's GOOD factors as (E_p)^2 but OVERRIDE the bad prime 37 with the
+  // non-square 1 - 3T + T^2. The good-prime-only certificate (pre-fix) k-th-rooted
+  // this uncertified bad factor blindly and extracted (n_factors=1); the exact-integer
+  // certificate over EVERY supplied factor must reject it. Expect ERR_POWER.
+  k_param = 2;
+  Lparams_t LpBad = { .degree = 4, .conductor = 37u*37u, .normalisation = 0.5,
+                      .mus = (double[]){0,0,1,1}, .target_prec = 100, .wprec = 0,
+                      .gprec = 0, .self_dual = YES, .rank = DK, .cache_dir = ".",
+                      .extract_powers = YES };
+  Lerror_t eBad = ERR_SUCCESS;
+  Lfunc_t LBad = Lfunc_init_advanced(&LpBad, &eBad);
+  assert(!fatal_error(eBad));
+  eBad |= Lfunc_use_all_lpolys(LBad, lk_badprime_callback, NULL); // INSUFF_EULER warning is fine
+  eBad |= Lfunc_compute(LBad);
+  assert(eBad & ERR_POWER);            // bad factor not a square -> refuse to extract
+  Lfunc_clear(LBad);
+
+  printf("extract_power_test: C1 non-square bad factor OK\n");
 
   return 0;
 }

--- a/test/extract_power_test.c
+++ b/test/extract_power_test.c
@@ -3,6 +3,7 @@
 // Asserts on certified balls only. Build with assertions on.
 #include <assert.h>
 #include <stdio.h>
+#include <flint/acb.h>
 #include <flint/acb_poly.h>
 #include "glfunc.h"
 
@@ -69,5 +70,59 @@ int main(void)
   Lfunc_clear(E);
 
   printf("extract_power_test: Task 2 OK\n");
+
+  // Build E^2 with extract_powers = NO -> ERR_POWER.
+  k_param = 2;
+  Lparams_t Lp2 = { .degree = 4, .conductor = 37u*37u, .normalisation = 0.5,
+                    .mus = (double[]){0,0,1,1}, .target_prec = 100, .wprec = 0,
+                    .gprec = 0, .self_dual = YES, .rank = DK, .cache_dir = ".",
+                    .extract_powers = NO };
+  Lerror_t e_off = ERR_SUCCESS;
+  Lfunc_t Loff = Lfunc_init_advanced(&Lp2, &e_off);
+  assert(!fatal_error(e_off));
+  e_off |= Lfunc_use_all_lpolys(Loff, lk_callback, NULL); // INSUFF_EULER warning is fine
+  e_off |= Lfunc_compute(Loff);
+  assert(e_off & ERR_POWER);          // opted out: rejected
+  Lfunc_clear(Loff);
+
+  // Reference: compute E directly.
+  Lfunc_t Eref = Lfunc_init(2, 37, 0.5, mus, &ec);
+  ec = ERR_SUCCESS;
+  ec |= Lfunc_use_all_lpolys(Eref, e_callback, NULL);
+  ec |= Lfunc_compute(Eref);
+  assert(!fatal_error(ec));
+  int64_t rankE = Lfunc_rank(Eref);
+  arb_srcptr zerosE = Lfunc_zeros(Eref, 0);
+
+  // Build E^2 with extract_powers = YES -> extract & assemble.
+  Lp2.extract_powers = YES;
+  Lerror_t e2 = ERR_SUCCESS;
+  Lfunc_t L2 = Lfunc_init_advanced(&Lp2, &e2);
+  assert(!fatal_error(e2));
+  e2 |= Lfunc_use_all_lpolys(L2, lk_callback, NULL);
+  e2 |= Lfunc_compute(L2);
+  assert(!fatal_error(e2));
+
+  // factor accessor returns (M, 2); M overlaps E
+  Lfunc_t *f2 = NULL; uint64_t *m2 = NULL;
+  assert(Lfunc_factors(L2, &f2, &m2) == 1);
+  assert(m2[0] == 2);
+  assert(Lfunc_rank(f2[0]) == rankE);
+  // assembled rank, zeros (doubled), sign
+  assert(Lfunc_rank(L2) == 2*rankE);
+  arb_srcptr z2 = Lfunc_zeros(L2, 0);
+  assert(arb_overlaps((arb_ptr)(z2+0), (arb_ptr)(zerosE+0)));
+  assert(arb_overlaps((arb_ptr)(z2+1), (arb_ptr)(zerosE+0))); // repeated k=2 times
+  assert(arb_overlaps((arb_ptr)(z2+2), (arb_ptr)(zerosE+1)));
+  acb_t s2; acb_init(s2);
+  acb_pow_ui(s2, Lfunc_sign(Eref), 2, 100);           // sign(E)^2
+  assert(acb_overlaps(s2, Lfunc_sign(L2)));
+  { arb_t am; arb_init(am); acb_abs(am, Lfunc_sign(L2), 100);
+    arb_sub_ui(am, am, 1, 100); assert(arb_contains_zero(am)); arb_clear(am); } // |eps|=1
+  acb_clear(s2);
+  Lfunc_clear(L2);
+  Lfunc_clear(Eref);
+
+  printf("extract_power_test: Task 3 OK\n");
   return 0;
 }

--- a/test/extract_power_test.c
+++ b/test/extract_power_test.c
@@ -143,6 +143,12 @@ int main(void)
   assert(acb_overlaps(vL, vEk));
   acb_clear(vL); acb_clear(vE); acb_clear(vEk);
 
+  // (Task / spec 13) assembled leading Taylor coefficient: L_d(L2) == L_d(Eref)^2
+  { arb_t tk; arb_init(tk);
+    arb_pow_ui(tk, Lfunc_Taylor(Eref), 2, 100);
+    assert(arb_overlaps((arb_ptr)Lfunc_Taylor(L2), tk));
+    arb_clear(tk); }
+
   Lfunc_clear(L2);
   Lfunc_clear(Eref);
 
@@ -185,6 +191,13 @@ int main(void)
   acb_pow_ui(vE3k, vE3, 3, 100);
   assert(acb_overlaps(vL3, vE3k));
   acb_clear(vL3); acb_clear(vE3); acb_clear(vE3k);
+
+  // (Task / spec 13) assembled leading Taylor coefficient: L_d(L3) == L_d(Eref3)^3
+  { arb_t tk; arb_init(tk);
+    arb_pow_ui(tk, Lfunc_Taylor(Eref3), 3, 100);
+    assert(arb_overlaps((arb_ptr)Lfunc_Taylor(L3), tk));
+    arb_clear(tk); }
+
   Lfunc_clear(L3); Lfunc_clear(Eref3);
 
   printf("extract_power_test: Task 5 OK\n");

--- a/test/extract_power_test.c
+++ b/test/extract_power_test.c
@@ -442,6 +442,40 @@ int main(void)
 
   printf("extract_power_test: out-of-order supply OK\n");
 
+  // ---- sparse supply: an aborted assembly must be FATAL ----
+  // L = M^2 (degree 4, conductor 196 = 14^2, EC-squared mus) supplied with a
+  // SINGLE exact square factor at p = 1009, far above nmax(M) for the would-be
+  // factor M (degree 2, conductor 14, nmax ~ 100). Certification finds k = 2,
+  // but no retained prime is <= nmax(M), so assembly cannot proceed at all.
+  // That abort must surface as fatal ERR_POWER: a bare ERR_INSUFF_EULER warning
+  // would leave fatal_error() false while rank/zeros/Taylor were never set.
+  {
+    Lparams_t LpSp = { .degree = 4, .conductor = 196, .normalisation = 0.5,
+                       .mus = (double[]){0,0,1,1}, .target_prec = 100, .wprec = 0,
+                       .gprec = 0, .self_dual = YES, .rank = DK, .cache_dir = ".",
+                       .extract_powers = YES };
+    Lerror_t eSp = ERR_SUCCESS;
+    Lfunc_t LSp = Lfunc_init_advanced(&LpSp, &eSp);
+    assert(!fatal_error(eSp));
+    (void) Lfunc_nmax(LSp);
+    fmpz_poly_t rSp, fSp;
+    fmpz_poly_init(rSp); fmpz_poly_init(fSp);
+    fmpz_poly_set_coeff_ui(rSp, 0, 1);           // r = 1 - T + 1009*T^2
+    fmpz_poly_set_coeff_si(rSp, 1, -1);
+    fmpz_poly_set_coeff_ui(rSp, 2, 1009);
+    fmpz_poly_pow(fSp, rSp, 2);                  // F_1009 = r^2, full degree 4
+    eSp |= Lfunc_use_lpoly_fmpz(LSp, 1009, fSp);
+    fmpz_poly_clear(rSp); fmpz_poly_clear(fSp);
+    eSp |= Lfunc_compute(LSp);
+    assert(fatal_error(eSp));                    // the abort must be fatal...
+    assert(eSp & ERR_POWER);
+    assert(eSp & ERR_INSUFF_EULER);              // ...and keep the why
+    assert(Lfunc_factors(LSp, NULL, NULL) == 0); // nothing half-assembled
+    Lfunc_clear(LSp);
+  }
+
+  printf("extract_power_test: sparse-supply abort is fatal OK\n");
+
   // ---- I2: non-k-divisible mus must be rejected (soundness gate) ----
   // A degree-4 L with mus={0,0,0,1} has sorted blocks [0,0] and [0,1] (k=2),
   // which are unequal: L's gamma factors disagree with any pure square, so even

--- a/test/extract_power_test.c
+++ b/test/extract_power_test.c
@@ -111,6 +111,20 @@ static void lk_badprime_callback_z(fmpz_poly_t poly, uint64_t p, int d, void *pa
   }
 }
 
+// Conductor-1 exact square with zero T^1 coefficient: L_p = (1 + T^2)^2.
+// The power guard's moment signal is zero here, so extraction depends on treating
+// conductor 1 as an exact k-th-power conductor and then certifying the fmpz roots.
+static void conductor1_square_callback_z(fmpz_poly_t poly, uint64_t p, int d, void *param)
+{
+  (void)p; (void)d; (void)param;
+  fmpz_poly_t root;
+  fmpz_poly_init(root);
+  fmpz_poly_set_coeff_ui(root, 0, 1);
+  fmpz_poly_set_coeff_ui(root, 2, 1);
+  fmpz_poly_pow(poly, root, 2);
+  fmpz_poly_clear(root);
+}
+
 // callback for the complex (non-self-dual) boundary: build M with a COMPLEX linear
 // coefficient (i times E_p's), so L = M^2 has complex Euler factors but the same 2nd
 // moment and perfect-square conductor as E^2 (detection still finds k=2). The exact
@@ -303,9 +317,33 @@ int main(void)
 	    Lfunc_clear(LMix2);
 	  }
 
-	  printf("extract_power_test: mixed provenance refused OK\n");
+  printf("extract_power_test: mixed provenance refused OK\n");
 
-	  // ---- E^3 (degree 6, odd k) ----
+  // Conductor 1 is still an exact square conductor: exact supplied powers must
+  // enter extraction instead of falling through as an ordinary primitive object.
+  // A previous temporary reproducer for this path returned ERR_POWER=0 and
+  // n_factors=0; the factor assertion below catches that bypass directly.
+  {
+    Lparams_t LpOne = { .degree = 4, .conductor = 1, .normalisation = 0.0,
+                        .mus = (double[]){0,0,1,1}, .target_prec = 100,
+                        .wprec = 0, .gprec = 0, .self_dual = YES, .rank = DK,
+                        .cache_dir = ".", .extract_powers = YES };
+    Lerror_t eOne = ERR_SUCCESS;
+    Lfunc_t LOne = Lfunc_init_advanced(&LpOne, &eOne);
+    assert(!fatal_error(eOne));
+    eOne |= Lfunc_use_all_lpolys_fmpz(LOne, conductor1_square_callback_z, NULL);
+    eOne |= Lfunc_compute(LOne);
+    assert(!fatal_error(eOne));
+    Lfunc_t *fOne = NULL; uint64_t *mOne = NULL;
+    assert(Lfunc_factors(LOne, &fOne, &mOne) == 1);
+    assert(mOne[0] == 2);
+    assert(Lfunc_rank(LOne) == 2*Lfunc_rank(fOne[0]));
+    Lfunc_clear(LOne);
+  }
+
+  printf("extract_power_test: conductor-1 exact square extracted OK\n");
+
+  // ---- E^3 (degree 6, odd k) ----
   k_param = 3;
   Lfunc_t Eref3 = Lfunc_init(2, 37, 0.5, mus, &ec);
   ec = ERR_SUCCESS;

--- a/test/gcache_collision_test.c
+++ b/test/gcache_collision_test.c
@@ -52,7 +52,7 @@ static void cleanup_dir(const char *dir) {
 // exp(2 pi (hi_i + 1/2) / B) term directly.
 static uint64_t nmax_in(uint64_t degree, double normalisation,
                         const double *mus, const char *cache_dir) {
-  Lparams_t Lp;
+  Lparams_t Lp = {0};
   Lp.degree = degree;
   Lp.conductor = 1;
   Lp.normalisation = normalisation;

--- a/test/gcache_collision_test.c
+++ b/test/gcache_collision_test.c
@@ -63,6 +63,7 @@ static uint64_t nmax_in(uint64_t degree, double normalisation,
   Lp.cache_dir = (char *)cache_dir;
   Lp.gprec = 0;                    // required for the cache path
   Lp.wprec = 0;
+  Lp.allow_nonprimitive = NO;
 
   Lerror_t ecode = ERR_SUCCESS;
   Lfunc_t L = Lfunc_init_advanced(&Lp, &ecode);

--- a/test/gcache_collision_test.c
+++ b/test/gcache_collision_test.c
@@ -63,7 +63,7 @@ static uint64_t nmax_in(uint64_t degree, double normalisation,
   Lp.cache_dir = (char *)cache_dir;
   Lp.gprec = 0;                    // required for the cache path
   Lp.wprec = 0;
-  Lp.allow_nonprimitive = NO;
+  Lp.extract_powers = NO;
 
   Lerror_t ecode = ERR_SUCCESS;
   Lfunc_t L = Lfunc_init_advanced(&Lp, &ecode);

--- a/test/gcache_validate_test.c
+++ b/test/gcache_validate_test.c
@@ -71,6 +71,7 @@ static bool init_is_fatal(uint64_t degree, double normalisation,
   Lp.cache_dir = (char *)cache_dir;
   Lp.gprec = 0;                          // required for the cache path
   Lp.wprec = wprec;
+  Lp.allow_nonprimitive = NO;
 
   Lerror_t ecode = ERR_SUCCESS;
   Lfunc_t L = Lfunc_init_advanced(&Lp, &ecode);

--- a/test/gcache_validate_test.c
+++ b/test/gcache_validate_test.c
@@ -60,7 +60,7 @@ static void cleanup_dir(const char *dir) {
 static bool init_is_fatal(uint64_t degree, double normalisation,
                           const double *mus, int64_t wprec,
                           const char *cache_dir, uint64_t *out_nmax) {
-  Lparams_t Lp;
+  Lparams_t Lp = {0};
   Lp.degree = degree;
   Lp.conductor = 1;
   Lp.normalisation = normalisation;

--- a/test/gcache_validate_test.c
+++ b/test/gcache_validate_test.c
@@ -71,7 +71,7 @@ static bool init_is_fatal(uint64_t degree, double normalisation,
   Lp.cache_dir = (char *)cache_dir;
   Lp.gprec = 0;                          // required for the cache path
   Lp.wprec = wprec;
-  Lp.allow_nonprimitive = NO;
+  Lp.extract_powers = NO;
 
   Lerror_t ecode = ERR_SUCCESS;
   Lfunc_t L = Lfunc_init_advanced(&Lp, &ecode);

--- a/test/highdeg/gen.py
+++ b/test/highdeg/gen.py
@@ -285,12 +285,13 @@ def main():
 
     e = obj["expected"]
     tay = e.get("taylor")
-    expect = "EXPECT %d %s %s %s %s %s %s %d %d" % (
+    expect = "EXPECT %d %s %s %s %s %s %s %d %d %d" % (
         e["rank"], repr(float(e["epsilon"][0])), repr(float(e["epsilon"][1])),
         str(e["first_zero"]), repr(float(e["first_zero_err"])),
         (str(tay) if tay is not None else "NA"),
         repr(float(e.get("taylor_err", 0.0))), 1 if e["tolerate_rh_error"] else 0,
-        1 if obj.get("expect_power") else 0)
+        1 if obj.get("expect_power") else 0,
+        1 if obj.get("extract_power") else 0)
 
     is_sympow = obj["kind"] == "sympow"
     head = "%d %d %s %d%s" % (der["degree"], cond, der["norm"], der["sd"],

--- a/test/highdeg/gen.py
+++ b/test/highdeg/gen.py
@@ -285,11 +285,12 @@ def main():
 
     e = obj["expected"]
     tay = e.get("taylor")
-    expect = "EXPECT %d %s %s %s %s %s %s %d" % (
+    expect = "EXPECT %d %s %s %s %s %s %s %d %d" % (
         e["rank"], repr(float(e["epsilon"][0])), repr(float(e["epsilon"][1])),
         str(e["first_zero"]), repr(float(e["first_zero_err"])),
         (str(tay) if tay is not None else "NA"),
-        repr(float(e.get("taylor_err", 0.0))), 1 if e["tolerate_rh_error"] else 0)
+        repr(float(e.get("taylor_err", 0.0))), 1 if e["tolerate_rh_error"] else 0,
+        1 if obj.get("expect_power") else 0)
 
     is_sympow = obj["kind"] == "sympow"
     head = "%d %d %s %d%s" % (der["degree"], cond, der["norm"], der["sd"],

--- a/test/highdeg/objects.yaml
+++ b/test/highdeg/objects.yaml
@@ -272,13 +272,15 @@ objects:
       taylor_err: 1.0e-12
       tolerate_rh_error: true
 
-  # ---- square of an elliptic curve (L = L(E)^2): rejected by the power guard ----
+  # ---- square of an elliptic curve (L = L(E)^2): extracted and assembled ----
   # Jac(196.a) ~_Q E^2 with E = 14.a (conductor 14), so L = L(14.a)^2 and every zero
-  # is doubled. The power guard detects the repeated factor (perfect-square Euler
-  # factors and a perfect-square conductor 196 = 14^2) and rejects it up front with
-  # ERR_POWER, so `expect_power` makes this a positive regression: the driver asserts
-  # the rejection. smalljac still computes its (squared) Euler factors fine. When square
-  # support (extraction, bead w70.2) lands, replace `expect_power` with the value checks.
+  # is doubled. With extract_powers opted in, the library detects the repeated factor
+  # (perfect-square Euler factors and a perfect-square conductor 196 = 14^2), recovers
+  # M = L(14.a), computes it through the normal degree-2 pipeline, and assembles L's
+  # rank/eps/zeros/Taylor from M (= M^2). `extract_power` makes this a positive
+  # regression: the driver asserts the assembled values below (which are L(14.a)^2)
+  # and that Lfunc_factors exposes (M, 2). smalljac computes its (squared) Euler
+  # factors fine.
   - label: "196.a"          # geom_end_alg "M_2(Q)", ST E_1: Q-isogenous to E^2 (= 14.a^2)
     kind: genus2
     curve: "[[1,3,6,7,6,3,1],[0,1,1]]"
@@ -287,8 +289,8 @@ objects:
     bad_factors:            # (1+T)^2 at 2 and (1-T)^2 at 7 -- squares, since L = L(E)^2
       2: [1, 2, 1]
       7: [1, -2, 1]
-    expect_power: true      # guard must reject L = L(14.a)^2 with ERR_POWER (repeated factor / doubled zeros)
-    expected:               # the L(14.a)^2 values; checked once extraction (w70.2) lands, ignored while expect_power is set
+    extract_power: true     # extract & assemble L = L(14.a)^2: recover M=14.a, compute, assemble (M^2); assert factor (M,2)
+    expected:               # the assembled L(14.a)^2 values (= M^2), now asserted by the driver
       rank: 0
       epsilon: [1.0, 0.0]
       first_zero: "5.57928681743"

--- a/test/highdeg/objects.yaml
+++ b/test/highdeg/objects.yaml
@@ -272,12 +272,13 @@ objects:
       taylor_err: 1.0e-12
       tolerate_rh_error: true
 
-  # ---- known-unsupported: square of an elliptic curve (L = L(E)^2) ----
+  # ---- square of an elliptic curve (L = L(E)^2): rejected by the power guard ----
   # Jac(196.a) ~_Q E^2 with E = 14.a (conductor 14), so L = L(14.a)^2 and every zero
-  # is doubled. The library cannot yet resolve repeated factors / double zeros, so this
-  # is expected to FAIL: it is marked `xfail` and wired into the suite now, so that when
-  # square support lands, deleting `xfail` promotes it to a real test. smalljac still
-  # computes its (squared) Euler factors fine; the failure is in the L-function solver.
+  # is doubled. The power guard detects the repeated factor (perfect-square Euler
+  # factors and a perfect-square conductor 196 = 14^2) and rejects it up front with
+  # ERR_POWER, so `expect_power` makes this a positive regression: the driver asserts
+  # the rejection. smalljac still computes its (squared) Euler factors fine. When square
+  # support (extraction, bead w70.2) lands, replace `expect_power` with the value checks.
   - label: "196.a"          # geom_end_alg "M_2(Q)", ST E_1: Q-isogenous to E^2 (= 14.a^2)
     kind: genus2
     curve: "[[1,3,6,7,6,3,1],[0,1,1]]"
@@ -286,8 +287,8 @@ objects:
     bad_factors:            # (1+T)^2 at 2 and (1-T)^2 at 7 -- squares, since L = L(E)^2
       2: [1, 2, 1]
       7: [1, -2, 1]
-    xfail: "Jac ~_Q E^2 (14.a^2); L = L(E)^2 has repeated factors / doubled zeros not yet supported"
-    expected:               # the L(14.a)^2 values, ready for when square support lands
+    expect_power: true      # guard must reject L = L(14.a)^2 with ERR_POWER (repeated factor / doubled zeros)
+    expected:               # the L(14.a)^2 values; checked once extraction (w70.2) lands, ignored while expect_power is set
       rank: 0
       epsilon: [1.0, 0.0]
       first_zero: "5.57928681743"

--- a/test/highdeg_check.cpp
+++ b/test/highdeg_check.cpp
@@ -8,7 +8,10 @@
 //   line 1: degree conductor normalisation self_dual
 //   line 2: mu_0 ... mu_{degree-1}
 //   line 3: EXPECT rank eps_re eps_im z1 z1_err taylor taylor_err tolerate_rh
-//             (taylor == "NA" => skip the leading-Taylor assertion)
+//             expect_power extract_power
+//             (taylor == "NA" => skip the leading-Taylor assertion;
+//              expect_power => assert the power guard rejects with ERR_POWER;
+//              extract_power => opt in to extraction, assert assembled values + factor)
 //   line p: p c0 c1 ... c_degree     (local L-poly coeffs, ascending, decimal strings)
 //
 // With only lines 1-2 present (no EXPECT, no factors) it prints the library's
@@ -66,6 +69,26 @@ int main(int argc, char **argv) {
   std::vector<double> mus(degree);
   for (auto &m : mus) s2 >> m;
 
+  // EXPECT line (optional — absent => nmax query). Parsed BEFORE init so the
+  // extract_powers opt-in can be set on Lparams: factor retention in use_lpoly
+  // and the extraction branch in Lfunc_compute both need the flag set before the
+  // factor-supply loop below.
+  int exp_rank = -1, tolerate_rh = 0, expect_power = 0, extract_power = 0;
+  double eps_re = 0, eps_im = 0, z1_err = 0, taylor_err = 0;
+  std::string z1s, taylors = "NA";
+  bool have_expect = false;
+  std::streampos after_mus = in.tellg();
+  if (std::getline(in, line)) {
+    std::stringstream s3(line);
+    std::string kw; s3 >> kw;
+    if (kw == "EXPECT") {
+      have_expect = true;
+      s3 >> exp_rank >> eps_re >> eps_im >> z1s >> z1_err >> taylors >> taylor_err >> tolerate_rh >> expect_power >> extract_power;
+    } else {
+      in.seekg(after_mus);  // line was a factor; rewind
+    }
+  }
+
   // Public advanced init so self-duality is declared up front instead of poking
   // the opaque handle. Mirrors Lfunc_init's defaults (target_prec=DEFAULT and
   // gprec=0 keep the G-cache active, see src/g.c); Lfunc_init_advanced copies
@@ -83,26 +106,10 @@ int main(int argc, char **argv) {
   Lp.self_dual = self_dual ? YES : DK;
   Lp.rank = DK;
   Lp.cache_dir = cache_dir;
+  Lp.extract_powers = extract_power ? YES : NO;
   Lfunc_t L = Lfunc_init_advanced(&Lp, &ec);
   if (fatal_error(ec)) { fprint_errors(stderr, ec); return 1; }
   uint64_t nmax = Lfunc_nmax(L);
-
-  // EXPECT line (optional — absent => nmax query)
-  int exp_rank = -1, tolerate_rh = 0, expect_power = 0;
-  double eps_re = 0, eps_im = 0, z1_err = 0, taylor_err = 0;
-  std::string z1s, taylors = "NA";
-  bool have_expect = false;
-  std::streampos after_mus = in.tellg();
-  if (std::getline(in, line)) {
-    std::stringstream s3(line);
-    std::string kw; s3 >> kw;
-    if (kw == "EXPECT") {
-      have_expect = true;
-      s3 >> exp_rank >> eps_re >> eps_im >> z1s >> z1_err >> taylors >> taylor_err >> tolerate_rh >> expect_power;
-    } else {
-      in.seekg(after_mus);  // line was a factor; rewind
-    }
-  }
 
   acb_poly_t poly; acb_poly_init(poly);
   fmpz_t z; fmpz_init(z);
@@ -214,6 +221,14 @@ int main(int argc, char **argv) {
       arb_clear(tref);
     } else {
       printf("  [skip] taylor (not provided)\n");
+    }
+
+    // (5) assembled power: the primitive factor M with multiplicity k is exposed.
+    if (extract_power) {
+      Lfunc_t *fs = NULL; uint64_t *ms = NULL;
+      uint64_t nf = Lfunc_factors(L, &fs, &ms);
+      { std::stringstream d; d << "n_factors=" << nf << (nf? (std::string(" mult=")+std::to_string(ms[0])) : std::string());
+        check(nf == 1 && ms[0] == 2, "factor", d.str()); }
     }
   }
 

--- a/test/highdeg_check.cpp
+++ b/test/highdeg_check.cpp
@@ -176,8 +176,10 @@ int main(int argc, char **argv) {
     // This object has a repeated primitive factor (e.g. L = L(E)^2): the power
     // guard must reject it up front with ERR_POWER. Assert that and skip the value
     // checks (it is intentionally not computed). Positive guard regression.
-    check((ec & ERR_POWER) != 0, "power-rejected",
-          "guard must reject this repeated-factor object with ERR_POWER");
+    uint64_t fatal_bits = ec & 0xFFFFFFFFu;
+    { std::stringstream d; d << "fatal_bits=0x" << std::hex << fatal_bits;
+      check(fatal_bits == ERR_POWER, "power-rejected",
+            "guard must reject with exactly ERR_POWER; " + d.str()); }
     fprintf(stderr, "ecode: "); fprint_errors(stderr, ec);
 	    fmpz_poly_clear(zpoly); acb_poly_clear(poly); fmpz_clear(z); Lfunc_clear(L);
     return g_fail;

--- a/test/highdeg_check.cpp
+++ b/test/highdeg_check.cpp
@@ -95,7 +95,7 @@ int main(int argc, char **argv) {
   // Lp.mus, so the local vector suffices, and cache_dir outlives the Lfunc.
   Lerror_t ec = 0;
   char cache_dir[] = ".";
-  Lparams_t Lp;
+  Lparams_t Lp = {};
   Lp.degree = degree;
   Lp.conductor = conductor;
   Lp.normalisation = norm;
@@ -111,21 +111,22 @@ int main(int argc, char **argv) {
   if (fatal_error(ec)) { fprint_errors(stderr, ec); return 1; }
   uint64_t nmax = Lfunc_nmax(L);
 
-  acb_poly_t poly; acb_poly_init(poly);
-  fmpz_t z; fmpz_init(z);
-  acb_t c; acb_init(c);
-  uint64_t count = 0;
-  while (std::getline(in, line)) {
+	  acb_poly_t poly; acb_poly_init(poly);
+	  fmpz_poly_t zpoly; fmpz_poly_init(zpoly);
+	  fmpz_t z; fmpz_init(z);
+	  uint64_t count = 0;
+	  while (std::getline(in, line)) {
     if (line.empty()) continue;
     std::stringstream ss(line);
     uint64_t p; ss >> p;
     if (p > nmax) continue;
-    std::vector<std::string> toks; std::string tok;
-    while (ss >> tok) toks.push_back(tok);
-    acb_poly_zero(poly);
-    if (form_sympow && toks.size() == 1) {
-      // base a_p only: form the Sym^k good-prime factor here, exact fmpz -> acb
-      fmpz_set_str(z, toks[0].c_str(), 10);
+	    std::vector<std::string> toks; std::string tok;
+	    while (ss >> tok) toks.push_back(tok);
+	    acb_poly_zero(poly);
+	    fmpz_poly_zero(zpoly);
+	    if (form_sympow && toks.size() == 1) {
+	      // base a_p only: form the Sym^k good-prime factor here, exact fmpz
+	      fmpz_set_str(z, toks[0].c_str(), 10);
       // A base a_p must satisfy the Hasse bound a_p^2 <= 4p (checked in fmpz to
       // avoid overflow). A value outside it is not a trace (e.g. a mis-padded bad
       // factor whose leading coefficient landed on a one-token line), so fail
@@ -137,40 +138,36 @@ int main(int argc, char **argv) {
         fmpz_set_ui(fourp, p); fmpz_mul_ui(fourp, fourp, 4); // 4p
         const bool hasse_ok = (fmpz_cmp(aa, fourp) <= 0);
         fmpz_clear(aa); fmpz_clear(fourp);
-        if (!hasse_ok) {
-          fprintf(stderr, "sympow base a_p=%s violates the Hasse bound at p=%lu (corrupt input)\n",
-                  toks[0].c_str(), (unsigned long) p);
-          acb_poly_clear(poly); fmpz_clear(z); acb_clear(c); Lfunc_clear(L);
-          return 2;
-        }
-      }
-      fmpz_poly_t f; fmpz_poly_init(f);
-      sym_power_lpoly(f, fmpz_get_si(z), p, sym_k);
-      const slong d = fmpz_poly_degree(f);
-      for (slong j = 0; j <= d; j++) {
-        fmpz_poly_get_coeff_fmpz(z, f, j);
-        acb_set_fmpz(c, z);
-        acb_poly_set_coeff_acb(poly, j, c);
-      }
-      fmpz_poly_clear(f);
-    } else {
-      // explicit local-factor coefficients (ascending): good ec/genus2/cmf primes
-      // and all bad primes, including sympow's
-      for (uint64_t i = 0; i < toks.size(); i++) {
-        fmpz_set_str(z, toks[i].c_str(), 10);
-        acb_set_fmpz(c, z);
-        acb_poly_set_coeff_acb(poly, i, c);
-      }
-    }
-    Lfunc_use_lpoly(L, p, poly);
-    count++;
-  }
+	        if (!hasse_ok) {
+	          fprintf(stderr, "sympow base a_p=%s violates the Hasse bound at p=%lu (corrupt input)\n",
+	                  toks[0].c_str(), (unsigned long) p);
+	          fmpz_poly_clear(zpoly); acb_poly_clear(poly); fmpz_clear(z); Lfunc_clear(L);
+	          return 2;
+	        }
+	      }
+	      sym_power_lpoly(zpoly, fmpz_get_si(z), p, sym_k);
+	    } else {
+	      // explicit local-factor coefficients (ascending): good ec/genus2/cmf primes
+	      // and all bad primes, including sympow's
+	      for (uint64_t i = 0; i < toks.size(); i++) {
+	        fmpz_set_str(z, toks[i].c_str(), 10);
+	        fmpz_poly_set_coeff_fmpz(zpoly, i, z);
+	      }
+	    }
+	    if (extract_power) {
+	      ec |= Lfunc_use_lpoly_fmpz(L, p, zpoly);
+	    } else {
+	      acb_poly_set_fmpz_poly(poly, zpoly, Lfunc_wprec(L));
+	      Lfunc_use_lpoly(L, p, poly);
+	    }
+	    count++;
+	  }
 
-  if (count == 0) {  // nmax query
-    printf("nmax=%lu\n", nmax);
-    acb_poly_clear(poly); fmpz_clear(z); acb_clear(c); Lfunc_clear(L);
-    return 0;
-  }
+	  if (count == 0) {  // nmax query
+	    printf("nmax=%lu\n", nmax);
+	    fmpz_poly_clear(zpoly); acb_poly_clear(poly); fmpz_clear(z); Lfunc_clear(L);
+	    return 0;
+	  }
 
   ec |= Lfunc_compute(L);
   printf("degree=%lu conductor=%lu nmax=%lu primes=%lu\n", degree, conductor, nmax, count);
@@ -182,7 +179,7 @@ int main(int argc, char **argv) {
     check((ec & ERR_POWER) != 0, "power-rejected",
           "guard must reject this repeated-factor object with ERR_POWER");
     fprintf(stderr, "ecode: "); fprint_errors(stderr, ec);
-    acb_poly_clear(poly); fmpz_clear(z); acb_clear(c); Lfunc_clear(L);
+	    fmpz_poly_clear(zpoly); acb_poly_clear(poly); fmpz_clear(z); Lfunc_clear(L);
     return g_fail;
   }
 
@@ -233,6 +230,6 @@ int main(int argc, char **argv) {
   }
 
   fprintf(stderr, "ecode: "); fprint_errors(stderr, ec);
-  acb_poly_clear(poly); fmpz_clear(z); acb_clear(c); Lfunc_clear(L);
+	  fmpz_poly_clear(zpoly); acb_poly_clear(poly); fmpz_clear(z); Lfunc_clear(L);
   return g_fail;
 }

--- a/test/highdeg_check.cpp
+++ b/test/highdeg_check.cpp
@@ -88,7 +88,7 @@ int main(int argc, char **argv) {
   uint64_t nmax = Lfunc_nmax(L);
 
   // EXPECT line (optional — absent => nmax query)
-  int exp_rank = -1, tolerate_rh = 0;
+  int exp_rank = -1, tolerate_rh = 0, expect_power = 0;
   double eps_re = 0, eps_im = 0, z1_err = 0, taylor_err = 0;
   std::string z1s, taylors = "NA";
   bool have_expect = false;
@@ -98,7 +98,7 @@ int main(int argc, char **argv) {
     std::string kw; s3 >> kw;
     if (kw == "EXPECT") {
       have_expect = true;
-      s3 >> exp_rank >> eps_re >> eps_im >> z1s >> z1_err >> taylors >> taylor_err >> tolerate_rh;
+      s3 >> exp_rank >> eps_re >> eps_im >> z1s >> z1_err >> taylors >> taylor_err >> tolerate_rh >> expect_power;
     } else {
       in.seekg(after_mus);  // line was a factor; rewind
     }
@@ -167,6 +167,17 @@ int main(int argc, char **argv) {
 
   ec |= Lfunc_compute(L);
   printf("degree=%lu conductor=%lu nmax=%lu primes=%lu\n", degree, conductor, nmax, count);
+
+  if (expect_power) {
+    // This object has a repeated primitive factor (e.g. L = L(E)^2): the power
+    // guard must reject it up front with ERR_POWER. Assert that and skip the value
+    // checks (it is intentionally not computed). Positive guard regression.
+    check((ec & ERR_POWER) != 0, "power-rejected",
+          "guard must reject this repeated-factor object with ERR_POWER");
+    fprintf(stderr, "ecode: "); fprint_errors(stderr, ec);
+    acb_poly_clear(poly); fmpz_clear(z); acb_clear(c); Lfunc_clear(L);
+    return g_fail;
+  }
 
   // (0) no fatal error; RH warning tolerated only when declared
   check(!fatal_error(ec), "no-fatal", "");

--- a/test/power_guard_test.c
+++ b/test/power_guard_test.c
@@ -6,6 +6,9 @@
     2. same, opted in     (extract_powers):  confirmed a power, M is degree 1 -> ERR_BAD_DEGREE.
     3. L(chi5)*L(chi7)     (degree 2, cond 35):  imprimitive but squarefree -> NOT rejected.
     4. L(chi3)^4          (degree 4, cond 81):  4th power          -> ERR_POWER by default.
+    5. synthetic square   (degree 2, cond 25):  low moment, rejected via the conductor signal alone.
+    6. L(chi5_4)^2        (degree 2, cond 25):  COMPLEX power      -> ERR_POWER (guard handles complex).
+    7. L(chi5_4)*L(chi5)  (degree 2, cond 25):  COMPLEX squarefree -> NOT rejected (Signal 1 over acb).
 */
 #include <stdio.h>
 #include <inttypes.h>
@@ -24,7 +27,29 @@ static void linear_factor(acb_poly_t f, int chi){
   if(chi!=0) acb_poly_set_coeff_si(f,1,-chi);
 }
 
-// kind: 1 = (1-chi5 T)^2, 2 = (1-chi5 T)(1-chi7 T), 3 = (1-chi3 T)^4
+// complex (order-4) Dirichlet character mod 5: chi(2)=i (2 is a primitive root mod 5),
+// so chi takes values in {1, i, -1, -i, 0}. This is a genuinely complex (non-self-dual)
+// character, used to exercise the guard's signals on complex acb coefficients.
+static void chi5_4(acb_t res, uint64_t p){
+  switch(p%5){
+    case 1: acb_set_si(res, 1); break;
+    case 2: acb_onei(res); break;                       //  i
+    case 3: acb_onei(res); acb_neg(res, res); break;    // -i
+    case 4: acb_set_si(res, -1); break;
+    default: acb_zero(res); break;                      // p == 0 mod 5
+  }
+}
+
+// (1 - chi(p) T) for a complex chi value
+static void linear_factor_acb(acb_poly_t f, const acb_t chi){
+  acb_t neg; acb_init(neg); acb_neg(neg, chi);
+  acb_poly_one(f);
+  acb_poly_set_coeff_acb(f, 1, neg);
+  acb_clear(neg);
+}
+
+// kind: 1 = (1-chi5 T)^2, 2 = (1-chi5 T)(1-chi7 T), 3 = (1-chi3 T)^4,
+//       5 = (1-chi5_4 T)^2 (complex power), 6 = (1-chi5_4 T)(1-chi5 T) (complex squarefree)
 static void cb(acb_poly_t poly, uint64_t p, int d, int64_t prec, void *param){
   (void)d;
   int kind = *(int *)param;
@@ -53,6 +78,17 @@ static void cb(acb_poly_t poly, uint64_t p, int d, int64_t prec, void *param){
     acb_poly_set_coeff_acb(a, 1, half);   // 1 - 0.5 T
     acb_poly_mul(poly, a, a, prec);        // (1 - 0.5 T)^2
     acb_clear(half);
+  } else if(kind==5){
+    acb_t c; acb_init(c); chi5_4(c, p);
+    linear_factor_acb(a, c);
+    acb_poly_mul(poly, a, a, prec);        // (1 - chi5_4 T)^2 : complex repeated factor
+    acb_clear(c);
+  } else if(kind==6){
+    acb_t c; acb_init(c); chi5_4(c, p);
+    linear_factor_acb(a, c);
+    linear_factor(b, chi5(p));
+    acb_poly_mul(poly, a, b, prec);        // (1 - chi5_4 T)(1 - chi5 T) : complex, squarefree
+    acb_clear(c);
   }
   acb_poly_clear(a); acb_poly_clear(b);
 }
@@ -120,6 +156,31 @@ int main(void){
   Lerror_t e5 = run(L5, 4);
   Lfunc_clear(L5);
   assert(e5 & ERR_POWER);
+
+  // 6. COMPLEX power: (1 - chi5_4 T)^2 with chi5_4 an order-4 (complex) character mod 5,
+  //    conductor 25 = 5^2. The guard's signals operate on complex acb factors: the
+  //    repeated factor is not squarefree, the 2nd moment is ~4, and the conductor is a
+  //    perfect power, so a genuine complex power is detected -> ERR_POWER.
+  double mus_11[] = {1,1};      // chi5_4 is odd (chi(-1)=chi(4)=-1) -> mu=1; squared -> [1,1]
+  ecode = ERR_SUCCESS;
+  Lfunc_t L6 = Lfunc_init(2, 25, 0.0, mus_11, &ecode);
+  assert(!fatal_error(ecode));
+  Lerror_t e6 = run(L6, 5);
+  Lfunc_clear(L6);
+  assert(e6 & ERR_POWER);       // complex repeated factor detected
+
+  // 7. COMPLEX squarefree primitive: (1 - chi5_4 T)(1 - chi5 T), two distinct factors
+  //    (one complex), conductor 25 = 5^2. Despite the perfect-power conductor, the
+  //    squarefree certificate (Signal 1, a Sylvester determinant over acb) is checked
+  //    first and vetoes -> NOT false-rejected. Confirms the squarefree certificate is
+  //    sound on complex coefficients (the complex analogue of the cmf_25.12.a.a control).
+  double mus_01[] = {0,1};      // chi5 even (mu=0), chi5_4 odd (mu=1)
+  ecode = ERR_SUCCESS;
+  Lfunc_t L7 = Lfunc_init(2, 25, 0.0, mus_01, &ecode);
+  assert(!fatal_error(ecode));
+  Lerror_t e7 = run(L7, 6);
+  Lfunc_clear(L7);
+  assert(!(e7 & ERR_POWER));    // complex squarefree -> not flagged
 
   printf("power_guard_test: all assertions passed\n");
   return 0;

--- a/test/power_guard_test.c
+++ b/test/power_guard_test.c
@@ -1,0 +1,102 @@
+/*
+  Regression test for the power / repeated-factor guard (ERR_POWER); bead lfunctions-w70.1.
+  Asserts on the error bitfield, never on printed output.
+
+    1. L(chi5)^2          (degree 2, cond 25):  genuine square     -> ERR_POWER by default.
+    2. same, bypassed     (allow_nonprimitive):  guard suppressed   -> no ERR_POWER.
+    3. L(chi5)*L(chi7)     (degree 2, cond 35):  imprimitive but squarefree -> NOT rejected.
+    4. L(chi3)^4          (degree 4, cond 81):  4th power          -> ERR_POWER by default.
+*/
+#include <stdio.h>
+#include <inttypes.h>
+#include <assert.h>
+#include <flint/acb_poly.h>
+#include "glfunc.h"
+
+// real (quadratic) Dirichlet characters, value in {-1,0,1}
+static int chi3(uint64_t p){ uint64_t r=p%3; if(r==0) return 0; return (r==1)?1:-1; }
+static int chi5(uint64_t p){ uint64_t r=p%5; if(r==1||r==4) return 1; if(r==2||r==3) return -1; return 0; }
+static int chi7(uint64_t p){ uint64_t r=p%7; if(r==0) return 0; return (r==1||r==2||r==4)?1:-1; }
+
+// (1 - chi(p) T) as an acb_poly
+static void linear_factor(acb_poly_t f, int chi){
+  acb_poly_one(f);
+  if(chi!=0) acb_poly_set_coeff_si(f,1,-chi);
+}
+
+// kind: 1 = (1-chi5 T)^2, 2 = (1-chi5 T)(1-chi7 T), 3 = (1-chi3 T)^4
+static void cb(acb_poly_t poly, uint64_t p, int d, int64_t prec, void *param){
+  (void)d;
+  int kind = *(int *)param;
+  acb_poly_t a,b;
+  acb_poly_init(a); acb_poly_init(b);
+  if(kind==1){
+    linear_factor(a, chi5(p));
+    acb_poly_mul(poly, a, a, prec);                 // (1-chi5 T)^2
+  } else if(kind==2){
+    linear_factor(a, chi5(p));
+    linear_factor(b, chi7(p));
+    acb_poly_mul(poly, a, b, prec);                 // (1-chi5 T)(1-chi7 T)
+  } else {
+    linear_factor(a, chi3(p));
+    acb_poly_mul(b, a, a, prec);                    // (1-chi3 T)^2
+    acb_poly_mul(poly, b, b, prec);                 // (1-chi3 T)^4
+  }
+  acb_poly_clear(a); acb_poly_clear(b);
+}
+
+// supply Euler factors and run the computation; return the accumulated error code
+static Lerror_t run(Lfunc_t L, int kind){
+  Lerror_t ecode = ERR_SUCCESS;
+  int k = kind;
+  ecode |= Lfunc_use_all_lpolys(L, cb, &k);
+  ecode |= Lfunc_compute(L);
+  return ecode;
+}
+
+int main(void){
+  double mus2[] = {0,0};       // L(chi5)^2 -> [0,0]
+  double mus_57[] = {0,1};     // L(chi5) even (0), L(chi7) odd (1)
+  double mus4[] = {1,1,1,1};   // chi3 is odd (mu=1); chi3^4 -> [1,1,1,1]
+  Lerror_t ecode;
+
+  // 1. genuine square -> rejected
+  ecode = ERR_SUCCESS;
+  Lfunc_t L1 = Lfunc_init(2, 25, 0.0, mus2, &ecode);
+  assert(!fatal_error(ecode));
+  Lerror_t e1 = run(L1, 1);
+  Lfunc_clear(L1);
+  assert(e1 & ERR_POWER);
+
+  // 2. same object, guard bypassed -> NOT flagged as ERR_POWER
+  Lparams_t Lp;
+  Lp.degree = 2; Lp.conductor = 25; Lp.normalisation = 0.0; Lp.mus = mus2;
+  Lp.target_prec = DEFAULT_TARGET_PREC; Lp.wprec = 0; Lp.gprec = 0;
+  Lp.self_dual = DK; Lp.rank = DK; Lp.cache_dir = ".";
+  Lp.allow_nonprimitive = YES;
+  ecode = ERR_SUCCESS;
+  Lfunc_t L2 = Lfunc_init_advanced(&Lp, &ecode);
+  assert(!fatal_error(ecode));
+  Lerror_t e2 = run(L2, 1);
+  Lfunc_clear(L2);
+  assert(!(e2 & ERR_POWER));
+
+  // 3. imprimitive but squarefree (two distinct primitives) -> NOT rejected
+  ecode = ERR_SUCCESS;
+  Lfunc_t L3 = Lfunc_init(2, 35, 0.0, mus_57, &ecode);
+  assert(!fatal_error(ecode));
+  Lerror_t e3 = run(L3, 2);
+  Lfunc_clear(L3);
+  assert(!(e3 & ERR_POWER));
+
+  // 4. a 4th power at degree 4 -> rejected
+  ecode = ERR_SUCCESS;
+  Lfunc_t L4 = Lfunc_init(4, 81, 0.0, mus4, &ecode);
+  assert(!fatal_error(ecode));
+  Lerror_t e4 = run(L4, 3);
+  Lfunc_clear(L4);
+  assert(e4 & ERR_POWER);
+
+  printf("power_guard_test: all assertions passed\n");
+  return 0;
+}

--- a/test/power_guard_test.c
+++ b/test/power_guard_test.c
@@ -1,5 +1,5 @@
 /*
-  Regression test for the power / repeated-factor guard (ERR_POWER); bead lfunctions-w70.1.
+  Regression test for the power / repeated-factor guard (ERR_POWER).
   Asserts on the error bitfield, never on printed output.
 
     1. L(chi5)^2          (degree 2, cond 25):  genuine square     -> ERR_POWER by default.

--- a/test/power_guard_test.c
+++ b/test/power_guard_test.c
@@ -14,6 +14,7 @@
 #include <inttypes.h>
 #include <assert.h>
 #include <flint/acb_poly.h>
+#include <flint/fmpz_poly.h>
 #include "glfunc.h"
 
 // real (quadratic) Dirichlet characters, value in {-1,0,1}
@@ -25,6 +26,11 @@ static int chi7(uint64_t p){ uint64_t r=p%7; if(r==0) return 0; return (r==1||r=
 static void linear_factor(acb_poly_t f, int chi){
   acb_poly_one(f);
   if(chi!=0) acb_poly_set_coeff_si(f,1,-chi);
+}
+
+static void linear_factor_z(fmpz_poly_t f, int chi){
+  fmpz_poly_one(f);
+  if(chi!=0) fmpz_poly_set_coeff_si(f,1,-chi);
 }
 
 // complex (order-4) Dirichlet character mod 5: chi(2)=i (2 is a primitive root mod 5),
@@ -93,11 +99,33 @@ static void cb(acb_poly_t poly, uint64_t p, int d, int64_t prec, void *param){
   acb_poly_clear(a); acb_poly_clear(b);
 }
 
+static void cb_z(fmpz_poly_t poly, uint64_t p, int d, void *param){
+  (void)d;
+  int kind = *(int *)param;
+  fmpz_poly_t a;
+  fmpz_poly_init(a);
+  if(kind==1){
+    linear_factor_z(a, chi5(p));
+    fmpz_poly_mul(poly, a, a);                 // (1-chi5 T)^2
+  } else {
+    fmpz_poly_zero(poly);
+  }
+  fmpz_poly_clear(a);
+}
+
 // supply Euler factors and run the computation; return the accumulated error code
 static Lerror_t run(Lfunc_t L, int kind){
   Lerror_t ecode = ERR_SUCCESS;
   int k = kind;
   ecode |= Lfunc_use_all_lpolys(L, cb, &k);
+  ecode |= Lfunc_compute(L);
+  return ecode;
+}
+
+static Lerror_t run_z(Lfunc_t L, int kind){
+  Lerror_t ecode = ERR_SUCCESS;
+  int k = kind;
+  ecode |= Lfunc_use_all_lpolys_fmpz(L, cb_z, &k);
   ecode |= Lfunc_compute(L);
   return ecode;
 }
@@ -118,7 +146,7 @@ int main(void){
 
   // 2. same object, opted in: extraction attempted, M would be degree 1 -> ERR_BAD_DEGREE.
   //    The power IS recognised (not ERR_POWER), but the primitive factor is sub-degree-2.
-  Lparams_t Lp;
+  Lparams_t Lp = {0};
   Lp.degree = 2; Lp.conductor = 25; Lp.normalisation = 0.0; Lp.mus = mus2;
   Lp.target_prec = DEFAULT_TARGET_PREC; Lp.wprec = 0; Lp.gprec = 0;
   Lp.self_dual = DK; Lp.rank = DK; Lp.cache_dir = ".";
@@ -126,7 +154,7 @@ int main(void){
   ecode = ERR_SUCCESS;
   Lfunc_t L2 = Lfunc_init_advanced(&Lp, &ecode);
   assert(!fatal_error(ecode));
-  Lerror_t e2 = run(L2, 1);
+  Lerror_t e2 = run_z(L2, 1);
   Lfunc_clear(L2);
   assert(e2 & ERR_BAD_DEGREE);   // confirmed a power; M = degree 1 is unsupported
   assert(!(e2 & ERR_POWER));     // not guard-rejected; extraction was attempted
@@ -138,6 +166,7 @@ int main(void){
   Lerror_t e3 = run(L3, 2);
   Lfunc_clear(L3);
   assert(!(e3 & ERR_POWER));
+  assert(!fatal_error(e3));
 
   // 4. a 4th power at degree 4 -> rejected
   ecode = ERR_SUCCESS;
@@ -181,6 +210,7 @@ int main(void){
   Lerror_t e7 = run(L7, 6);
   Lfunc_clear(L7);
   assert(!(e7 & ERR_POWER));    // complex squarefree -> not flagged
+  assert(!fatal_error(e7));      // and no other fatal error was hidden by the control
 
   printf("power_guard_test: all assertions passed\n");
   return 0;

--- a/test/power_guard_test.c
+++ b/test/power_guard_test.c
@@ -37,10 +37,22 @@ static void cb(acb_poly_t poly, uint64_t p, int d, int64_t prec, void *param){
     linear_factor(a, chi5(p));
     linear_factor(b, chi7(p));
     acb_poly_mul(poly, a, b, prec);                 // (1-chi5 T)(1-chi7 T)
-  } else {
+  } else if(kind==3) {
     linear_factor(a, chi3(p));
     acb_poly_mul(b, a, a, prec);                    // (1-chi3 T)^2
     acb_poly_mul(poly, b, b, prec);                 // (1-chi3 T)^4
+  } else if(kind==4){
+    // synthetic: (1 - 0.5 T)^2 -- a non-squarefree factor with |a_p| = 1, so the 2nd
+    // moment stays ~1 (below POWER_MOMENT_THRESHOLD). It is NOT a real arithmetic Euler
+    // factor; it exists only to drive the guard's moment signal below threshold so that,
+    // at conductor 25 (=5^2), ONLY the conductor perfect-power signal can trigger the reject.
+    acb_t half;
+    acb_init(half);
+    acb_set_d(half, -0.5);
+    acb_poly_one(a);
+    acb_poly_set_coeff_acb(a, 1, half);   // 1 - 0.5 T
+    acb_poly_mul(poly, a, a, prec);        // (1 - 0.5 T)^2
+    acb_clear(half);
   }
   acb_poly_clear(a); acb_poly_clear(b);
 }
@@ -96,6 +108,16 @@ int main(void){
   Lerror_t e4 = run(L4, 3);
   Lfunc_clear(L4);
   assert(e4 & ERR_POWER);
+
+  // 5. synthetic pure square: 2nd moment ~1 (below threshold) but conductor 25 = 5^2.
+  //    No squarefree full-degree factor + moment < 3.5, so ONLY the conductor signal
+  //    can reject. Fails without the conductor trigger (the moment alone lets it through).
+  ecode = ERR_SUCCESS;
+  Lfunc_t L5 = Lfunc_init(2, 25, 0.0, mus2, &ecode);
+  assert(!fatal_error(ecode));
+  Lerror_t e5 = run(L5, 4);
+  Lfunc_clear(L5);
+  assert(e5 & ERR_POWER);
 
   printf("power_guard_test: all assertions passed\n");
   return 0;

--- a/test/power_guard_test.c
+++ b/test/power_guard_test.c
@@ -3,7 +3,7 @@
   Asserts on the error bitfield, never on printed output.
 
     1. L(chi5)^2          (degree 2, cond 25):  genuine square     -> ERR_POWER by default.
-    2. same, bypassed     (extract_powers):  guard suppressed   -> no ERR_POWER.
+    2. same, opted in     (extract_powers):  confirmed a power, M is degree 1 -> ERR_BAD_DEGREE.
     3. L(chi5)*L(chi7)     (degree 2, cond 35):  imprimitive but squarefree -> NOT rejected.
     4. L(chi3)^4          (degree 4, cond 81):  4th power          -> ERR_POWER by default.
 */
@@ -80,7 +80,8 @@ int main(void){
   Lfunc_clear(L1);
   assert(e1 & ERR_POWER);
 
-  // 2. same object, guard bypassed -> NOT flagged as ERR_POWER
+  // 2. same object, opted in: extraction attempted, M would be degree 1 -> ERR_BAD_DEGREE.
+  //    The power IS recognised (not ERR_POWER), but the primitive factor is sub-degree-2.
   Lparams_t Lp;
   Lp.degree = 2; Lp.conductor = 25; Lp.normalisation = 0.0; Lp.mus = mus2;
   Lp.target_prec = DEFAULT_TARGET_PREC; Lp.wprec = 0; Lp.gprec = 0;
@@ -91,7 +92,8 @@ int main(void){
   assert(!fatal_error(ecode));
   Lerror_t e2 = run(L2, 1);
   Lfunc_clear(L2);
-  assert(!(e2 & ERR_POWER));
+  assert(e2 & ERR_BAD_DEGREE);   // confirmed a power; M = degree 1 is unsupported
+  assert(!(e2 & ERR_POWER));     // not guard-rejected; extraction was attempted
 
   // 3. imprimitive but squarefree (two distinct primitives) -> NOT rejected
   ecode = ERR_SUCCESS;

--- a/test/power_guard_test.c
+++ b/test/power_guard_test.c
@@ -3,7 +3,7 @@
   Asserts on the error bitfield, never on printed output.
 
     1. L(chi5)^2          (degree 2, cond 25):  genuine square     -> ERR_POWER by default.
-    2. same, bypassed     (allow_nonprimitive):  guard suppressed   -> no ERR_POWER.
+    2. same, bypassed     (extract_powers):  guard suppressed   -> no ERR_POWER.
     3. L(chi5)*L(chi7)     (degree 2, cond 35):  imprimitive but squarefree -> NOT rejected.
     4. L(chi3)^4          (degree 4, cond 81):  4th power          -> ERR_POWER by default.
 */
@@ -85,7 +85,7 @@ int main(void){
   Lp.degree = 2; Lp.conductor = 25; Lp.normalisation = 0.0; Lp.mus = mus2;
   Lp.target_prec = DEFAULT_TARGET_PREC; Lp.wprec = 0; Lp.gprec = 0;
   Lp.self_dual = DK; Lp.rank = DK; Lp.cache_dir = ".";
-  Lp.allow_nonprimitive = YES;
+  Lp.extract_powers = YES;
   ecode = ERR_SUCCESS;
   Lfunc_t L2 = Lfunc_init_advanced(&Lp, &ecode);
   assert(!fatal_error(ecode));


### PR DESCRIPTION
## Summary
- Adds a **guard** that detects when the supplied L-function has a *repeated primitive factor* (a perfect power `M^k`, or more generally `N·M^k`) and rejects it up front with a new fatal **`ERR_POWER`**, instead of grinding through the full computation and returning garbage. (A repeated factor means doubled zeros, which break `stat_point` → `ERR_DBL_ZERO` → RH-count mismatch / `ERR_RH_ERROR`.)
- The guard is **bypassable** via a new `Lparams_t.allow_nonprimitive` flag (default off, so existing callers are unaffected).
- Implements bead `lfunctions-w70.1` — part A of the "handle non-primitive L-functions" epic (GitHub #2). **Guard-only**; recovering `M`/`N` (the square root / factorization) is deferred to `w70.2`/`w70.3`.

## How detection works (belt-and-suspenders; sound, not complete)
Signals 1 and 2 are accumulated per full-degree ("good") prime while the Euler factor is in hand (`src/coeff.c::use_lpoly`); signal 2b is read once from the conductor:

- **Signal 1 — rigorous, one-sided.** If any full-degree local factor `L_p(T)` is provably **squarefree** (distinct roots), then `L` has no repeated factor → safe. Tested as `res(L_p, L_p') ≠ 0` via a Sylvester-matrix determinant (`acb_mat_det`); declared squarefree only when the determinant ball provably excludes 0. A genuine primitive has squarefree full-degree factors at almost every prime, so it is **never false-rejected**.
- **Signal 2 — heuristic.** The empirical second moment `(1/#)·Σ_{p}|a_p|² → Σ mᵢ²` (which is `k²` for a pure power `M^k`).
- **Signal 2b — conductor, cheap and exact.** The conductor is multiplicative, so a pure power `M^k` has a **perfect-k-th-power conductor** (`cond(M)^k`). This corroborates a power even when the moment is noisy/low (few primes), and gives `cond(M) = cond(L)^{1/k}` for the later extraction work. (`n_is_perfect_power` on the `uint64` conductor.)
- **Decision.** Reject with `ERR_POWER` iff **both** (1) no squarefree full-degree factor was seen **and** (2) the second moment ≥ `3.5` **or** the conductor is a perfect power; otherwise proceed. Signal 1 is checked **first** and certifies primitives as safe, so signals 2/2b only ever corroborate — a primitive with a perfect-power conductor (e.g. `cmf_25.12.a.a`, conductor 25 = 5²) is still cleared by Signal 1 and not rejected. The guard runs at the very top of `Lfunc_compute`, before any FFT/zero-finding.

It is **sound** (never false-rejects a primitive) but **not complete** (a power supplied with too few primes may still slip through and fail downstream as it does today); the conductor signal shrinks that gap for pure powers.

## Files
- `include/glfunc.h` — `ERR_POWER` (fatal, `1<<13`); `Lparams_t.allow_nonprimitive`.
- `include/glfunc_internals.h` — `Lfunc` detection state; `POWER_SQFREE_PROBES` / `POWER_MOMENT_THRESHOLD`; `power_guard` declaration.
- `src/glfunc.c` — `fprint_errors` branch; copy/default the flag; init the accumulators.
- `src/clear.c` — free the new `arb_t`.
- `src/coeff.c` — Sylvester squarefree certificate + second-moment accumulation + conductor perfect-power signal + `power_guard`.
- `src/compute.c` — call the guard at the top of `Lfunc_compute`.
- `test/power_guard_test.c` — new regression test.
- `test/highdeg_check.cpp`, `test/highdeg/gen.py`, `test/highdeg/objects.yaml` — promote the high-degree object `196.a` (`L = L(14.a)²`) from a generic `xfail` to a **positive** test asserting the guard returns `ERR_POWER` (new `expect_power` flag threaded through the generator and driver).

## Test plan
- [x] `make check` green (the new test auto-registers via the deny-list `CHECK_BINS`).
- [x] `test/power_guard_test.c` asserts on the `Lerror_t` bitfield (never on stdout):
  - `L(χ₅)²` (deg 2, cond 25) → `ERR_POWER` by default; with `allow_nonprimitive=YES` → not rejected.
  - `L(χ₅)·L(χ₇)` (deg 2, cond 35; imprimitive but squarefree) → **not** rejected.
  - `L(χ₃)⁴` (deg 4, cond 81) → `ERR_POWER`.
  - Synthetic low-moment square at conductor 25 = 5² → `ERR_POWER` via the **conductor signal alone** (isolation test for Signal 2b; the moment stays ≈1, so it fails without the conductor signal).
- [x] The reject cases fail on the pre-guard code and pass on this branch (genuine regression tests).
- [x] `cmf_25.12.a.a` (primitive, conductor 25 = 5²) stays green — a built-in soundness check that the conductor signal does not fire before Signal 1's squarefree veto.
- [x] **High-degree suite** (`make check-highdeg`, degree 2–9): `196.a` (genus-2, Jac ≅ 14.a², so `L = L(14.a)²`) now asserts a clean `ERR_POWER` rejection; and the primitive objects that merely *have* perfect-power conductors — `169.a` (13²), `529.a` (23²), `Sym²(11.a)` (11²), `Sym⁴(11.a)` (11⁴) — are verified **not** rejected (Signal 1 vetoes before the conductor trigger). The other E²-Jacobian curves (`400.a`, `576.b`, …) behave like `196.a`.

## Notes
- Rebased onto `origin/main` @ `8aba947`, which includes the degree-2…9 highdeg suite (`86d3db3`).
- Tests use inline Dirichlet-character objects rather than elliptic-curve fixtures; a genuine primitive (`ec_37.a1`, etc.) is exercised as a "not falsely rejected" control by the existing `make check` suite.
- Pre-existing `fprint_errors` fatal/warning ordering is left untouched (out of scope).
