### PR TITLE
fix(sympow): harden sym_power_lpoly (k<1) and the high-degree sympow driver input

### DIFF
--- a/include/sym_power.h
+++ b/include/sym_power.h
@@ -22,7 +22,8 @@ extern "C" {
    * With k=1 this is the curve's own factor 1 - a_p*T + p*T^2.
    *
    * Coefficients are exact and routinely exceed 64 bits (the leading one has
-   * absolute value p^{k(k+1)/2}), hence the fmpz_poly output.  Requires k >= 1.
+   * absolute value p^{k(k+1)/2}), hence the fmpz_poly output.  Requires k >= 1
+   * (k < 1 yields the trivial factor 1 rather than reading out of bounds).
    *
    * GOOD PRIMES ONLY: this is a pure function of (a_p, p, k).  Bad/ramified
    * factors are not a function of a_p (e.g. Sym^4 of 27.a at p=3 is 1 - p^2*T,

--- a/src/sym_power.c
+++ b/src/sym_power.c
@@ -9,6 +9,10 @@
 void sym_power_lpoly(fmpz_poly_t out, slong a_p, ulong p, int k)
 {
   assert(k >= 1);
+  if (k < 1) {  // out of contract; stay defined (no out-of-bounds) when NDEBUG drops the assert
+    fmpz_poly_one(out);
+    return;
+  }
 
   fmpz_t pp, pk, pj, c1, t;
   fmpz_init_set_ui(pp, p);          // p

--- a/test/highdeg_check.cpp
+++ b/test/highdeg_check.cpp
@@ -119,9 +119,23 @@ int main(int argc, char **argv) {
     if (form_sympow && toks.size() == 1) {
       // base a_p only: form the Sym^k good-prime factor here, exact fmpz -> acb
       fmpz_set_str(z, toks[0].c_str(), 10);
-      if (!fmpz_fits_si(z)) {  // a_p is Hasse-bounded; a huge value means corrupt input
-        fprintf(stderr, "sympow base a_p out of slong range at p=%lu\n", (unsigned long) p);
-        return 2;
+      // A base a_p must satisfy the Hasse bound a_p^2 <= 4p (checked in fmpz to
+      // avoid overflow). A value outside it is not a trace (e.g. a mis-padded bad
+      // factor whose leading coefficient landed on a one-token line), so fail
+      // loudly instead of silently forming a wrong Sym^k factor. This also subsumes
+      // the slong-range check: any Hasse-valid a_p fits a slong.
+      {
+        fmpz_t aa, fourp; fmpz_init(aa); fmpz_init(fourp);
+        fmpz_mul(aa, z, z);                                  // a_p^2
+        fmpz_set_ui(fourp, p); fmpz_mul_ui(fourp, fourp, 4); // 4p
+        const bool hasse_ok = (fmpz_cmp(aa, fourp) <= 0);
+        fmpz_clear(aa); fmpz_clear(fourp);
+        if (!hasse_ok) {
+          fprintf(stderr, "sympow base a_p=%s violates the Hasse bound at p=%lu (corrupt input)\n",
+                  toks[0].c_str(), (unsigned long) p);
+          acb_poly_clear(poly); fmpz_clear(z); acb_clear(c); Lfunc_clear(L);
+          return 2;
+        }
       }
       fmpz_poly_t f; fmpz_poly_init(f);
       sym_power_lpoly(f, fmpz_get_si(z), p, sym_k);


### PR DESCRIPTION
## Summary

Post-merge hardening from an independent audit of the symmetric-power work. The audit's verdict was merge-quality; these two commits address the findings it raised. There is no behaviour change for any real input.

## Changes

- **`sym_power_lpoly` is now defined for `k < 1`** (`src/sym_power.c`, `include/sym_power.h`). The `k >= 1` precondition was guarded only by `assert`, which compiles out under `-DNDEBUG`; a `k < 1` call then wrote past the Lucas vector (a heap overflow). Since the symbol is exported from `liblfun.so`, a release-mode early return (yielding the trivial factor 1) now sits next to the assert: debug builds still abort loudly on misuse, release builds stay defined and never read out of bounds. No in-tree caller passes `k < 1`.
- **The high-degree driver validates the sympow base a_p** (`test/highdeg_check.cpp`). Under the `sympow` marker a one-token line is read as a base trace; it is now checked against the Hasse bound `a_p^2 <= 4p` (computed in `fmpz`, overflow-safe), so a corrupt or mis-padded value fails loudly (exit 2) instead of silently forming a wrong Sym^k factor. This subsumes the previous slong-range check, and the error return now also frees its FLINT objects.

## Verification

- `make check` green (17/17); `make check-highdeg` green (all objects, from committed fixtures); the helper unit test passes all 24 cases.
- Positive test of the new guard: a deliberately corrupt base a_p (100 at p=13, which exceeds the Hasse bound 2*sqrt(13)) is rejected with a clear message and exit code 2.
- valgrind on the corrupt-input error path: definitely lost = 0, indirectly lost = 0 (the remaining "possibly lost" blocks are FLINT global caches: Bernoulli / Stirling / zeta / G-data, pre-existing and unrelated).
