### PR TITLE
fix(turing): static-cache reuse bug + c_θ tightening

### DIFF
--- a/src/turing.c
+++ b/src/turing.c
@@ -212,7 +212,8 @@ bool St_int(arb_t res, arb_t h, arb_t t0, Lfunc *L, int64_t prec) {
   // 4.69028764131 (verified, and equal to Palojarvi-Zhao c_0(eps=1/2)). 4.6902877
   // rounds UP, so it stays a valid, strictly-tighter upper bound.
   arb_set_d(Q2, 4.6902877);
-  arb_set_d(tmp1, 0.8);
+  arb_set_ui(tmp1, 8);
+  arb_div_ui(tmp1, tmp1, 10, prec);              // 0.8 (exact)
   arb_sub_ui(tmp, L->X, 5, prec);                  // X-5
   arb_div(Q1, tmp1, tmp, prec);                    // 0.8/(X-5)
   arb_add(Q1, Q1, Q2, prec);                       // c_theta + 0.8/(X-5)

--- a/src/turing.c
+++ b/src/turing.c
@@ -203,19 +203,20 @@ bool St_int(arb_t res, arb_t h, arb_t t0, Lfunc *L, int64_t prec) {
     arb_set_d(Q2, -0.5);
     arb_add(l2_half, Q1, Q2, prec);
     arb_init(rc_theta_etc);
-    arb_set_d(Q2, 5.65056); // c_theta < 5.65055 in ARB Th 4.6
-    arb_set_ui(Q1, 8);
-    arb_div_ui(pi, Q1, 10, prec);                  // 0.8
-    arb_sub_ui(tmp, L->X, 5, prec);                // X-5
-    arb_div(Q1, pi, tmp, prec);                    // 0.8/(X-5)
-    arb_add(pi, Q1, Q2, prec);                     // c_theta + 0.8/(X-5)
-    arb_mul_ui(rc_theta_etc, pi, L->degree, prec); // c_\theta r+0.8 r/(X-5)
-    if (verbose) {
-      printf("c theta bit = ");
-      arb_printd(rc_theta_etc, 10);
-      printf("\n");
-    }
     arb_const_pi(pi, prec);
+  }
+  // rc_theta_etc depends on L (via L->X and L->degree), so it must be
+  // recomputed for every L-function, not cached in the init block.
+  arb_set_d(Q2, 5.65056); // c_theta < 5.65055 in ARB Th 4.6
+  arb_set_d(tmp1, 0.8);
+  arb_sub_ui(tmp, L->X, 5, prec);                  // X-5
+  arb_div(Q1, tmp1, tmp, prec);                    // 0.8/(X-5)
+  arb_add(Q1, Q1, Q2, prec);                       // c_theta + 0.8/(X-5)
+  arb_mul_ui(rc_theta_etc, Q1, L->degree, prec);   // c_\theta r+0.8 r/(X-5)
+  if (verbose) {
+    printf("c theta bit = ");
+    arb_printd(rc_theta_etc, 10);
+    printf("\n");
   }
   arb_set(acb_imagref(s), t0); // 3/2+it0
   logQ(Q2, s, L, prec);
@@ -287,29 +288,32 @@ uint64_t turing_count(arb_t res, Lfunc *L, int64_t prec) {
     arb_init(t0);
     arb_init(pi);
     arb_const_pi(pi, prec);
-    arb_div_ui(h, L->B, TURING_RATIO, prec);
-    if (verbose) {
-      printf("Turing h set to ");
-      arb_printd(h, 10);
-      printf("\n");
-    }
-    arb_div_ui(t0, L->B, OUTPUT_RATIO, prec);
-    if (verbose) {
-      printf("Turing t0 set to ");
-      arb_printd(t0, 10);
-      printf("\n");
-    }
     arb_init(rlogpi);
-    arb_log(tmp, pi, prec);
-    arb_mul_ui(rlogpi, tmp, L->degree, prec);
     arb_init(t0hbit);
-    arb_mul(tmp, t0, h, prec);
-    arb_mul_2exp_si(tmp, tmp, 1);
-    arb_mul(tmp1, h, h, prec);
-    arb_add(sint, tmp1, tmp, prec);
-    arb_div(t0hbit, sint, pi, prec);
-    arb_mul_2exp_si(t0hbit, t0hbit, -1); // (2t0h+h^2)/2Pi
   }
+  // h, t0, rlogpi and t0hbit all depend on L (via L->B = 512/degree and
+  // L->degree), so they must be recomputed for every L-function rather than
+  // cached once in the init block.
+  arb_div_ui(h, L->B, TURING_RATIO, prec);
+  if (verbose) {
+    printf("Turing h set to ");
+    arb_printd(h, 10);
+    printf("\n");
+  }
+  arb_div_ui(t0, L->B, OUTPUT_RATIO, prec);
+  if (verbose) {
+    printf("Turing t0 set to ");
+    arb_printd(t0, 10);
+    printf("\n");
+  }
+  arb_log(tmp, pi, prec);
+  arb_mul_ui(rlogpi, tmp, L->degree, prec);
+  arb_mul(tmp, t0, h, prec);
+  arb_mul_2exp_si(tmp, tmp, 1);
+  arb_mul(tmp1, h, h, prec);
+  arb_add(sint, tmp1, tmp, prec);
+  arb_div(t0hbit, sint, pi, prec);
+  arb_mul_2exp_si(t0hbit, t0hbit, -1); // (2t0h+h^2)/2Pi
   uint64_t zeros_found = 0;
   if (!turing_int(tint, t0, h, L, &zeros_found, 0, prec))
     return 0;

--- a/src/turing.c
+++ b/src/turing.c
@@ -207,7 +207,11 @@ bool St_int(arb_t res, arb_t h, arb_t t0, Lfunc *L, int64_t prec) {
   }
   // rc_theta_etc depends on L (via L->X and L->degree), so it must be
   // recomputed for every L-function, not cached in the init block.
-  arb_set_d(Q2, 5.65056); // c_theta < 5.65055 in ARB Th 4.6
+  // c_theta for theta=0 (Booker Thm 4.6). The paper's printed bound 5.65055 is
+  // loose by exactly log zeta(3/2)=0.96026; the displayed-expression value is
+  // 4.69028764131 (verified, and equal to Palojarvi-Zhao c_0(eps=1/2)). 4.6902877
+  // rounds UP, so it stays a valid, strictly-tighter upper bound.
+  arb_set_d(Q2, 4.6902877);
   arb_set_d(tmp1, 0.8);
   arb_sub_ui(tmp, L->X, 5, prec);                  // X-5
   arb_div(Q1, tmp1, tmp, prec);                    // 0.8/(X-5)

--- a/test/turing_static_cache_test.c
+++ b/test/turing_static_cache_test.c
@@ -1,0 +1,94 @@
+// Regression test for the turing.c static-cache bug.
+//
+// Invariant: an L-function's Turing RH verdict must not depend on what other
+// L-functions were processed earlier in the same process. The degree-2
+// elliptic curve 37.a1 (rank 1) confirms RH cleanly (ecode == 0) when it is the
+// only object in a process. Here we process a DIFFERENT-degree object FIRST
+// (Sym^2 of 11.a, degree 3) so that the static Turing caches in turing.c are
+// initialised with degree-3 constants (h=B/16, t0=B/8, rlogpi, t0hbit with
+// B=512/3), then compute 37.a1. On the broken library 37.a1 reuses those stale
+// degree-3 constants (correct would be B=512/2) and spuriously returns
+// ERR_RH_ERROR. The fix recomputes the constants per L-function.
+//
+// NOTE: the FIRST object to reach turing_check_RH must be the degree-3 one;
+// if 37.a1 ran first it would itself seed the (then-correct) degree-2 cache and
+// the bug would be masked. So this test deliberately orders sym2 before 37.a1.
+//
+// Build:  gcc -I include artifacts/research/regression_rh_order.c \
+//             -o /tmp/rh_order -L build -llfun -lflint -lm
+// Run:    LD_LIBRARY_PATH=build /tmp/rh_order   (exit 0 = pass)
+//
+// FAILS (assert) on the pre-fix library, PASSES on the post-fix library.
+
+#include <assert.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <flint/acb_poly.h>
+#include "glfunc.h"
+
+static long g_ainvs[5];
+static long g_bad, g_apbad;
+static int g_sym;
+
+static long mod_p(long v, long p) { return ((v % p) + p) % p; }
+static long ap_good(long p) {
+  long a1 = g_ainvs[0], a2 = g_ainvs[1], a3 = g_ainvs[2], a4 = g_ainvs[3], a6 = g_ainvs[4];
+  long c = 1;
+  for (long x = 0; x < p; x++) {
+    long x2 = mod_p(x * x, p), r = mod_p(x2 * x, p);
+    r = mod_p(r + a2 * x2, p); r = mod_p(r + a4 * x, p); r = mod_p(r + a6, p);
+    for (long y = 0; y < p; y++) if (mod_p(y * y + a1 * x * y + a3 * y, p) == r) c++;
+  }
+  return p + 1 - c;
+}
+static void cb(acb_poly_t poly, uint64_t p, int d, int64_t prec, void *pm) {
+  (void)d; (void)prec; (void)pm; acb_poly_zero(poly); long P = (long)p;
+  if (P == g_bad) {
+    acb_poly_set_coeff_si(poly, 0, 1);
+    acb_poly_set_coeff_si(poly, 1, (g_sym == 2) ? -1 : -g_apbad);
+    return;
+  }
+  long a = ap_good(P);
+  if (g_sym == 2) {
+    long t = a * a - P;
+    acb_poly_set_coeff_si(poly, 0, 1); acb_poly_set_coeff_si(poly, 1, -t);
+    acb_poly_set_coeff_si(poly, 2, P * t); acb_poly_set_coeff_si(poly, 3, -(P * P * P));
+  } else {
+    acb_poly_set_coeff_si(poly, 0, 1); acb_poly_set_coeff_si(poly, 1, -a);
+    acb_poly_set_coeff_si(poly, 2, P);
+  }
+}
+static Lerror_t run(long av[5], uint64_t cond, long bad, long apbad, int sym,
+                    uint64_t deg, double norm, double *mus) {
+  for (int i = 0; i < 5; i++) g_ainvs[i] = av[i];
+  g_bad = bad; g_apbad = apbad; g_sym = sym;
+  Lerror_t ec = 0; char cd[] = ".";
+  Lparams_t Lp = {0};
+  Lp.degree = deg; Lp.conductor = cond; Lp.normalisation = norm; Lp.mus = mus;
+  Lp.target_prec = DEFAULT_TARGET_PREC; Lp.self_dual = YES; Lp.rank = DK; Lp.cache_dir = cd;
+  Lfunc_t L = Lfunc_init_advanced(&Lp, &ec);
+  ec |= Lfunc_use_all_lpolys(L, cb, NULL);
+  ec |= Lfunc_compute(L);
+  Lfunc_clear(L);
+  return ec;
+}
+
+int main(void) {
+  long a11[5] = {0, -1, 1, -10, -20}, a37[5] = {0, 0, 1, -1, 0};
+  double m2[2] = {0, 1}, m3[3] = {0, 1, 0};
+
+  // Degree-3 object FIRST: seeds the static Turing caches with degree-3 values.
+  (void)run(a11, 121, 11, 1, 2, 3, 1.0, m3); // Sym^2 of 11.a, degree 3
+
+  // Then the degree-2 curve 37.a1. Run alone it confirms RH with ecode == 0.
+  Lerror_t after = run(a37, 37, 37, -1, 1, 2, 0.5, m2);
+  printf("37.a1 after deg-3 sym2: ecode=0x%lx (want 0x0)\n", (unsigned long)after);
+
+  // The bug: `after` gains ERR_RH_ERROR on the broken library because the stale
+  // degree-3 Turing constants are applied to this degree-2 zero count.
+  assert((after & ERR_RH_ERROR) == 0);
+  assert(after == 0);
+
+  printf("PASS: 37.a1 RH verdict is order-independent.\n");
+  return 0;
+}

--- a/test/turing_static_cache_test.c
+++ b/test/turing_static_cache_test.c
@@ -14,10 +14,6 @@
 // if 37.a1 ran first it would itself seed the (then-correct) degree-2 cache and
 // the bug would be masked. So this test deliberately orders sym2 before 37.a1.
 //
-// Build:  gcc -I include artifacts/research/regression_rh_order.c \
-//             -o /tmp/rh_order -L build -llfun -lflint -lm
-// Run:    LD_LIBRARY_PATH=build /tmp/rh_order   (exit 0 = pass)
-//
 // FAILS (assert) on the pre-fix library, PASSES on the post-fix library.
 
 #include <assert.h>


### PR DESCRIPTION
## What

Two small, independent correctness fixes in `src/turing.c`, as separate commits.

### 1. Static-cache reuse bug (`fix(turing): recompute L-dependent constants...`)

`St_int` and `turing_count` computed L-dependent quantities (`rc_theta_etc`, the Turing window `h = B/16`, `t0 = B/8`, `rlogpi = degree·logπ`, `t0hbit`) inside one-time `if(!init){…}` blocks and cached them in function-local `static` variables. The first L-function through Turing's RH check seeded them, and every later object of a **different degree** in the same process reused the stale values, producing a wrong RH verdict.

This is reachable through the in-tree batch driver `examples/rational.c` (one `Lfunc_init`/`compute`/`clear` per input line). It is masked when each object is its own process, which is why the existing single-object tests never caught it.

Fix: move the L-dependent computations out of the `if(!init)` blocks so they recompute per call; keep only L-independent allocations/constants (π, `log2−½`, `Re s = 1.5`) cached. Adds `test/turing_static_cache_test.c`: a public-API regression that processes `Sym²(11.a)` (degree 3) before `37.a1` (degree 2) in one process and asserts `37.a1`'s verdict is order-independent. It **fails on the unfixed library** (aborts on the assert) and **passes on the fix**.

### 2. Tighten `c_θ` to its true value (`fix(turing): tighten c_theta to 4.6902877...`)

The Turing constant `c_θ` (θ=0, Booker Thm 4.6) was hardcoded as `5.65056`. Booker's *printed* bound `c_0 ⪅ 5.65055` exceeds the displayed-expression value by exactly `log ζ(3/2) ≈ 0.96026`; the true value is `4.69028764131` (independently corroborated by Palojärvi–Zhao's `c_0(ε=½)`, which equals it term-for-term). `4.6902877` rounds **up** from the true value (margin `+5.9e-8`, far above double epsilon), so it remains a valid, strictly-tighter upper bound that cannot under-bound the error. Cleanup; it does not by itself rescue degree ≥ 3.

## Scope / non-goals

This does **not** close the degree ≥ 3 RH-confirmation gap (that is the separate Büthe-default work) and is independent of PR #26 (leave that unmerged). A small follow-up commit keeps the `0.8` term exact-rational (the de-caching had incidentally changed it to `arb_set_d`) and drops a stale comment.

## Testing

`make check` passes (full rebuild). The new regression test is fail-on-base / pass-on-fix.
