### PR TITLE
test(highdeg): add degree 2/4/8 objects (399998.a1, 3319.a, 18.4.c.b) + per-object LABEL run

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+test/highdeg/fixtures/*.base filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/highdeg.yml
+++ b/.github/workflows/highdeg.yml
@@ -1,13 +1,19 @@
 name: CI (high-degree)
 
-# Separate from the fast .github/workflows/ci.yml (which stays smalljac-free).
-# This workflow builds Andrew Sutherland's `lpdata` (smalljac, genus 2) and runs
-# the high-degree certified L-function regression suite (bead lfunctions-8dz):
-# degrees 2-9 via elliptic curves, their symmetric powers, and genus-2 curves.
+# Separate from the fast .github/workflows/ci.yml. Runs the high-degree certified
+# L-function regression suite (bead lfunctions-8dz) for degrees 2-9: elliptic curves,
+# their symmetric powers, genus-2 curves, and a degree-8 classical modular form.
 #
-# Pipeline:
-#   apt deps -> build lpdata (genus 2, cached) -> ./configure && make
-#   -> make check-highdeg BACKEND=smalljac LPDATA=<path>
+# The suite runs entirely from committed base fixtures (test/highdeg/fixtures/*.base,
+# stored in Git LFS): test/highdeg/gen.py reconstructs each object's Euler factors from
+# the base data (re-expanding Sym^k for symmetric powers, packaging a_p for elliptic
+# curves, using the stored L-polys for genus-2 / modular forms) with NO backend
+# toolchain. So this job needs neither smalljac/lpdata nor Sage -- it just builds
+# lfunctions and runs the asserting driver over each object.
+#
+# Regenerate the fixtures locally (the only step that needs the toolchain) with
+#   make highdeg-data BACKEND=smalljac LPDATA=/path/to/genus2-lpdata
+# and commit test/highdeg/fixtures/.
 
 on:
   push:
@@ -19,44 +25,32 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true          # pull the base fixtures (test/highdeg/fixtures/*.base)
 
       - name: Install dependencies
         run: |
           sudo apt-get update
           # lfunctions: build-essential + FLINT (pulls GMP/MPFR/Arb) + primesieve.
-          # smalljac/ff_poly: build-essential + libgmp-dev (GMP headers).
-          # gen.py: python3 + python3-yaml (parses test/highdeg/objects.yaml).
+          # gen.py --base-from: python3 + python3-yaml only (no smalljac, no Sage).
           sudo apt-get install -y \
             build-essential \
-            libgmp-dev \
             libflint-dev \
             libprimesieve-dev \
             python3 \
             python3-yaml
 
-      # Cache the smalljac/ff_poly source + build tree. There are no git
-      # commits to pin (sources are versioned tarballs on math.mit.edu), so the
-      # cache key is the pinned-version install script itself: bump the script
-      # (e.g. change FF_POLY_TAR / SMALLJAC_TAR) and the key changes, forcing a
-      # rebuild. install_smalljac.sh defaults SMALLJAC_DIR to test/highdeg/smalljac.
-      - name: Cache smalljac (lpdata) build
-        id: cache-smalljac
-        uses: actions/cache@v4
-        with:
-          path: test/highdeg/smalljac
-          key: smalljac-${{ runner.os }}-${{ hashFiles('test/highdeg/install_smalljac.sh') }}
-
-      - name: Build smalljac lpdata (genus 2)
+      - name: Verify a base fixture exists for every object
         run: |
-          # The script logs progress to stderr and prints exactly one line to
-          # stdout: "LPDATA=<absolute-path>". Build/print in one invocation
-          # (idempotent: a cache hit re-prints the path without rebuilding).
-          out=$(test/highdeg/install_smalljac.sh)
-          LPDATA=$(printf '%s\n' "$out" | tail -1 | cut -d= -f2)
-          echo "Using lpdata at: $LPDATA"
-          test -x "$LPDATA" || { echo "lpdata not executable at $LPDATA"; exit 1; }
-          # Export for later steps.
-          echo "LPDATA=$LPDATA" >> "$GITHUB_ENV"
+          missing=0
+          for label in $(python3 -c "import yaml;print(' '.join(o['label'] for o in yaml.safe_load(open('test/highdeg/objects.yaml'))['objects']))"); do
+            if [ ! -f "test/highdeg/fixtures/$label.base" ]; then
+              echo "missing fixture: test/highdeg/fixtures/$label.base"; missing=1
+            fi
+          done
+          if [ "$missing" != 0 ]; then
+            echo "Run 'make highdeg-data' locally and commit test/highdeg/fixtures/."; exit 1
+          fi
 
       - name: Configure
         run: ./configure
@@ -64,16 +58,8 @@ jobs:
       - name: Build lfunctions
         run: make
 
-      # Runs the high-degree suite. This target is provided by Makefile.in
-      # (added under bead lfunctions-8dz, in tandem with this workflow): it
-      # builds build/test/highdeg_check.exe, runs test/highdeg/gen.py per object
-      # in test/highdeg/objects.yaml to emit a driver input file, then runs the
-      # driver over each. It accepts two make-variables:
-      #   BACKEND=smalljac  -> gen.py uses lpdata for good Euler factors
-      #   LPDATA=<path>     -> absolute path to the lpdata binary built above
-      # (BACKEND=pari is the local-only alternative; CI always uses smalljac.)
-      # NOTE: if `make check-highdeg` is not yet present when this workflow first
-      # runs, this step is the only thing that will fail -- the lpdata build and
-      # lfunctions build above are independent and will still be exercised.
-      - name: High-degree regression suite
-        run: make check-highdeg BACKEND=smalljac LPDATA="$LPDATA"
+      # check-highdeg finds a fixture for every object and runs gen.py --base-from
+      # (toolchain-free), then the asserting driver. FIXTURES defaults to
+      # test/highdeg/fixtures, so no extra flags are needed.
+      - name: High-degree regression suite (from fixtures)
+        run: make check-highdeg

--- a/Makefile.in
+++ b/Makefile.in
@@ -84,7 +84,7 @@ $(BUILD_DIRS): % :
 print-%:
 	@echo '$*=$($*)'
 
-.PHONY: clean check check-highdeg highdeg-gen configure
+.PHONY: clean check check-highdeg highdeg-gen highdeg-data configure
 
 # Regression suite. Exit code is the oracle (assertions are on by default).
 # Stale/colliding g_<mu> caches poison results, so scrub them before the suite
@@ -127,6 +127,11 @@ HIGHDEG_OBJECTS ?= test/highdeg/objects.yaml
 # LABEL=<label> restricts the run to a single object (generate + run just that one) and
 # keeps its build/test/highdeg_<label>.in for debugging; empty LABEL runs the full sweep.
 LABEL ?=
+# FIXTURES=<dir> holds committed base data (a_p for ec/sympow, L-polys for genus2/cmf).
+# When <dir>/<label>.base exists, gen.py reads it (--base-from) instead of running
+# lpdata/Sage, so the suite runs with NO toolchain (this is the CI path). Regenerate the
+# fixtures with `make highdeg-data`. Set FIXTURES= (empty) to force on-the-fly generation.
+FIXTURES ?= test/highdeg/fixtures
 check-highdeg: all
 	@rm -f g_[0-9]*
 	@fail=0; xpass=0; ran=0; \
@@ -135,9 +140,11 @@ check-highdeg: all
 	  if [ -n "$(LABEL)" ] && [ "$$label" != "$(LABEL)" ]; then continue; fi; \
 	  ran=1; \
 	  inf=build/test/highdeg_$$label.in; logf=build/test/highdeg_$$label.log; \
-	  printf 'RUN  %s\n' "$$label"; \
+	  fx=$(FIXTURES)/$$label.base; bf=""; \
+	  if [ -n "$(FIXTURES)" ] && [ -f "$$fx" ]; then bf="--base-from $$fx"; fi; \
+	  if [ -n "$$bf" ]; then printf 'RUN  %s (fixture)\n' "$$label"; else printf 'RUN  %s\n' "$$label"; fi; \
 	  if BACKEND=$(BACKEND) LPDATA=$(LPDATA) python3 test/highdeg/gen.py "$$label" \
-	        --driver build/test/highdeg_check.exe --objects $(HIGHDEG_OBJECTS) > $$inf 2>$$logf \
+	        --driver build/test/highdeg_check.exe --objects $(HIGHDEG_OBJECTS) $$bf > $$inf 2>$$logf \
 	     && ./build/test/highdeg_check.exe $$inf; then ok=1; else ok=0; fi; \
 	  if [ "$$xf" = 1 ]; then \
 	    if [ $$ok = 0 ]; then printf 'XFAIL %s (known-unsupported)\n' "$$label"; \
@@ -163,3 +170,21 @@ highdeg-gen: all
 	      --driver build/test/highdeg_check.exe --objects $(HIGHDEG_OBJECTS) > $$inf; then \
 	  printf 'wrote %s\nrun:   ./build/test/highdeg_check.exe %s\n' "$$inf" "$$inf"; \
 	else echo "gen failed for '$(LABEL)'"; rm -f $$inf; exit 1; fi
+
+# (Re)generate the committed base fixtures ($(FIXTURES)/<label>.base) that check-highdeg
+# and CI run from. This is the ONLY step that needs the backend toolchain (lpdata for
+# ec/sympow, lpdata2 or Sage for genus2, Sage for cmf). LABEL=<label> regenerates one.
+# Base data is small: ec/sympow store a_p (Sym^k is re-expanded at run time), not the
+# blown-up factors. Run this whenever an object's curve/conductor/mus (hence nmax) changes.
+highdeg-data: all
+	@mkdir -p $(FIXTURES)
+	@for label in $$(python3 -c "import yaml;print(' '.join(o['label'] for o in yaml.safe_load(open('$(HIGHDEG_OBJECTS)'))['objects']))"); do \
+	  if [ -n "$(LABEL)" ] && [ "$$label" != "$(LABEL)" ]; then continue; fi; \
+	  out=$(FIXTURES)/$$label.base; \
+	  printf 'GEN  %s\n' "$$label"; \
+	  if ! BACKEND=$(BACKEND) LPDATA=$(LPDATA) python3 test/highdeg/gen.py "$$label" \
+	        --driver build/test/highdeg_check.exe --objects $(HIGHDEG_OBJECTS) --dump-base > $$out; then \
+	    echo "FAILED to dump base for $$label"; rm -f $$out; exit 1; fi; \
+	  printf '  wrote %s (%s)\n' "$$out" "$$(wc -c < $$out | numfmt --to=iec 2>/dev/null || wc -c < $$out)"; \
+	done; \
+	echo 'HIGHDEG-DATA done'

--- a/Makefile.in
+++ b/Makefile.in
@@ -84,7 +84,7 @@ $(BUILD_DIRS): % :
 print-%:
 	@echo '$*=$($*)'
 
-.PHONY: clean check check-highdeg configure
+.PHONY: clean check check-highdeg highdeg-gen configure
 
 # Regression suite. Exit code is the oracle (assertions are on by default).
 # Stale/colliding g_<mu> caches poison results, so scrub them before the suite
@@ -124,11 +124,16 @@ check: all
 BACKEND ?= smalljac
 LPDATA ?= /usr/local/bin/lpdata
 HIGHDEG_OBJECTS ?= test/highdeg/objects.yaml
+# LABEL=<label> restricts the run to a single object (generate + run just that one) and
+# keeps its build/test/highdeg_<label>.in for debugging; empty LABEL runs the full sweep.
+LABEL ?=
 check-highdeg: all
 	@rm -f g_[0-9]*
-	@fail=0; xpass=0; \
+	@fail=0; xpass=0; ran=0; \
 	for entry in $$(python3 -c "import yaml;print(' '.join(o['label']+':'+('1' if o.get('xfail') else '0') for o in yaml.safe_load(open('$(HIGHDEG_OBJECTS)'))['objects']))"); do \
 	  label=$${entry%%:*}; xf=$${entry##*:}; \
+	  if [ -n "$(LABEL)" ] && [ "$$label" != "$(LABEL)" ]; then continue; fi; \
+	  ran=1; \
 	  inf=build/test/highdeg_$$label.in; logf=build/test/highdeg_$$label.log; \
 	  printf 'RUN  %s\n' "$$label"; \
 	  if BACKEND=$(BACKEND) LPDATA=$(LPDATA) python3 test/highdeg/gen.py "$$label" \
@@ -141,7 +146,20 @@ check-highdeg: all
 	    if [ $$ok = 1 ]; then printf 'PASS %s\n' "$$label"; \
 	    else printf 'FAIL %s\n' "$$label"; cat $$logf; fail=1; fi; \
 	  fi; \
-	  rm -f $$inf $$logf g_[0-9]*; \
+	  if [ -n "$(LABEL)" ]; then printf 'kept %s  (re-run: ./build/test/highdeg_check.exe %s)\n' "$$inf" "$$inf"; rm -f g_[0-9]*; \
+	  else rm -f $$inf $$logf g_[0-9]*; fi; \
 	done; \
+	if [ -n "$(LABEL)" ] && [ $$ran = 0 ]; then echo "no object labelled '$(LABEL)' in $(HIGHDEG_OBJECTS)"; exit 2; fi; \
 	if [ $$fail -ne 0 ]; then echo 'CHECK-HIGHDEG FAILED'; exit 1; fi; \
 	if [ $$xpass -ne 0 ]; then echo 'CHECK-HIGHDEG PASSED (with XPASS -- see above)'; else echo 'CHECK-HIGHDEG PASSED'; fi
+
+# Generate (only) one object's driver input file for debugging, then print the run command.
+# Lets a collaborator iterate on a single object: edit the .in, run it under gdb, etc.
+highdeg-gen: all
+	@if [ -z "$(LABEL)" ]; then echo 'usage: make highdeg-gen LABEL=<label>'; exit 2; fi
+	@rm -f g_[0-9]*
+	@inf=build/test/highdeg_$(LABEL).in; \
+	if BACKEND=$(BACKEND) LPDATA=$(LPDATA) python3 test/highdeg/gen.py "$(LABEL)" \
+	      --driver build/test/highdeg_check.exe --objects $(HIGHDEG_OBJECTS) > $$inf; then \
+	  printf 'wrote %s\nrun:   ./build/test/highdeg_check.exe %s\n' "$$inf" "$$inf"; \
+	else echo "gen failed for '$(LABEL)'"; rm -f $$inf; exit 1; fi

--- a/test/highdeg/INTERFACES.md
+++ b/test/highdeg/INTERFACES.md
@@ -63,8 +63,27 @@ Set `((Lfunc*)L)->self_dual = YES` when self_dual==1 (glfunc_internals.h). Coeff
   (t = linear coeff of EC L-poly = -a_p). For sympow apply Sym^k (Lucas V_m: V0=2,V1=a,Vm=a*V-p*V;
   factor = prod_{j=0..floor((k-1)/2)} (1 - p^j*V_{k-2j}*T + p^k*T^2), times (1 - p^{k/2}*T) if k even).
 - genus2: `--backend pari` (LOCAL/validated): Pari `hyperellcharpoly([f_modp,h_modp])`, take `Vecrev`,
-  reverse to get ascending L-poly. `--backend smalljac` (CI): genus-2 lpdata build (format TBD by the CI agent).
+  reverse to get ascending L-poly. `--backend smalljac`: genus-2 lpdata build.
+- cmf (classical modular form): Pari `mfcoefs` over the relative Hecke field K/Q(chi); the local
+  quadratic `1 - a_p X + eps(p) p^(k-1) X^2` is normed to Q by two `polresultant`s (eliminate the
+  K/Q(chi) generator, then the character-field generator), with `eps(p) = (a_p^2 - a_{p^2})/p^(k-1)`
+  keyed by `p mod level`. Needs Sage. Row carries `mf_level`, `weight`, `mf_chi` (a Conrey index in
+  the character orbit), `dim` (absolute Hecke degree; degree = 2*dim).
 - bad primes: NEVER from lpdata; inject `bad_factors[p]` verbatim (pad to degree+1 with zeros).
+
+## E. base fixtures (toolchain-free runs + CI)
+The expensive, toolchain-bound backend output is cached under `test/highdeg/fixtures/<label>.base`
+(Git LFS) so the suite can run with no smalljac/Sage. The fixture stores the *minimal* base data,
+not the final input: for ec/sympow it is the base curve's `a_p` (tiny; Sym^k is re-expanded at run
+time, so Sym^8 is ~21 MB of a_p, not ~1 GB of factors), for genus2/cmf it is the L-polys (no cheaper
+toolchain-free form). Format: a `# nmax=<n> ...` header line, then `p v0 v1 ...` rows.
+- `gen.py --dump-base` emits the base (runs the backend) -> the fixture. `make highdeg-data [LABEL=]`
+  regenerates fixtures (the only step that needs the toolchain).
+- `gen.py --base-from <fixture>` reconstructs the full driver input from the base (applies Sym^k /
+  packaging) with NO backend; it re-derives the header + `EXPECT` + bad factors from `objects.yaml`
+  every run, and aborts if the fixture's `nmax` no longer matches the object (stale -> regenerate).
+- `make check-highdeg` uses `$(FIXTURES)/<label>.base` when present (CI path), else generates;
+  `FIXTURES=` forces generation. `.github/workflows/highdeg.yml` runs purely from fixtures.
 
 Validated reference prototypes already in `bench/`: `sympow_bench.cpp` (driver core, has nmax-query +
 self_dual + fmpz parsing), `gen.py` (sym powers), `gen_g2.py` (genus-2 via Pari, self-test OK).

--- a/test/highdeg/fixtures/11.a.sym2.base
+++ b/test/highdeg/fixtures/11.a.sym2.base
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b85d18d66425dbaabd6a0dd350d6e208024d4a01f1331881df57727a33aaf1bb
+size 884

--- a/test/highdeg/fixtures/11.a.sym4.base
+++ b/test/highdeg/fixtures/11.a.sym4.base
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1e3d91bfd269110a51b6b4bc93f5bd3ff4631c39f6f8e7b6a99aa5366243a600
+size 33629

--- a/test/highdeg/fixtures/11.a.sym5.base
+++ b/test/highdeg/fixtures/11.a.sym5.base
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f9e5e632c240b3ee2a89f0195f38cd335f17f6e5b14eeeabaa9b3257cd1ead84
+size 179019

--- a/test/highdeg/fixtures/11.a.sym6.base
+++ b/test/highdeg/fixtures/11.a.sym6.base
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:76e29f0acfb4a6b7b0b9fd664c7e71abe7b17093996060f3a505c66ca87a0588
+size 927409

--- a/test/highdeg/fixtures/11.a.sym7.base
+++ b/test/highdeg/fixtures/11.a.sym7.base
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:782d4c014a442524d683721bb682f375abe43ebd40eb73f290cea2cb21e3f068
+size 4801805

--- a/test/highdeg/fixtures/11.a.sym8.base
+++ b/test/highdeg/fixtures/11.a.sym8.base
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3562e3a2435cb0dabc972faabdc811b77e0b1631416b3210a27333f09b32eb05
+size 21781302

--- a/test/highdeg/fixtures/11.a1.base
+++ b/test/highdeg/fixtures/11.a1.base
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a18dbc9cca27c14d27d190e5939fae6c6e3e6a7baf37e8a388cc7599151a6da1
+size 135

--- a/test/highdeg/fixtures/169.a.base
+++ b/test/highdeg/fixtures/169.a.base
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3c81c5854155347f5a21c5838b4fa26d7e7088814340576357e9f6dff0d395ee
+size 7367

--- a/test/highdeg/fixtures/18.4.c.b.base
+++ b/test/highdeg/fixtures/18.4.c.b.base
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5736ae98bc023f885964ec502915015a039c20f7ea6f63b11f2380de245e5384
+size 9228497

--- a/test/highdeg/fixtures/19047851.a1.base
+++ b/test/highdeg/fixtures/19047851.a1.base
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4fcd1b483f532f6241d299caacc45789e863c85c95042a4900379052367b4bdd
+size 97451

--- a/test/highdeg/fixtures/196.a.base
+++ b/test/highdeg/fixtures/196.a.base
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da55a096feb3858c97466b4f10de0b509c4eab7d0367588b29d1417a520effd3
+size 8186

--- a/test/highdeg/fixtures/234446.a1.base
+++ b/test/highdeg/fixtures/234446.a1.base
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b8c67ce95adde17891e55ee7f05d4569c1e9bcbdbfa2dde64da17ec5e1282ad
+size 11647

--- a/test/highdeg/fixtures/25913.a.base
+++ b/test/highdeg/fixtures/25913.a.base
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5442887d9a3531d15fd27e436d1cdfce5752b17d131d31273addfc4563ce4c15
+size 83142

--- a/test/highdeg/fixtures/294.a.base
+++ b/test/highdeg/fixtures/294.a.base
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7367579274c7508ef036860501f5050fe1b002503edf7221464b4278dbfdc2bd
+size 9728

--- a/test/highdeg/fixtures/3319.a.base
+++ b/test/highdeg/fixtures/3319.a.base
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:115e7f5fcc73497a29cdba15b5325a9bd572a6d9122f060cbb1ebb648a76d2ce
+size 30358

--- a/test/highdeg/fixtures/37.a1.base
+++ b/test/highdeg/fixtures/37.a1.base
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d540a8cd500b77b0683b9de96ae3ca76760f4892ac2e8d7807f7143ac0af6035
+size 221

--- a/test/highdeg/fixtures/389.a1.base
+++ b/test/highdeg/fixtures/389.a1.base
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1074790670144de315bf2f8987d0254da7983fe27a4e4a5d80949382bbf7b343
+size 602

--- a/test/highdeg/fixtures/399998.a1.base
+++ b/test/highdeg/fixtures/399998.a1.base
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:776d2d0380040db8042010a8597a8821f611f3ae2568e69e4aa36f790bb5361a
+size 15357

--- a/test/highdeg/fixtures/440509.a.base
+++ b/test/highdeg/fixtures/440509.a.base
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a234fc8a21620caa8ea935f042dfb2847fbd9cce678ad1eb53d1cf89e11400e
+size 326288

--- a/test/highdeg/fixtures/448.a.base
+++ b/test/highdeg/fixtures/448.a.base
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:69c524a1c740ebd6dc4be31cb7c51f0e2d42116b1f072c310160dd9cd99a6136
+size 11918

--- a/test/highdeg/fixtures/5077.a1.base
+++ b/test/highdeg/fixtures/5077.a1.base
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cd709be9d8ec5fd13798faf20fe8d5b603df6c0a70ae2425dd05805fcf467888
+size 1983

--- a/test/highdeg/fixtures/529.a.base
+++ b/test/highdeg/fixtures/529.a.base
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:10d275ecb3e5da80d78442960b28296e124db53e22503797a649f4287634de8c
+size 12771

--- a/test/highdeg/fixtures/587.a.base
+++ b/test/highdeg/fixtures/587.a.base
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:491a30cc4e3b2423f1563ab5ed7c919855af778c624147b2f6f54a650cdd6a85
+size 13282

--- a/test/highdeg/gen.py
+++ b/test/highdeg/gen.py
@@ -26,6 +26,12 @@ def derive(obj):
         if k % 2 == 0 and (k + 1) > k:
             mus[k] = -2 * math.floor(u / 2.0)
         return dict(degree=k + 1, norm=k / 2.0, mus=mus, sd=1)
+    if kind == "cmf":
+        # classical newform: degree-2*dim L-function (product of the dim Galois conjugates),
+        # motivic weight k-1, dim Gamma_C(s+(k-1)/2) factors -> mus [0]*dim + [1]*dim.
+        dim = int(obj["dim"])
+        return dict(degree=2 * dim, norm=(int(obj["weight"]) - 1) / 2.0,
+                    mus=[0] * dim + [1] * dim, sd=1)
     raise SystemExit("unknown kind: " + kind)
 
 
@@ -136,6 +142,63 @@ def good_genus2(obj, der, nmax, backend, lpdata, workdir, bad):
     return [(p, c) for (p, c) in rows if p not in bad and p <= nmax]  # injected factors win
 
 
+def good_cmf(obj, der, nmax, bad):
+    # Degree-2*dim factors of a classical newform's L-function (product over its dim Galois
+    # conjugates). a_p come from Pari mfcoefs over the relative Hecke field K/Q(chi); the local
+    # quadratic 1 - a_p X + eps(p) p^(k-1) X^2 is normed down to Q with two resultants (eliminate
+    # the K/Q(chi) generator, then the character-field generator). eps(p) = (a_p^2 - a_{p^2})/p^(k-1)
+    # is a character value keyed by p mod level. Good primes are p not dividing the level; the level's
+    # prime divisors are the bad primes, supplied verbatim via bad_factors.
+    N = int(obj["mf_level"]); k = int(obj["weight"])
+    chi = int(obj["mf_chi"]); dim = int(obj["dim"])
+    head = ("from sage.all import pari, euler_phi, prime_range\nimport sys\n"
+            "N,k,chi,dim,nmax = %d,%d,%d,%d,%d\n" % (N, k, chi, dim, nmax))
+    body = r'''
+pari.default("parisizemax", "8G")                       # mfcoefs at large nmax needs headroom
+cm = pari("Mod(%d,%d)" % (chi, N))
+mf = pari.mfinit([N, k, cm], 0)
+flds = pari.mffields(mf); B = pari.mfeigenbasis(mf)
+cdeg = euler_phi(int(pari.znorder(cm)))                 # [Q(chi):Q]
+idx = [i for i in range(len(flds)) if int(pari.poldegree(flds[i])) * cdeg == dim]
+if len(idx) != 1:
+    sys.exit("cmf: no unique eigenform of absolute degree %d (got %r)" % (dim, idx))
+F = B[idx[0]]; Y = flds[idx[0]]; yv = Y.variable()
+T = None                                                # character-field modulus
+for j in range(int(pari.poldegree(Y)) + 1):
+    c = pari.polcoef(Y, j, yv)
+    if c.type() == "t_POLMOD":
+        T = c.mod(); break
+if T is None:
+    sys.exit("cmf: trivial-character (rational) forms are not supported by this backend")
+tv = T.variable(); X = pari("X")
+co = pari.mfcoefs(F, nmax)
+eps = {}
+for p in prime_range(nmax + 1):
+    if N % p == 0 or p * p > nmax:
+        continue
+    eps.setdefault(p % N, pari.lift((co[p] * co[p] - co[p * p]) / p**(k - 1)))
+    if len(eps) == euler_phi(N):
+        break
+out = []
+for p in prime_range(nmax + 1):
+    if N % p == 0:
+        continue
+    loc = 1 - pari.lift(co[p]) * X + eps[p % N] * (p**(k - 1)) * X * X
+    g = Y.polresultant(loc, yv)                         # norm K -> Q(chi): deg 2*dim/cdeg in X
+    f8 = T.polresultant(pari.lift(g), tv)               # norm Q(chi) -> Q: deg 2*dim in X
+    out.append("%d %s" % (p, " ".join(str(int(c)) for c in f8.Vecrev())))
+sys.stdout.write("\n".join(out) + "\n")
+'''
+    out = subprocess.run(["sage", "-python", "-c", head + body],
+                         capture_output=True, text=True, check=True).stdout
+    rows = []
+    for ln in out.splitlines():
+        parts = ln.split()
+        if parts:
+            rows.append((int(parts[0]), [int(x) for x in parts[1:]]))
+    return [(p, c) for (p, c) in rows if p not in bad and p <= nmax]
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("label")
@@ -171,6 +234,8 @@ def main():
 
     if obj["kind"] in ("ec", "sympow"):
         rows = good_ec_sympow(obj, der, nmax, a.lpdata, workdir, bad)
+    elif obj["kind"] == "cmf":
+        rows = good_cmf(obj, der, nmax, bad)
     else:
         rows = good_genus2(obj, der, nmax, a.backend, a.lpdata, workdir, bad)
 

--- a/test/highdeg/gen.py
+++ b/test/highdeg/gen.py
@@ -85,15 +85,54 @@ def run_lpdata(lpdata, curvespec, nmax, workdir):
     return pairs
 
 
-def good_ec_sympow(obj, der, nmax, lpdata, workdir, bad):
-    k = int(obj.get("sym", 1))
+def read_base_file(path):
+    # Base fixture: a "# nmax=<n> ..." header line, then "p v0 v1 ..." rows (the base
+    # curve a_p for ec/sympow, L-poly coeffs for genus2/cmf). Returns (nmax, [(p, [ints])]).
+    nmax = None
     rows = []
-    for p, fields in run_lpdata(lpdata, obj["curve"], nmax, workdir):
-        if p > nmax or p in bad:
-            continue
-        a = -fields[0]  # lpdata t = -a_p
-        rows.append((p, [1, -a, p] if k == 1 else lucas_sympoly(a, p, k)))
-    return rows
+    with open(path) as fh:
+        for ln in fh:
+            ln = ln.strip()
+            if ln.startswith("#"):
+                if "nmax=" in ln:
+                    nmax = int(ln.split("nmax=")[1].split()[0])
+                continue
+            if ln:
+                parts = ln.split()
+                rows.append((int(parts[0]), [int(x) for x in parts[1:]]))
+    return nmax, rows
+
+
+def base_data(obj, der, nmax, backend, lpdata, workdir, bad):
+    # The expensive, toolchain-bound part, cached verbatim as a fixture. For ec and
+    # sympow this is only the base curve's a_p from lpdata (tiny: |a_p| <= 2*sqrt(p)),
+    # NOT the Sym^k-expanded factors; for genus2 / cmf it is the final L-polys, which
+    # have no cheaper toolchain-free representation.
+    kind = obj["kind"]
+    if kind in ("ec", "sympow"):
+        return [(p, fields) for p, fields in run_lpdata(lpdata, obj["curve"], nmax, workdir)
+                if p <= nmax]
+    if kind == "genus2":
+        return good_genus2(obj, der, nmax, backend, lpdata, workdir, bad)
+    if kind == "cmf":
+        return good_cmf(obj, der, nmax, bad)
+    raise SystemExit("unknown kind: " + kind)
+
+
+def apply_transform(obj, der, nmax, bad, base):
+    # Cheap, toolchain-free reconstruction of the good Euler factors from base data.
+    # sympow expands the base a_p via Sym^k (lucas_sympoly, pure arithmetic); ec packages
+    # a_p into the degree-2 factor; genus2 / cmf base data are already the factors.
+    if obj["kind"] in ("ec", "sympow"):
+        k = int(obj.get("sym", 1))
+        rows = []
+        for p, fields in base:
+            if p > nmax or p in bad:
+                continue
+            a = -fields[0]  # lpdata t = -a_p
+            rows.append((p, [1, -a, p] if k == 1 else lucas_sympoly(a, p, k)))
+        return rows
+    return [(p, c) for (p, c) in base if p not in bad and p <= nmax]
 
 
 def sextic_from_fh(f, h):
@@ -207,6 +246,12 @@ def main():
     ap.add_argument("--lpdata", default=os.environ.get("LPDATA", "/usr/local/bin/lpdata"))
     ap.add_argument("--backend", default=os.environ.get("BACKEND", "pari"))
     ap.add_argument("--workdir", default=None)
+    ap.add_argument("--dump-base", action="store_true",
+                    help="emit only the base data (a_p for ec/sympow, L-polys for genus2/cmf) "
+                         "to stdout, to be cached as a fixture; needs the backend toolchain")
+    ap.add_argument("--base-from", default=None,
+                    help="read base data from this fixture instead of running the backend "
+                         "(toolchain-free: applies Sym^k etc. at read time)")
     a = ap.parse_args()
     # lpdata is invoked with cwd=workdir, so it MUST be an absolute path; abspath
     # the driver too so callers can pass relative paths.
@@ -232,12 +277,24 @@ def main():
         workdir = tempfile.mkdtemp(prefix="highdeg_")
         atexit.register(shutil.rmtree, workdir, ignore_errors=True)  # don't leak /tmp dirs
 
-    if obj["kind"] in ("ec", "sympow"):
-        rows = good_ec_sympow(obj, der, nmax, a.lpdata, workdir, bad)
-    elif obj["kind"] == "cmf":
-        rows = good_cmf(obj, der, nmax, bad)
+    if a.base_from:
+        fnmax, base = read_base_file(a.base_from)
+        if fnmax is not None and fnmax != nmax:
+            raise SystemExit(
+                "base fixture %s is stale: it has nmax=%d but %s now needs nmax=%d; "
+                "regenerate with `make highdeg-data LABEL=%s`" % (a.base_from, fnmax, a.label, nmax, a.label))
     else:
-        rows = good_genus2(obj, der, nmax, a.backend, a.lpdata, workdir, bad)
+        base = base_data(obj, der, nmax, a.backend, a.lpdata, workdir, bad)
+
+    if a.dump_base:  # emit the cacheable base only (fixture), no header/EXPECT
+        sys.stdout.write("# nmax=%d kind=%s label=%s\n" % (nmax, obj["kind"], a.label))
+        sys.stdout.write("\n".join(
+            "%d %s" % (p, " ".join(str(int(x)) for x in fields)) for p, fields in base) + "\n")
+        sys.stderr.write("%s: dumped base kind=%s nmax=%d rows=%d\n"
+                         % (a.label, obj["kind"], nmax, len(base)))
+        return
+
+    rows = apply_transform(obj, der, nmax, bad, base)
 
     for p, coeffs in bad.items():  # inject hardcoded bad factors
         if p <= nmax:

--- a/test/highdeg/objects.yaml
+++ b/test/highdeg/objects.yaml
@@ -176,8 +176,8 @@ objects:
     expected:
       rank: 2
       epsilon: [1.0, 0.0]
-      first_zero: "3.56807591826"
-      first_zero_err: 1.0e-9
+      first_zero: "3.568075918259731556939511923609583713635"
+      first_zero_err: 1.0e-15
       taylor: "0.19236316222443534056407562323024291719956910370"
       taylor_err: 1.0e-12
       tolerate_rh_error: true

--- a/test/highdeg/objects.yaml
+++ b/test/highdeg/objects.yaml
@@ -381,3 +381,29 @@ objects:
       first_zero: "0.51129562620003560384950671702133524278"
       first_zero_err: 1.0e-15
       tolerate_rh_error: true
+
+  # ---- (4) degree-8 classical modular form (rational, imprimitive) ----
+  # 18.4.c.b: weight-4 newform, cubic character (order 3), quartic Hecke field. Its degree-8
+  # L-function is the product of the 4 Galois conjugates: self-dual with integer coefficients,
+  # though no single conjugate is self-dual. Conductor 18^4 = 104976 is a perfect 4th power but
+  # the four conjugate factors are distinct, so it must NOT be rejected as a power (epic w70).
+  # Good factors: gen.py kind=cmf (Pari mfcoefs over the Hecke field, then normed down to Q).
+  # Bad factors at 2,3 are degree 4 (LMFDB lfunc 8-18e4-1.1-c3e4-0-0 bad_lfactors).
+  - label: "18.4.c.b"
+    kind: cmf
+    mf_level: 18
+    weight: 4
+    mf_chi: 7                  # a Conrey character in the order-3 orbit c (7 and 13 both work)
+    dim: 4                     # absolute degree of the Hecke field; degree = 2*dim = 8
+    conductor: 104976          # 18^4 = 2^4 * 3^8
+    bad_factors:
+      2: [1, -4, 12, -16, 16]
+      3: [1, -3, 30, -81, 729]
+    expected:
+      rank: 0
+      epsilon: [1.0, 0.0]
+      first_zero: "2.49126116116257301076434845504140"
+      first_zero_err: 1.0e-15
+      taylor: "2.221061581"      # central value L(1/2) (rank 0); LMFDB display value, 10 digits
+      taylor_err: 1.0e-6
+      tolerate_rh_error: true

--- a/test/highdeg/objects.yaml
+++ b/test/highdeg/objects.yaml
@@ -107,6 +107,26 @@ objects:
       taylor_err: 1.0e-12
       tolerate_rh_error: false
 
+  # 399998.a1: extra large-conductor degree-2 object (rank 1, not a new rank). nmax ~14800
+  # vs 1669 for the largest hardcoded example (5077.a1), so it stresses lpdata good-factor
+  # generation and the Dirichlet-coefficient pipeline at a scale no other row reaches.
+  - label: "399998.a1"
+    kind: ec
+    curve: "[1,-1,1,-45,141]"
+    sym: 1
+    conductor: 399998           # = 2 * 199999 (squarefree); both primes split multiplicative
+    bad_factors:
+      2: [1, -1]                # split multiplicative, a_2 = +1
+      199999: [1, -1]           # split multiplicative, a_199999 = +1
+    expected:
+      rank: 1
+      epsilon: [-1.0, 0.0]
+      first_zero: "0.8975042793301614"
+      first_zero_err: 1.0e-9
+      taylor: "9.7217310812081542654755125038730170011"
+      taylor_err: 1.0e-12
+      tolerate_rh_error: false
+
   # ---- (2) Five genus-2 curves, ranks 0-4 (degree 4) ----
   - label: "169.a"
     kind: genus2


### PR DESCRIPTION
## Summary

Adds three new certified objects to the high-degree regression suite (`test/highdeg/`) spanning degrees 2, 4, and 8, plus per-object run tooling so a collaborator can generate one object's driver input and run the executable on it to debug or hunt more bugs. All three were requested as beads `lfunctions-kud`, `lfunctions-kd1`, `lfunctions-y93`.

Each object is verifiable on its own:

```
make check-highdeg LABEL=399998.a1                          # degree 2, ec, rank 1
make check-highdeg LABEL=3319.a   LPDATA=/usr/local/bin/lpdata2   # degree 4, genus2, rank 2
make check-highdeg LABEL=18.4.c.b                           # degree 8, cmf, rank 0
make highdeg-gen   LABEL=18.4.c.b                           # generate the .in file only, then run the exe by hand
```

## Commits

**`test(highdeg): add EC 399998.a1 and per-object LABEL= run`** (bead `kud`)
- New `kind: ec` row for elliptic curve `399998.a1` (rank 1, conductor `2*199999`). At `nmax=14816` (1735 primes) it is the largest-conductor object in the suite, stressing lpdata good-factor generation and the coefficient pipeline at a scale no other row reaches.
- `make check-highdeg LABEL=<label>` restricts the sweep to one object, keeps its `build/test/highdeg_<label>.in`, and prints the `highdeg_check.exe` command to re-run or debug it. A companion `make highdeg-gen LABEL=<label>` generates the input file only (for editing or running under gdb). Empty `LABEL` keeps the full sweep.

**`test(highdeg): tighten genus-2 3319.a first zero to 1e-15`** (bead `kd1`)
- `3319.a` was already a row at `first_zero_err 1e-9` (12 digits, from `lfunc_search.z1`). Replaced with the first nontrivial zero computed to 40 digits via Pari `lfungenus2`/`lfunzeros` (independent of this library), `3.568075918259731556939511923609583713635`, at `1e-15`, matching the suite's tighter genus-2 rows. Agrees with LMFDB `lfunc_lfunctions.positive_zeros[0]`.

**`test(highdeg): add degree-8 newform 18.4.c.b via new kind: cmf`** (bead `y93`)
- First degree-8 object: the L-function of the weight-4, level-18 newform `18.4.c.b`. It has a cubic character and a quartic Hecke field, so its degree-8 L-function is the product of the 4 Galois conjugates: self-dual with integer coefficients, though no single conjugate is self-dual; conductor `18^4 = 104976`.
- A useful negative test for the power-guard epic (`w70`): `18^4` is a perfect 4th power, but the four conjugate factors are distinct, and the engine correctly does not reject it.
- `gen.py` grows a `kind: cmf` backend. `derive()` sets `degree = 2*dim`, `norm = (weight-1)/2`, `mus = [0]*dim + [1]*dim`. `good_cmf` computes the good Euler factors from Pari `mfcoefs` over the relative Hecke field `K/Q(chi)`: the local quadratic `1 - a_p X + eps(p) p^(k-1) X^2` is normed down to Q with two resultants (eliminate the `K/Q(chi)` generator, then the character-field generator), with `eps(p) = (a_p^2 - a_{p^2})/p^(k-1)` keyed by `p mod level`. Validated against LMFDB `euler_factors` at p=5,7,11. Bad factors at 2,3 and the certified outputs come from LMFDB `8-18e4-1.1-c3e4-0-0`.
- Generation is about 3.5 minutes (Pari `mfcoefs` to `nmax=362304`); the factor loop and the driver take a few seconds.

## Verification

`make check-highdeg LPDATA=/usr/local/bin/lpdata2` (full sweep). Each new object asserts rank, `|eps|=1` and `eps`, the first zero, and (for ec/genus2/cmf) the leading Taylor coefficient / central value, against LMFDB and Pari golden values via `arb_overlaps`/`acb_overlaps`. Degree >= 3 objects tolerate `ERR_RH_ERROR` (bead `lfunctions-0zo`).

## Notes

- The high-degree suite is on `main` (it merged via PR #21); these changes extend it.
- The `cmf` backend needs Sage/Pari (like the genus-2 `--backend pari` path). The ec and genus-2 objects are unchanged.
