### PR TITLE
Configurable critical-line output-window height

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -209,12 +209,11 @@ examples additionally use FLINT's C++ bindings.
   header and the library to the same prefix. (This commonly happens when a
   system copy and a Sage or local copy are both installed.)
 
-- **Stale `g_<...>` cache files poison results.** The G-function (the gamma
-  factor product) is cached to disk in the current working directory as files
-  named `g_<normalisation>` (for example `g_0.5`, `g_1.5`). A stale or
-  mismatched cache file sitting in the CWD is silently reused and can corrupt a
-  computation. `make check` and `make check-highdeg` scrub `g_[0-9]*` for you,
-  but for ad-hoc runs remove them first:
+- **Stale `g_*` cache files can confuse ad-hoc runs.** The G-function (the gamma
+  factor product) is cached to disk in self-identifying `g_*` files. Current
+  cache files validate their headers before reuse, but old-format files or
+  scratch files in the CWD are best removed before ad-hoc runs. `make check` and
+  `make check-highdeg` scrub `g_*` for you:
 
   ```
   rm -f g_*

--- a/Makefile.in
+++ b/Makefile.in
@@ -94,12 +94,16 @@ print-%:
 # drop in a new source file and it joins the suite, no edit here required.
 # CHECK_EXCLUDE is the deny-list: binaries that require command-line arguments
 # or input files (they assert on argc / print a usage message and exit nonzero
-# without args) and so cannot run unattended. Only add an entry here if a
-# binary needs arguments. (artin runs an embedded self-test when given none.)
+# without args) and so cannot run unattended, plus heavy opt-in tests that are
+# too slow/large for the default suite. Only add an entry here if a binary needs
+# arguments or is an intentionally opt-in heavy run. (artin runs an embedded
+# self-test when given none; zero_overflow_test is a several-minute, multi-GB
+# MAX_ZEROS-exhaustion regression run directly via its .exe.)
 CHECK_EXCLUDE = \
 	examples/bound \
 	examples/rational \
-	test/highdeg_check
+	test/highdeg_check \
+	test/zero_overflow_test
 
 CHECK_BINS = $(filter-out $(addprefix build/, $(addsuffix .exe, $(CHECK_EXCLUDE))), $(TESTS) $(EXECUTABLES))
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -87,8 +87,8 @@ print-%:
 .PHONY: clean check check-highdeg highdeg-gen highdeg-data configure
 
 # Regression suite. Exit code is the oracle (assertions are on by default).
-# Stale/colliding g_<mu> caches poison results, so scrub them before the suite
-# and after each binary (different L-functions can share a g_<mu> filename).
+# Stale/colliding g_* caches poison results, so scrub them before the suite
+# and after each binary.
 #
 # Every test/ and examples/ binary runs under `make check` automatically --
 # drop in a new source file and it joins the suite, no edit here required.
@@ -108,13 +108,13 @@ CHECK_EXCLUDE = \
 CHECK_BINS = $(filter-out $(addprefix build/, $(addsuffix .exe, $(CHECK_EXCLUDE))), $(TESTS) $(EXECUTABLES))
 
 check: all
-	@rm -f g_[0-9]*
+	@rm -f g_*
 	@fail=0; \
 	for t in $(CHECK_BINS); do \
 	  printf 'RUN  %s\n' "$$t"; \
 	  if ./$$t >$$t.log 2>&1; then printf 'PASS %s\n' "$$t"; rm -f $$t.log; \
 	  else rc=$$?; printf 'FAIL %s (rc=%s)\n' "$$t" "$$rc"; cat $$t.log; rm -f $$t.log; fail=1; fi; \
-	  rm -f g_[0-9]*; \
+	  rm -f g_*; \
 	done; \
 	if [ $$fail -ne 0 ]; then echo 'CHECK FAILED'; exit 1; fi; \
 	echo 'CHECK PASSED'
@@ -137,7 +137,7 @@ LABEL ?=
 # fixtures with `make highdeg-data`. Set FIXTURES= (empty) to force on-the-fly generation.
 FIXTURES ?= test/highdeg/fixtures
 check-highdeg: all
-	@rm -f g_[0-9]*
+	@rm -f g_*
 	@fail=0; xpass=0; ran=0; \
 	for entry in $$(python3 -c "import yaml;print(' '.join(o['label']+':'+('1' if o.get('xfail') else '0') for o in yaml.safe_load(open('$(HIGHDEG_OBJECTS)'))['objects']))"); do \
 	  label=$${entry%%:*}; xf=$${entry##*:}; \
@@ -157,8 +157,8 @@ check-highdeg: all
 	    if [ $$ok = 1 ]; then printf 'PASS %s\n' "$$label"; \
 	    else printf 'FAIL %s\n' "$$label"; cat $$logf; fail=1; fi; \
 	  fi; \
-	  if [ -n "$(LABEL)" ]; then printf 'kept %s  (re-run: ./build/test/highdeg_check.exe %s)\n' "$$inf" "$$inf"; rm -f g_[0-9]*; \
-	  else rm -f $$inf $$logf g_[0-9]*; fi; \
+	  if [ -n "$(LABEL)" ]; then printf 'kept %s  (re-run: ./build/test/highdeg_check.exe %s)\n' "$$inf" "$$inf"; rm -f g_*; \
+	  else rm -f $$inf $$logf g_*; fi; \
 	done; \
 	if [ -n "$(LABEL)" ] && [ $$ran = 0 ]; then echo "no object labelled '$(LABEL)' in $(HIGHDEG_OBJECTS)"; exit 2; fi; \
 	if [ $$fail -ne 0 ]; then echo 'CHECK-HIGHDEG FAILED'; exit 1; fi; \
@@ -168,7 +168,7 @@ check-highdeg: all
 # Lets a collaborator iterate on a single object: edit the .in, run it under gdb, etc.
 highdeg-gen: all
 	@if [ -z "$(LABEL)" ]; then echo 'usage: make highdeg-gen LABEL=<label>'; exit 2; fi
-	@rm -f g_[0-9]*
+	@rm -f g_*
 	@inf=build/test/highdeg_$(LABEL).in; \
 	if BACKEND=$(BACKEND) LPDATA=$(LPDATA) python3 test/highdeg/gen.py "$(LABEL)" \
 	      --driver build/test/highdeg_check.exe --objects $(HIGHDEG_OBJECTS) > $$inf; then \

--- a/doc/api.md
+++ b/doc/api.md
@@ -101,10 +101,17 @@ typedef struct {
   int      self_dual;     // DK / YES / NO
   int      rank;          // DK, or a known rank
   char    *cache_dir;     // directory for the cached G data
+  double   max_t;         // output-window half-height H
+  uint64_t max_fft_NN;    // cap on output transform length
 } Lparams_t;
 ```
 
-| Field | Meaning | Default when left as 0 / `DK` |
+Initialise this struct with {c:func}`Lparams_init`, then overwrite the
+object-specific fields (`degree`, `conductor`, `normalisation`, `mus`, and any
+non-default knobs). Do not rely on raw zero-initialisation: the tri-state fields
+use `DK == -1` as the default, while `0` is the meaningful value `NO` / rank 0.
+
+| Field | Meaning | Default from `Lparams_init` |
 | --- | --- | --- |
 | {c:member}`target_prec <Lparams_t.target_prec>` | precision the results are refined to | {c:macro}`DEFAULT_TARGET_PREC` (100 bits) |
 | {c:member}`wprec <Lparams_t.wprec>` | internal working precision | derived from `target_prec` |
@@ -112,6 +119,8 @@ typedef struct {
 | {c:member}`self_dual <Lparams_t.self_dual>` | whether the L-function equals its dual | `DK`: the library decides |
 | {c:member}`rank <Lparams_t.rank>` | analytic rank, if already known | `DK`: the library determines it |
 | {c:member}`cache_dir <Lparams_t.cache_dir>` | where to read/write cached G data | current directory; see [The G-data cache](#g-data-cache) |
+| {c:member}`max_t <Lparams_t.max_t>` | output-window half-height H | `0`: `64 / degree` |
+| {c:member}`max_fft_NN <Lparams_t.max_fft_NN>` | cap on output transform length | `0`: `1 << 16` |
 
 The tri-state fields use the macros {c:macro}`DK` (-1, "don't know"),
 {c:macro}`YES` (1), and {c:macro}`NO` (0). Setting `self_dual = YES` when you
@@ -123,7 +132,7 @@ supplied, you get the {c:macro}`ERR_CONFLICT_RANK` warning.
 Leaving a numeric knob at 0 asks the library to choose it. There is no need to
 set `target_prec`, `wprec`, or `gprec` unless you have a specific reason;
 {c:func}`Lfunc_init` is exactly `Lfunc_init_advanced` with those left to their
-defaults, `self_dual = DK`, `rank = DK`, and no cache directory.
+defaults, `self_dual = DK`, `rank = DK`, and `cache_dir = "."`.
 
 ### 2. Supply the Euler factors
 
@@ -337,7 +346,7 @@ borrowed `arb_t` balls. `side = 0` gives the zeros of `L`; `side = 1` gives
 those of the dual L-function (for a self-dual L-function the two agree). When
 the rank is 0 or 1 and the RH check succeeded (no {c:macro}`ERR_RH_ERROR`
 warning), the list is complete up to the height reached; otherwise some zeros
-may be missing. At most {c:macro}`MAX_ZEROS` (256) zeros are stored per side.
+may be missing. At most {c:macro}`MAX_ZEROS` (2048) zeros are stored per side.
 If the zeros could not be refined to the target precision you get the
 {c:macro}`ERR_ZERO_PREC` warning.
 
@@ -456,11 +465,11 @@ a matching message branch in `fprint_errors` (in `src/glfunc.c`).
   - largest supported degree; raising it requires extending the Buthe integral
     tables in `src/buthe.c` and reviewing `src/g.c`
 * - {c:macro}`MAX_ZEROS`
-  - 256
+  - 2048
   - hard cap on the number of zeros found and stored per side
 * - {c:macro}`DEFAULT_TARGET_PREC`
   - 100
-  - default target precision, in bits, when {c:member}`target_prec <Lparams_t.target_prec>` is left at 0
+  - default target precision, in bits, as set by {c:func}`Lparams_init`
 ```
 
 ({c:macro}`MAX_R` is an alias for {c:macro}`MAX_DEGREE` that sizes the Buthe
@@ -471,22 +480,22 @@ tables.)
 ## The G-data cache and `cache_dir`
 
 The gamma-factor product (the "G data") depends only on the degree, the gamma
-shifts, and the precision, not on the Euler factors. Computing it is expensive,
-so the library caches it to disk, keyed by the analytic normalisation, in a file
-named `g_<normalisation>` (for example `g_0.5`). On a subsequent run with a
-matching gamma factor the cache is read back instead of recomputed.
+shifts, the output-window geometry, and the precision, not on the Euler factors.
+Computing it is expensive, so the library caches it to disk using a
+self-identifying `g_*` filename that includes the cache format version, degree,
+effective G precision, window `1/B`, and analytic gamma shifts. On a subsequent
+run with a matching gamma factor the cache is read back instead of recomputed.
 
 {c:member}`cache_dir <Lparams_t.cache_dir>` (settable through
 {c:func}`Lfunc_init_advanced`) chooses the directory for these files; left
 unset, the current working directory is used.
 
 ```{warning}
-A stale or mismatched `g_<normalisation>` file in the cache directory can poison
-a run. For a hermetic computation, point {c:member}`cache_dir
-<Lparams_t.cache_dir>` at a clean directory, or remove any `g_*` files from the
-working directory first. A cache that cannot be read raises the fatal
-{c:macro}`ERR_G_INFILE`; a grid that does not extend far enough (which a stale
-cache can also cause) raises {c:macro}`ERR_G_EXTENT`.
+A cache whose self-describing header validates is reused; a stale filename from
+an older format or mismatched request is recomputed. For a hermetic computation,
+point {c:member}`cache_dir <Lparams_t.cache_dir>` at a clean directory, or remove
+any `g_*` files from the working directory first. A cache with a valid-looking
+header but corrupt/truncated body raises the fatal {c:macro}`ERR_G_INFILE`.
 ```
 
 ## A worked end-to-end example

--- a/doc/rational.md
+++ b/doc/rational.md
@@ -147,6 +147,5 @@ prime-ordered form described above, and they must cover every prime up to
 `Lfunc_nmax`.
 
 > **Stale `g_*` cache files.** The library caches the gamma-factor product to
-> disk as `g_<normalisation>` files in the current directory. Remove any such
-> files (`rm -f g_*`) before a run; a stale one is silently reused and can
-> corrupt the result.
+> disk as self-identifying `g_*` files in the current directory. Remove them
+> (`rm -f g_*`) before an ad-hoc run when you want a clean cache.

--- a/examples/ec_sym.cpp
+++ b/examples/ec_sym.cpp
@@ -184,16 +184,13 @@ static Lerror_t check_sym_power(int k, uint64_t conductor, double normalisation,
   Lerror_t ecode = 0;
   char cache_dir[] = ".";
 
-  Lparams_t Lp = {}; // zero-init so the window fields (max_t/max_fft_NN) default to 0
+  Lparams_t Lp;
+  Lparams_init(&Lp);
   Lp.degree = (uint64_t) (k + 1);
   Lp.conductor = conductor;
   Lp.normalisation = normalisation;
   Lp.mus = mus;                 // Lfunc_init_advanced copies this
-  Lp.target_prec = DEFAULT_TARGET_PREC;
-  Lp.wprec = 0;
-  Lp.gprec = 0;
   Lp.self_dual = YES;           // Sym^k of a self-dual EC L-function is self-dual
-  Lp.rank = DK;
   Lp.cache_dir = cache_dir;
 
   Lfunc_t L = Lfunc_init_advanced(&Lp, &ecode);

--- a/examples/ec_sym.cpp
+++ b/examples/ec_sym.cpp
@@ -184,7 +184,7 @@ static Lerror_t check_sym_power(int k, uint64_t conductor, double normalisation,
   Lerror_t ecode = 0;
   char cache_dir[] = ".";
 
-  Lparams_t Lp;
+  Lparams_t Lp = {}; // zero-init so the window fields (max_t/max_fft_NN) default to 0
   Lp.degree = (uint64_t) (k + 1);
   Lp.conductor = conductor;
   Lp.normalisation = normalisation;

--- a/include/examples_tools.h
+++ b/include/examples_tools.h
@@ -377,13 +377,12 @@ ostream& operator<<(ostream& s, const Lplot_t *Lpp) {
 }
 
 // << operator for Lfunc_zeros
-// Only the zeros in 64/degree get checked against RH.
-// There may be some missing in [64/degree,96/degree]
+// Only the zeros up to the configured window height L->max_t get checked against RH.
+// There may be some missing above that height.
 ostream& ostream_zeros(ostream& s, const Lfunc_t L, uint64_t side=0, bool checked=true) {
   arb_t rh_lim;
   arb_init(rh_lim); // to what height do we check RH?
-  arb_set_ui(rh_lim,64);
-  arb_div_ui(rh_lim,rh_lim, ((Lfunc *) L)->degree, 200);
+  arb_set_d(rh_lim, ((Lfunc *) L)->max_t);   // RH-verified window height (= 64/degree by default)
   const arb_srcptr zeros = Lfunc_zeros(L, side);
   s << "[";
   for(size_t i = 0; i < 10; ++i) {

--- a/include/glfunc.h
+++ b/include/glfunc.h
@@ -111,6 +111,9 @@ extern "C"{
   // do the same but with more control. Lparams.conductor fixes the coefficient
   // range M implicitly, as in Lfunc_init (see Lfunc_nmax); no Lparams field sets
   // the prime/coefficient count directly.
+  // NOTE: zero-initialise Lparams_t (memset, or set every field) before calling.
+  // The newer fields (max_t, max_fft_NN) use 0 / <= 0 as the "use the default"
+  // sentinel, so leaving them uninitialised yields garbage window geometry.
   Lfunc_t Lfunc_init_advanced(Lparams_t *Lparams, Lerror_t *ecode);
 
   // Largest prime p (equivalently largest index M) for which an Euler factor /

--- a/include/glfunc.h
+++ b/include/glfunc.h
@@ -15,7 +15,7 @@
 #define MAX_DEGREE (9) // if increasing, need more integrals in buthe.c
 // and probably need to take a good look at g.c
 #define MAX_R MAX_DEGREE // alias for MAX_DEGREE (max degree r); sizes the Buthe tables
-#define MAX_ZEROS (256) // hard cap on the number of zeros found/stored per side
+#define MAX_ZEROS (2048) // hard cap on the number of zeros found/stored per side
 #define DEFAULT_TARGET_PREC (100) // default target precision in bits when none is given
 // error codes
 // those in lower 32 bits are fatal

--- a/include/glfunc.h
+++ b/include/glfunc.h
@@ -39,7 +39,7 @@
 #define ERR_G_EXTENT ((uint64_t) 4096) // fatal: G grid does not extend low enough (conductor too large for the fixed grid floor, or a cached grid was reused)
 #define ERR_WINDOW_TOO_LARGE ((uint64_t) 8192)  // requested window needs fft_NN > max_fft_NN
 #define ERR_WINDOW_TOO_SMALL ((uint64_t) 16384) // requested window below the valid floor
-#define ERR_ZERO_OVERFLOW ((uint64_t) 32768) // fatal: found more than MAX_ZEROS zeros on a side (storage exhausted); enlarge MAX_ZEROS or shrink the output window
+#define ERR_ZERO_OVERFLOW ((uint64_t) 32768) // fatal: zero storage exhausted after finding MAX_ZEROS zeros on a side
 
 // warnings
 #define ERR_SOME_DATA ((uint64_t) 1<<32) // We had some sensible data, but not to end of Turing Zone

--- a/include/glfunc.h
+++ b/include/glfunc.h
@@ -71,7 +71,8 @@ extern "C"{
     int self_dual; // -1 = DK, 0 = No, 1 = Yes
     int rank; // -1 = DK
     char *cache_dir;
-    double max_t;        // output-window half-height H; <= 0 => default 64/degree
+    double max_t;        // output-window half-height H; exactly 0 => default 64/degree;
+                         // a negative or non-finite value is rejected (ERR_WINDOW_TOO_SMALL)
     uint64_t max_fft_NN; // cap on output transform length; 0 => default 1<<16
   } Lparams_t;
 
@@ -112,8 +113,9 @@ extern "C"{
   // range M implicitly, as in Lfunc_init (see Lfunc_nmax); no Lparams field sets
   // the prime/coefficient count directly.
   // NOTE: zero-initialise Lparams_t (memset, or set every field) before calling.
-  // The newer fields (max_t, max_fft_NN) use 0 / <= 0 as the "use the default"
-  // sentinel, so leaving them uninitialised yields garbage window geometry.
+  // The newer fields use exactly 0 as the "use the default" sentinel (max_t => 64/degree,
+  // max_fft_NN => 1<<16); a negative or non-finite max_t is a caller error rejected with
+  // ERR_WINDOW_TOO_SMALL, so leaving these uninitialised yields garbage window geometry.
   Lfunc_t Lfunc_init_advanced(Lparams_t *Lparams, Lerror_t *ecode);
 
   // Largest prime p (equivalently largest index M) for which an Euler factor /

--- a/include/glfunc.h
+++ b/include/glfunc.h
@@ -110,13 +110,17 @@ extern "C"{
    *        mus = [6, 7] and normalisation = 0
    */
   Lfunc_t Lfunc_init(uint64_t degree, uint64_t conductor, double normalisation, const double *mus, Lerror_t *ecode);
+  // Fill Lparams with the defaults used by Lfunc_init:
+  // target_prec=DEFAULT_TARGET_PREC, wprec/gprec=0 (derived), self_dual=DK,
+  // rank=DK, cache_dir=".", max_t=0 (64/degree), max_fft_NN=0 (1<<16).
+  // Call this before setting the object-specific fields for Lfunc_init_advanced.
+  void Lparams_init(Lparams_t *Lparams);
+
   // do the same but with more control. Lparams.conductor fixes the coefficient
   // range M implicitly, as in Lfunc_init (see Lfunc_nmax); no Lparams field sets
   // the prime/coefficient count directly.
-  // NOTE: zero-initialise Lparams_t (memset, or set every field) before calling.
-  // The newer fields use exactly 0 as the "use the default" sentinel (max_t => 64/degree,
-  // max_fft_NN => 1<<16); a negative or non-finite max_t is a caller error rejected with
-  // ERR_WINDOW_TOO_SMALL, so leaving these uninitialised yields garbage window geometry.
+  // Prefer Lparams_init() over raw zero-initialisation: the tri-state fields use
+  // DK (-1) as their default, while 0 is the meaningful value NO / rank 0.
   Lfunc_t Lfunc_init_advanced(Lparams_t *Lparams, Lerror_t *ecode);
 
   // Largest prime p (equivalently largest index M) for which an Euler factor /

--- a/include/glfunc.h
+++ b/include/glfunc.h
@@ -39,6 +39,7 @@
 #define ERR_G_EXTENT ((uint64_t) 4096) // fatal: G grid does not extend low enough (conductor too large for the fixed grid floor, or a cached grid was reused)
 #define ERR_WINDOW_TOO_LARGE ((uint64_t) 8192)  // requested window needs fft_NN > max_fft_NN
 #define ERR_WINDOW_TOO_SMALL ((uint64_t) 16384) // requested window below the valid floor
+#define ERR_ZERO_OVERFLOW ((uint64_t) 32768) // fatal: found more than MAX_ZEROS zeros on a side (storage exhausted); enlarge MAX_ZEROS or shrink the output window
 
 // warnings
 #define ERR_SOME_DATA ((uint64_t) 1<<32) // We had some sensible data, but not to end of Turing Zone

--- a/include/glfunc.h
+++ b/include/glfunc.h
@@ -37,6 +37,8 @@
 #define ERR_BAD_DEGREE ((uint64_t) 1024) //fatal error when the degree is too low or too high
 #define ERR_SPEC_NZ ((uint64_t) 2048) // special value routine requires Im s >= 0.
 #define ERR_G_EXTENT ((uint64_t) 4096) // fatal: G grid does not extend low enough (conductor too large for the fixed grid floor, or a cached grid was reused)
+#define ERR_WINDOW_TOO_LARGE ((uint64_t) 8192)  // requested window needs fft_NN > max_fft_NN
+#define ERR_WINDOW_TOO_SMALL ((uint64_t) 16384) // requested window below the valid floor
 
 // warnings
 #define ERR_SOME_DATA ((uint64_t) 1<<32) // We had some sensible data, but not to end of Turing Zone
@@ -69,6 +71,8 @@ extern "C"{
     int self_dual; // -1 = DK, 0 = No, 1 = Yes
     int rank; // -1 = DK
     char *cache_dir;
+    double max_t;        // output-window half-height H; <= 0 => default 64/degree
+    uint64_t max_fft_NN; // cap on output transform length; 0 => default 1<<16
   } Lparams_t;
 
   typedef struct{

--- a/include/glfunc_internals.h
+++ b/include/glfunc_internals.h
@@ -65,6 +65,9 @@ extern "C"{
 
     arb_t **Gs;        // Gs[k][i-low_i] = k-th Taylor coeff G^(k)(u_i)/k! at u_i=i*(2*pi/B); built in g.c
 
+    double max_t; // resolved output-window half-height H (analytic t units)
+    uint64_t max_fft_NN; // resolved cap on fft_NN
+
     // computation related
     uint64_t fft_N; // length of the short DFT for the Euler-product convolutions (2^11)
     uint64_t fft_NN; // length of the final output iFFT (2^16)

--- a/include/glfunc_internals.h
+++ b/include/glfunc_internals.h
@@ -139,16 +139,18 @@ extern "C"{
     arb_t L_d; // L^(rank)(1/2)/rank!
   } Lfunc;
 
-  // Upper bound on the linear-convolution support (G grid [low_i,hi_i] plus the coefficient
-  // buckets, which reach down to calc_m(M0)) that the length-fft_N cyclic convolution must
-  // hold without aliasing. M0/sqrt(N) >= 1/100 (M0 = ceil(sqrt(N)/100)), so
-  // calc_m(M0) >= floor(log(0.01)/(2*pi/B)); using that floor makes this conductor-
-  // independent and guarantees it never undercounts the true support. Shared by the fft_N
-  // sizing (glfunc.c) and the runtime alias backstop (compute.c) so they cannot diverge.
+  // Upper bound on the linear-convolution support (the G grid [low_i,hi_i] together with the
+  // coefficient buckets) that the length-fft_N cyclic convolution must hold without aliasing.
+  // The SMALLEST coefficient is n=1, mapped to bucket calc_m(1) = round(log(1/sqrt(N))/(2pi/B));
+  // finish_convolves writes res[] down to it. For sqrt(N) > 100 that is below
+  // floor(log(0.01)/(2pi/B)) (the old M0/sqrt(N) >= 1/100 bound), which therefore UNDERCOUNTED
+  // and silently aliased enlarged windows at conductor > ~1e4. floor() gives a safe
+  // (<= calc_m(1)) conductor-dependent lower index. Shared by the fft_N sizing (glfunc.c)
+  // and the runtime alias backstop (compute.c) so they cannot diverge.
   static inline uint64_t conv_support(const Lfunc *L) {
     double two_pi_by_B = L->one_over_B * 2.0 * M_PI;
-    int64_t cm0_min = (int64_t)floor(log(0.01) / two_pi_by_B);
-    return (uint64_t)(L->hi_i - L->low_i + 1) + (uint64_t)(L->hi_i - cm0_min + 1);
+    int64_t cm1 = (int64_t)floor(log(1.0 / sqrt((double)L->conductor)) / two_pi_by_B);
+    return (uint64_t)(L->hi_i - L->low_i + 1) + (uint64_t)(L->hi_i - cm1 + 1);
   }
 
   // from glfunc_g.c

--- a/include/glfunc_internals.h
+++ b/include/glfunc_internals.h
@@ -80,6 +80,7 @@ extern "C"{
     acb_t *w; // twiddle factors for length fft_N
     acb_t *ww; // ditto for fft_NN
     arb_t *zeros[2]; // zero ordinates t on the critical line; [0]=L, [1]=dual L
+    uint64_t zero_cap; // active per-side zero cap, <= MAX_ZEROS; default MAX_ZEROS
     double eta; // contour-tilt knob in delta=(1-eta)*pi/2; =0, only feeds delta
     arb_t delta; // contour offset (1-eta)*pi/2 = pi/2; only feeds (unused) exp_delta
     arb_t exp_delta; // exp(-delta) = exp(-pi/2); unused
@@ -155,6 +156,9 @@ extern "C"{
 
   // from glfunc_g.c
   Lerror_t compute_g(Lfunc *);
+
+  // from glfunc.c
+  void Lfunc_set_zero_cap_for_tests(Lfunc_t L, uint64_t cap);
 
   // from acb_fft.c
   void acb_initfft(acb_t *w, uint64_t n, uint64_t prec);

--- a/include/glfunc_internals.h
+++ b/include/glfunc_internals.h
@@ -164,6 +164,7 @@ extern "C"{
 
   // from error.c
   void abs_gamma(arb_t res, acb_t s, Lfunc *L, int64_t prec);
+  bool ftwiddle_beta_positive(const Lfunc *L, int64_t prec);
   void init_ftwiddle_error(Lfunc *L, int64_t prec);
   void complete_ftwiddle_error(Lfunc *L, int64_t prec);
   Lerror_t do_pre_iFFT_errors(Lfunc *L);

--- a/include/glfunc_internals.h
+++ b/include/glfunc_internals.h
@@ -54,7 +54,7 @@ extern "C"{
     arb_t alpha;       // alpha = 1 under Ramanujan (set in g.c)
     //arb_t k0; // no longer used
     //arb_t k2;
-    double one_over_B; // 1/B = degree/512; the G-kernel u-grid step is 2*pi/B
+    double one_over_B; // 1/B = degree/512 for the default window (= 1/(OUTPUT_RATIO*max_t) in general); the G-kernel u-grid step is 2*pi/B
     arb_t B; // scaling parameter B = 1/one_over_B; sets the t-spacing of Lambda samples
     arb_t two_pi_by_B; // 2*pi/B: u-spacing between consecutive G/Lambda sample indices
     arb_t pi; // the constant pi at working precision wprec
@@ -70,8 +70,8 @@ extern "C"{
 
     // computation related
     uint64_t fft_N; // length of the short DFT for the Euler-product convolutions (2^11)
-    uint64_t fft_NN; // length of the final output iFFT (2^16)
-    double A; // output sampling rate = fft_NN/B; output sample i is Lambda at t = i/A
+    uint64_t fft_NN; // length of the final output iFFT (2^16 for the default window; scales with the window)
+    double A; // output sampling rate = fft_NN/B (runtime value); output sample i is Lambda at t = i/A
     arb_t arb_A; // A as a rigorous real ball (for the error analysis)
     arf_t arf_A; // A as an arf_t; only used to form arf_one_over_A
     arb_t one_over_A; // 1/A as a ball; the t-grid spacing (sample i has imag part i/A)

--- a/include/glfunc_internals.h
+++ b/include/glfunc_internals.h
@@ -139,6 +139,18 @@ extern "C"{
     arb_t L_d; // L^(rank)(1/2)/rank!
   } Lfunc;
 
+  // Upper bound on the linear-convolution support (G grid [low_i,hi_i] plus the coefficient
+  // buckets, which reach down to calc_m(M0)) that the length-fft_N cyclic convolution must
+  // hold without aliasing. M0/sqrt(N) >= 1/100 (M0 = ceil(sqrt(N)/100)), so
+  // calc_m(M0) >= floor(log(0.01)/(2*pi/B)); using that floor makes this conductor-
+  // independent and guarantees it never undercounts the true support. Shared by the fft_N
+  // sizing (glfunc.c) and the runtime alias backstop (compute.c) so they cannot diverge.
+  static inline uint64_t conv_support(const Lfunc *L) {
+    double two_pi_by_B = L->one_over_B * 2.0 * M_PI;
+    int64_t cm0_min = (int64_t)floor(log(0.01) / two_pi_by_B);
+    return (uint64_t)(L->hi_i - L->low_i + 1) + (uint64_t)(L->hi_i - cm0_min + 1);
+  }
+
   // from glfunc_g.c
   Lerror_t compute_g(Lfunc *);
 

--- a/src/buthe.c
+++ b/src/buthe.c
@@ -301,17 +301,15 @@ extern "C"{
   // add digamma(1/4+mu/2)
   void buthe_lgam1(arb_t res, double mu, int64_t prec)
   {
-    static bool init=false;
-    static arb_t s,tmp;
-    if(!init)
-    {
-      arb_init(s);
-      arb_init(tmp);
-    }
+    arb_t s,tmp;
+    arb_init(s);
+    arb_init(tmp);
     arb_set_d(s,1.0/4.0+(double)mu/2.0); // all normalised to (1-s)
     arb_digamma(tmp,s,prec);
     //if(verbose) {printf("lgam1(%f) returning ",mu);arb_printd(tmp,20);printf("\n");}
     arb_add(res,res,tmp,prec);
+    arb_clear(s);
+    arb_clear(tmp);
   }
 
   // add log N - r log pi

--- a/src/clear.c
+++ b/src/clear.c
@@ -12,6 +12,8 @@ extern "C"{
   void Lfunc_clear(Lfunc_t LL)
   {
     Lfunc *L=(Lfunc *) LL;
+    if(!L)
+      return;
 
     free(L->mus);
     arb_cclear(L->zero_prec);

--- a/src/compute.c
+++ b/src/compute.c
@@ -119,6 +119,11 @@ Lerror_t finalise_comp(Lfunc *L)
           L->offset,L->low_i);
     return ERR_G_EXTENT;
   }
+  // Backstop: the cyclic convolution aliases if the support exceeds fft_N. fft_N was
+  // sized for this at init; this catches a stale cache whose grid is larger.
+  int64_t cm0_min = (int64_t)floor(log(0.01) / two_pi_by_B);
+  if ((uint64_t)(L->hi_i - L->low_i + 1) + (uint64_t)(L->hi_i - cm0_min + 1) > L->fft_N)
+    return ERR_G_EXTENT;
   return ERR_SUCCESS;
 } /* finalise_comp */
 

--- a/src/compute.c
+++ b/src/compute.c
@@ -119,10 +119,11 @@ Lerror_t finalise_comp(Lfunc *L)
           L->offset,L->low_i);
     return ERR_G_EXTENT;
   }
-  // Backstop: the cyclic convolution aliases if the support exceeds fft_N. fft_N was
-  // sized for this at init; this catches a stale cache whose grid is larger.
-  int64_t cm0_min = (int64_t)floor(log(0.01) / two_pi_by_B);
-  if ((uint64_t)(L->hi_i - L->low_i + 1) + (uint64_t)(L->hi_i - cm0_min + 1) > L->fft_N)
+  // Backstop: the length-fft_N cyclic convolution aliases if the grid+coeff support exceeds
+  // fft_N. Init sized fft_N from conv_support(), so this fires only if a (stale) cache
+  // supplied a larger grid than the current fft_N. Reuses ERR_G_EXTENT (a G-grid extent
+  // problem) rather than a dedicated code; near-unreachable given GCACHE header validation.
+  if (conv_support(L) > L->fft_N)
     return ERR_G_EXTENT;
   return ERR_SUCCESS;
 } /* finalise_comp */

--- a/src/compute.c
+++ b/src/compute.c
@@ -109,14 +109,18 @@ Lerror_t finalise_comp(Lfunc *L)
 {
   double two_pi_by_B=L->one_over_B*2*M_PI;
   L->offset=calc_m(1,two_pi_by_B,L->dc);
-  if(L->offset<L->low_i)
+  // finish_convolves' direct path starts at n=-1, so it reads the G grid down to
+  // Gs[offset-1]; the floor must reach offset-1, not just offset, to close a one-cell
+  // out-of-bounds read at offset==low_i. offset is conductor-dependent; the grid floor
+  // (fixed at umin=-32 ln2) is degree-dependent only. Reachable only at astronomically
+  // large conductor, but the cost of being exact here is one subtraction.
+  if(L->offset-1<L->low_i)
   {
-    // The grid floor (fixed at umin=-32 ln2, so degree-dependent only) does not
-    // reach the conductor-dependent offset we need.  Report it as a recoverable
-    // fatal error rather than exit()ing out from under the caller.
+    // Report the short grid as a recoverable fatal error rather than exit()ing out
+    // from under the caller.
     if(verbose)
       fprintf(stderr,"G values need to go down to %" PRId64 ". We only have down to %" PRId64 ".\n",
-          L->offset,L->low_i);
+          L->offset-1,L->low_i);
     return ERR_G_EXTENT;
   }
   // Backstop: the length-fft_N cyclic convolution aliases if the grid+coeff support exceeds

--- a/src/compute.c
+++ b/src/compute.c
@@ -284,7 +284,7 @@ void final_ifft(Lfunc *L)
 
 // this is called by the user to compute all the bits of the Lfunc we expect them to want
 // including Lambda(t) for t =0,1/A,2/A,....
-// the zeros up to height 64/degree
+// the zeros up to the configured window height H (default 64/degree)
 // the (apparent) rank
 // sign and sqrt_sign
 // Lambda^(rank)(1/2)

--- a/src/error.c
+++ b/src/error.c
@@ -100,27 +100,84 @@ void abs_gamma(arb_t res, acb_t s, Lfunc *L, int64_t prec)
   arb_clear(tmp);
 }
 
-// Lemma 5.7 of Artin's conjecture,....
-// we compute this for the family by leaving out the conductor
-void init_ftwiddle_error(Lfunc *L, int64_t prec)
+// Compute the ftwiddle decay rate beta into `beta`, using EXACTLY the formula in
+// init_ftwiddle_error (Lemma 5.7): beta = pi*r/4 - sum_j atan((1/2+mu_j)/B)
+//   - (4/pi^2) sum_j 1/(B^2-(1/2+mu_j)^2).
+// Factored out so the init-time preflight (ftwiddle_beta_positive) and
+// init_ftwiddle_error cannot diverge. Requires L->B to be set.
+static void ftwiddle_beta(arb_t beta, const Lfunc *L, int64_t prec)
 {
-  acb_t s,s_plus_mu;
-  arb_t tmp1,tmp2,tmp3,tmp4,E,two_pi,four_by_pi2,beta;
-  acb_init(s);
-  acb_init(s_plus_mu);
+  arb_t tmp1,tmp2,tmp3,tmp4,two_pi,four_by_pi2;
   arb_init(tmp1);
   arb_init(tmp2);
   arb_init(tmp3);
   arb_init(tmp4);
-  arb_init(E);
   arb_init(two_pi);
   arb_init(four_by_pi2);
-  arb_init(beta);
   arb_const_pi(two_pi,prec);
   arb_inv(tmp1,two_pi,prec);
   arb_mul(four_by_pi2,tmp1,tmp1,prec);
   arb_mul_2exp_si(four_by_pi2,four_by_pi2,2); // 4/Pi^2
   arb_mul_2exp_si(two_pi,two_pi,1); // 2Pi
+
+  arb_mul_2exp_si(tmp1,two_pi,-3); //pi/4
+  arb_mul_ui(beta,tmp1,L->degree,prec); // pi r/4
+  uint64_t j;
+  for(j=0;j<L->degree;j++)
+  {
+    arb_set_d(tmp1,0.5+L->mus[j]);
+    arb_div(tmp2,tmp1,L->B,prec);
+    arb_atan(tmp1,tmp2,prec);
+    arb_sub(beta,beta,tmp1,prec);
+  }
+
+  arb_mul(tmp2,L->B,L->B,prec);
+  arb_zero(tmp4);
+  for(j=0;j<L->degree;j++)
+  {
+    arb_set_d(tmp1,(0.5+L->mus[j])*(0.5+L->mus[j]));
+    arb_sub(tmp3,tmp2,tmp1,prec);
+    arb_inv(tmp1,tmp3,prec);
+    arb_add(tmp4,tmp4,tmp1,prec);
+  }
+  arb_mul(tmp1,tmp4,four_by_pi2,prec);
+  arb_sub(beta,beta,tmp1,prec);
+
+  arb_clear(tmp1);
+  arb_clear(tmp2);
+  arb_clear(tmp3);
+  arb_clear(tmp4);
+  arb_clear(two_pi);
+  arb_clear(four_by_pi2);
+}
+
+// Side-effect-free preflight: is the ftwiddle decay rate beta strictly positive?
+// If not, 1-exp(-beta*B) <= 0 and pre_ftwiddle_error is silently garbage, so the
+// window must be rejected (ERR_WINDOW_TOO_SMALL) before compute_g. Requires
+// L->B to be set; never touches L->pre_ftwiddle_error.
+bool ftwiddle_beta_positive(const Lfunc *L, int64_t prec)
+{
+  arb_t beta;
+  arb_init(beta);
+  ftwiddle_beta(beta,L,prec);
+  bool ok = arb_is_positive(beta);
+  arb_clear(beta);
+  return ok;
+}
+
+// Lemma 5.7 of Artin's conjecture,....
+// we compute this for the family by leaving out the conductor
+void init_ftwiddle_error(Lfunc *L, int64_t prec)
+{
+  acb_t s,s_plus_mu;
+  arb_t tmp1,tmp2,tmp3,E,beta;
+  acb_init(s);
+  acb_init(s_plus_mu);
+  arb_init(tmp1);
+  arb_init(tmp2);
+  arb_init(tmp3);
+  arb_init(E);
+  arb_init(beta);
 
   arb_set_d(acb_realref(s),0.5);
   arb_set(acb_imagref(s),L->B); // 1/2+iB
@@ -150,30 +207,8 @@ void init_ftwiddle_error(Lfunc *L, int64_t prec)
 
   arb_mul_2exp_si(E,E,1);
 
-
-
-  arb_mul_2exp_si(tmp1,two_pi,-3); //pi/4
-  arb_mul_ui(beta,tmp1,L->degree,prec); // pi r/4
-  uint64_t j;
-  for(j=0;j<L->degree;j++)
-  {
-    arb_set_d(tmp1,0.5+L->mus[j]);
-    arb_div(tmp2,tmp1,L->B,prec);
-    arb_atan(tmp1,tmp2,prec);
-    arb_sub(beta,beta,tmp1,prec);
-  }
-
-  arb_mul(tmp2,L->B,L->B,prec);
-  arb_zero(tmp4);
-  for(j=0;j<L->degree;j++)
-  {
-    arb_set_d(tmp1,(0.5+L->mus[j])*(0.5+L->mus[j]));
-    arb_sub(tmp3,tmp2,tmp1,prec);
-    arb_inv(tmp1,tmp3,prec);
-    arb_add(tmp4,tmp4,tmp1,prec);
-  }
-  arb_mul(tmp1,tmp4,four_by_pi2,prec);
-  arb_sub(beta,beta,tmp1,prec);
+  // beta via the shared helper so the preflight cannot diverge from this
+  ftwiddle_beta(beta,L,prec);
 
   arb_mul(tmp1,beta,L->B,prec);
   arb_neg(tmp1,tmp1);
@@ -189,10 +224,7 @@ void init_ftwiddle_error(Lfunc *L, int64_t prec)
   arb_clear(tmp1);
   arb_clear(tmp2);
   arb_clear(tmp3);
-  arb_clear(tmp4);
-  arb_clear(two_pi);
   arb_clear(E);
-  arb_clear(four_by_pi2);
   arb_clear(beta);
 
 }
@@ -357,7 +389,9 @@ void djp_zeta(arb_t res, const arb_t x, slong prec)
 }
       
 // Lemma 5 of ARB's g.pdf
-void F_hat_twiddle_error(arb_t res, arb_t x, Lfunc *L)
+// Returns false (instead of exit()ing) if the X>r/2 side condition fails, so the
+// caller can propagate a fatal Lerror_t rather than the library dying under a caller.
+bool F_hat_twiddle_error(arb_t res, arb_t x, Lfunc *L)
 {
   int64_t prec=L->wprec;
   arb_t tmp1,tmp2,tmp3,u,X,half_log_N,twoXbyr;
@@ -386,8 +420,19 @@ void F_hat_twiddle_error(arb_t res, arb_t x, Lfunc *L)
   if(verbose){printf("X=");arb_printd(X,10);printf("\n");}
   if(!arb_is_positive(tmp2))
   {
-    fprintf(stderr,"Fhat twiddle error failed X>r/2 test. Exiting.\n");
-    exit(0);
+    // X>r/2 side condition failed: the bound is invalid for this window. Do not
+    // exit() out from under the caller; clean up and signal failure so the caller
+    // can raise a fatal Lerror_t (ERR_WINDOW_TOO_SMALL via do_pre_iFFT_errors).
+    if(verbose)
+      fprintf(stderr,"Fhat twiddle error failed X>r/2 test.\n");
+    arb_clear(tmp1);
+    arb_clear(tmp2);
+    arb_clear(tmp3);
+    arb_clear(u);
+    arb_clear(X);
+    arb_clear(half_log_N);
+    arb_clear(twoXbyr);
+    return false;
   }
   // 2X/r
   arb_div_ui(twoXbyr,X,L->degree,prec);
@@ -428,6 +473,7 @@ void F_hat_twiddle_error(arb_t res, arb_t x, Lfunc *L)
   arb_clear(X);
   arb_clear(half_log_N);
   arb_clear(twoXbyr);
+  return true;
 
 }
 
@@ -533,7 +579,10 @@ Lerror_t do_pre_iFFT_errors(Lfunc *L)
 
   // error sum k\neq 0 F_hat(x+2\pi k A)
   arb_sub(err,two_pi_A,x,prec);
-  F_hat_twiddle_error(fhattwiddle,err,L);
+  // X>r/2 side condition failed => window too small for a valid bound (matches the
+  // existing M_error return-on-fatal style above).
+  if(!F_hat_twiddle_error(fhattwiddle,err,L))
+    return ERR_WINDOW_TOO_SMALL;
   arb_mul_2exp_si(fhattwiddle,fhattwiddle,1);
   if(verbose)
   {
@@ -617,7 +666,8 @@ Lerror_t do_pre_iFFT_errors(Lfunc *L)
   // the rest of the vector we just approximate with F_hat_twiddle error
 
   // error sum F_hat(x+2\pi k A)
-  F_hat_twiddle_error(fhattwiddle,x,L);
+  if(!F_hat_twiddle_error(fhattwiddle,x,L))
+    return ERR_WINDOW_TOO_SMALL;
   // we have sum k\geq 0 F_hat(x+2\pi k A)
   // since x<\pi A we can just double this
   arb_mul_2exp_si(fhattwiddle,fhattwiddle,1);

--- a/src/error.c
+++ b/src/error.c
@@ -546,10 +546,10 @@ Lerror_t do_pre_iFFT_errors(Lfunc *L)
   if(verbose){printf("Adding eq 5-9 error = ");arb_printd(err,10);printf("\n");}
   for(j=0;j<i;j++)
   {
-    arb_add_error(acb_realref(L->res[i]),fhattwiddle);
-    arb_add_error(acb_imagref(L->res[i]),fhattwiddle);
-    arb_add_error(acb_realref(L->res[i]),err);
-    arb_add_error(acb_imagref(L->res[i]),err);
+    arb_add_error(acb_realref(L->res[j]),fhattwiddle);
+    arb_add_error(acb_imagref(L->res[j]),fhattwiddle);
+    arb_add_error(acb_realref(L->res[j]),err);
+    arb_add_error(acb_imagref(L->res[j]),err);
   }
 
   // figure out epsilon

--- a/src/g.c
+++ b/src/g.c
@@ -557,9 +557,7 @@ computeres:
     for (imax=imin;error_bound(twomu,L->degree,imax*delta)<prec;imax++);
 
     coeff_bound(m,L->degree,53);
-    arb_init(L->C);
     arb_set_arf(L->C,m);
-    arb_init(L->alpha);
     arb_set_ui(L->alpha,1);
 
     if(op) {
@@ -589,7 +587,6 @@ computeres:
       // header has already been written (and would flush on fclose), so discard
       // the partial file before returning so it cannot poison the cache name.
       arb_clear(u); arb_clear(eps); arb_clear(thresh); arf_clear(m);
-      arb_clear(L->C); arb_clear(L->alpha);
       gcache_writer_abort(fp, cache_path);
       return ERR_WINDOW_TOO_SMALL;
     }
@@ -599,7 +596,6 @@ computeres:
     L->low_i=imin;
     L->hi_i=imax;
 
-    arb_init(L->eq59);
     arb_set(L->eq59,thresh);
     if(op) {
       // %a (hex float) so this body copy of one_over_B round-trips bit-for-bit;
@@ -614,13 +610,12 @@ computeres:
       fflush(fp);
     }
 
-    L->Gs=(arb_t **)malloc(sizeof(arb_t *)*k);
+    L->Gs=(arb_t **)calloc(k,sizeof(arb_t *));
     if(!L->Gs)
     {
       // Graceful fatal return (no exit() on this branch); discard the partial
       // cache file so it cannot poison the cache name on a later run.
       arb_clear(u); arb_clear(eps); arb_clear(thresh); arf_clear(m);
-      arb_clear(L->C); arb_clear(L->alpha); arb_clear(L->eq59);
       gcache_writer_abort(fp, cache_path);
       return ERR_OOM;
     }
@@ -629,23 +624,24 @@ computeres:
       L->Gs[i]=(arb_t *)malloc(sizeof(arb_t)*(imax-imin+1));
       if(!L->Gs[i])
       {
-        // Unwind the rows already allocated (none are arb_init'd yet), then fail
-        // gracefully and discard the partial cache file.
-        for(j=0;j<i;j++)
-          free(L->Gs[j]);
-        free(L->Gs);
+        // Leave already-initialised rows for Lfunc_clear; just discard the
+        // partial cache file and report a graceful fatal error.
         arb_clear(u); arb_clear(eps); arb_clear(thresh); arf_clear(m);
-        arb_clear(L->C); arb_clear(L->alpha); arb_clear(L->eq59);
         gcache_writer_abort(fp, cache_path);
         return ERR_OOM;
       }
-    }
-    for(i=0;i<k;i++)
       for(j=0;j<=imax-imin;j++)
         arb_init(L->Gs[i][j]);
+    }
 
 
     g = calloc(k,sizeof(g[0]));
+    if(!g) {
+      arb_clear(u); arb_clear(eps);
+      arb_clear(thresh); arf_clear(m);
+      gcache_writer_abort(fp, cache_path);
+      return ERR_OOM;
+    }
     for (i=0;i<k;i++)
       arb_init(g[i]);
     int64_t ii;
@@ -797,8 +793,6 @@ computeres:
     //double dalpha;
     // C = coeff_bound(degree, 53) is canonical in the degree, which the header
     // has just verified, so the value read below is safe to trust.
-    arb_init(L->C);
-    arb_init(L->alpha);
     if(fscanf(infile,"%" PRId64 " %" PRId64 " %" PRId64 "\n",&m,&e,&alpha)!=3)
       return GCACHE_CORRUPT;
     arb_set_si(L->C,m);
@@ -819,7 +813,6 @@ computeres:
     fmpz_init(b);
     mpz_init(x);
     mpz_init(ee);
-    arb_init(L->eq59);
     if(!mpz_inp_str(x,infile,10))
       return GCACHE_CORRUPT;
     if(!mpz_inp_str(ee,infile,10))
@@ -832,7 +825,7 @@ computeres:
     mpz_clear(x);
     mpz_clear(ee);
 
-    L->Gs=(arb_t **)malloc(sizeof(arb_t *)*L->max_K);
+    L->Gs=(arb_t **)calloc(L->max_K,sizeof(arb_t *));
     if(!L->Gs)
       return GCACHE_CORRUPT;
     for(uint64_t k=0;k<L->max_K;k++)
@@ -883,17 +876,22 @@ computeres:
     if(use_cache) {
       char fname1[1024] = "";
       size_t off = 0;
-      // Build the cache filename, bailing out if any snprintf hits an encoding
-      // error (returns < 0) or would truncate. snprintf reports the would-be
-      // length, so capture it in an int (off is size_t: adding a negative return
-      // directly would wrap) and advance only once a write fully fit. A truncated
-      // name would drop trailing mus / path chars and let distinct L-functions
-      // collide on one cache file, so on any failure we skip the cache
-      // (best-effort) and compute the G data fresh rather than read or write the
-      // wrong data. These checks bound both writes for any mus and cache_dir --
-      // nothing here relies on a cap on the number or magnitude of the mus.
+      // Build a self-identifying cache filename, bailing out if any snprintf hits
+      // an encoding error (returns < 0) or would truncate. The header is still
+      // validated on read, but the filename now carries the fields that define
+      // the G data in normal use: cache format version, degree, effective gprec,
+      // window one_over_B, and the sorted analytic mus.
       bool name_fits = true;
+      int n0 = snprintf(fname1, sizeof(fname1), "v%d_r%lu_p%" PRId64 "_b%a",
+                        GCACHE_VERSION, (unsigned long)L->degree,
+                        L->gprec, L->one_over_B);
+      if(n0 < 0 || (size_t) n0 >= sizeof(fname1))
+        name_fits = false;
+      else
+        off = (size_t) n0;
       for(uint64_t r=0; r<L->degree; r++) {
+        if(!name_fits)
+          break;
         int n = snprintf(fname1+off, sizeof(fname1)-off, "_%.1f", L->mus[r]);
         if(n < 0 || (size_t) n >= sizeof(fname1)-off) {
           name_fits = false;
@@ -902,7 +900,7 @@ computeres:
         off += (size_t) n;
       }
       if(name_fits) {
-        int n = snprintf(fname, sizeof(fname), "%s/g%s", L->cache_dir, fname1);
+        int n = snprintf(fname, sizeof(fname), "%s/g_%s", L->cache_dir, fname1);
         name_fits = (n >= 0) && ((size_t) n < sizeof(fname));
       }
       if(name_fits) {

--- a/src/g.c
+++ b/src/g.c
@@ -375,8 +375,18 @@ computeres:
       arb_trim(res[j],res[j]);
   }
 
+  // Hard certification cap on the taylor_terms recurrence. For a valid window the
+  // asymptotic per-step multiplier 4/(r*B) is < 1 (guaranteed by the init-time
+  // B > 4/degree preflight) and the term count is modest (tens to low hundreds).
+  // If the threshold is not reached within this many terms the configured window
+  // is degenerate; taylor_terms returns -1 and the caller raises a fatal
+  // ERR_WINDOW_TOO_SMALL instead of looping forever. The cap is astronomically
+  // larger than any legitimate window needs, so it never fires on valid input.
+#define TAYLOR_TERMS_CAP (1000000L)
+
   // compute k >= r such that |eps^k*G^{(k)}(u)/k!| < thresh for all u
   // replace thresh by an interval containing eps^k*G^{(k)}(u)/k!
+  // returns -1 (instead of looping forever) if the cap above is exceeded
   static long taylor_terms(arb_t thresh,long twomu[],long r,
       arb_srcptr eps,long prec) {
     long j,k;
@@ -433,6 +443,8 @@ computeres:
     arb_div(x,x,t,prec);
 
     for (k=r;!arb_lt(x,thresh);) {
+      if (k >= TAYLOR_TERMS_CAP)
+        return -1; // recurrence did not contract: degenerate window
       k++;
       arb_one(t);
       for (j=0;j<r;j++) {
@@ -499,7 +511,7 @@ computeres:
 
   // compute G data into L
   // if(op) then also write the data to fp (in the cache dierctory)
-  static void computeall(Lfunc *L, double umin,double Binv,long prec, bool op, FILE *fp) 
+  static Lerror_t computeall(Lfunc *L, double umin,double Binv,long prec, bool op, FILE *fp)
   {
     long i, j, k, prec2, imin, imax;
     double delta;
@@ -545,6 +557,15 @@ computeres:
     prec2 = prec + (long)(exp(2*imax*delta/L->degree)*M_PI*L->degree/M_LN2) + 100;
     arb_const_pi(u,prec2); arb_set_d(eps,Binv); arb_mul(eps,eps,u,prec2);
     k = taylor_terms(thresh,twomu,L->degree,eps,prec);
+    if(k < 0) {
+      // taylor_terms hit its certification cap: the configured window is too
+      // small for the recurrence to contract. Fail loudly before allocating
+      // anything off k (the init-time B > 4/degree preflight normally rejects
+      // such windows first, so this is a belt-and-suspenders safety net).
+      arb_clear(u); arb_clear(eps); arb_clear(thresh); arf_clear(m);
+      arb_clear(L->C); arb_clear(L->alpha);
+      return ERR_WINDOW_TOO_SMALL;
+    }
     L->max_K=k;
     L->one_over_B=Binv;
     if(verbose) printf("1/B set to %f\n",Binv);
@@ -605,6 +626,7 @@ computeres:
     arb_clear(u); arb_clear(eps);
     arb_clear(thresh); arf_clear(m);
 
+    return ERR_SUCCESS;
   }
 
   bool read_arb(arb_ptr res, FILE *infile)
@@ -845,7 +867,7 @@ computeres:
       }
     }
 
-    computeall(L, -32*M_LN2, L->one_over_B, L->gprec, op, ofile);
+    ecode |= computeall(L, -32*M_LN2, L->one_over_B, L->gprec, op, ofile);
     if(op)
       fclose(ofile);
     return ecode;

--- a/src/g.c
+++ b/src/g.c
@@ -40,6 +40,21 @@ extern "C"{
 // the body then failed to parse) is a genuinely broken file and stays fatal.
 typedef enum { GCACHE_OK, GCACHE_STALE, GCACHE_CORRUPT } gcache_status;
 
+// A mid-write failure in computeall (header flushed, body short or absent) would
+// leave a valid-header/short-body file that read_gfile later flags GCACHE_CORRUPT
+// -> fatal ERR_G_INFILE, permanently poisoning that cache name.  Before any such
+// error return, close the file and unlink the partial path so the next run simply
+// misses and recomputes.  fp is the handle computeall was writing on and cache_path
+// is the exact path it was opened on; both may be NULL (no cache being written, e.g.
+// op == false), in which case this is a no-op.  computeall nulls nothing of the
+// caller's, so the caller must not fclose again on the error path (it keys its close
+// on a clean return) -- this never double-closes.
+  static void gcache_writer_abort(FILE *fp, const char *cache_path) {
+    if(fp)
+      fclose(fp);
+    if(cache_path)
+      remove(cache_path);
+  }
 
   static void printarf(FILE *fp,const arf_t x) {
     static int init;
@@ -516,7 +531,7 @@ computeres:
 
   // compute G data into L
   // if(op) then also write the data to fp (in the cache dierctory)
-  static Lerror_t computeall(Lfunc *L, double umin,double Binv,long prec, bool op, FILE *fp)
+  static Lerror_t computeall(Lfunc *L, double umin,double Binv,long prec, bool op, FILE *fp, const char *cache_path)
   {
     long i, j, k, prec2, imin, imax;
     double delta;
@@ -570,9 +585,12 @@ computeres:
       // taylor_terms hit its certification cap: the configured window is too
       // small for the recurrence to contract. Fail loudly before allocating
       // anything off k (the init-time B > 4/degree preflight normally rejects
-      // such windows first, so this is a belt-and-suspenders safety net).
+      // such windows first, so this is a belt-and-suspenders safety net). The
+      // header has already been written (and would flush on fclose), so discard
+      // the partial file before returning so it cannot poison the cache name.
       arb_clear(u); arb_clear(eps); arb_clear(thresh); arf_clear(m);
       arb_clear(L->C); arb_clear(L->alpha);
+      gcache_writer_abort(fp, cache_path);
       return ERR_WINDOW_TOO_SMALL;
     }
     L->max_K=k;
@@ -599,16 +617,27 @@ computeres:
     L->Gs=(arb_t **)malloc(sizeof(arb_t *)*k);
     if(!L->Gs)
     {
-      fprintf(stderr,"Fatal error allocating memory in computeall. Exiting.\n");
-      exit(0);
+      // Graceful fatal return (no exit() on this branch); discard the partial
+      // cache file so it cannot poison the cache name on a later run.
+      arb_clear(u); arb_clear(eps); arb_clear(thresh); arf_clear(m);
+      arb_clear(L->C); arb_clear(L->alpha); arb_clear(L->eq59);
+      gcache_writer_abort(fp, cache_path);
+      return ERR_OOM;
     }
     for(i=0;i<k;i++)
     {
       L->Gs[i]=(arb_t *)malloc(sizeof(arb_t)*(imax-imin+1));
       if(!L->Gs[i])
       {
-        fprintf(stderr,"Fatal error allocating memory in computeall. Exiting.\n");
-        exit(0);
+        // Unwind the rows already allocated (none are arb_init'd yet), then fail
+        // gracefully and discard the partial cache file.
+        for(j=0;j<i;j++)
+          free(L->Gs[j]);
+        free(L->Gs);
+        arb_clear(u); arb_clear(eps); arb_clear(thresh); arf_clear(m);
+        arb_clear(L->C); arb_clear(L->alpha); arb_clear(L->eq59);
+        gcache_writer_abort(fp, cache_path);
+        return ERR_OOM;
       }
     }
     for(i=0;i<k;i++)
@@ -824,6 +853,9 @@ computeres:
     Lerror_t ecode=ERR_SUCCESS;
     bool op = false; // true if we are going to write a cache file
     FILE *ofile = NULL; // file to write to
+    char fname[1337]; // cache path; set when op becomes true (function scope so
+                      // computeall can unlink the partial file on a mid-write error)
+    const char *cache_path = NULL; // == fname once a writer is open, else NULL
 
     // "Default mode" means the caller left gprec at 0; we then both derive the
     // working gprec ourselves and may consult the on-disk cache.  Capture that
@@ -849,7 +881,6 @@ computeres:
       printf("g precision set to %" PRId64 " bits\n", L->gprec);
 
     if(use_cache) {
-      char fname[1337];
       char fname1[1024] = "";
       size_t off = 0;
       // Build the cache filename, bailing out if any snprintf hits an encoding
@@ -895,12 +926,18 @@ computeres:
           op = false;
         } else {
           op = true; // file open ok so we can output
+          cache_path = fname; // so computeall can unlink it on a mid-write error
         }
       }
     }
 
-    ecode |= computeall(L, -32*M_LN2, L->one_over_B, L->gprec, op, ofile);
-    if(op)
+    // computeall closes AND unlinks the cache file itself on any mid-write error
+    // (so a partial header never poisons the cache name). On a clean run it leaves
+    // the file open for us to close here. Closing only on a clean return avoids a
+    // double fclose of an already-closed handle.
+    Lerror_t gcode = computeall(L, -32*M_LN2, L->one_over_B, L->gprec, op, ofile, cache_path);
+    ecode |= gcode;
+    if(op && !fatal_error(gcode))
       fclose(ofile);
     return ecode;
   }

--- a/src/g.c
+++ b/src/g.c
@@ -845,7 +845,7 @@ computeres:
       }
     }
 
-    computeall(L, -32*M_LN2, (double)L->degree/512, L->gprec, op, ofile);
+    computeall(L, -32*M_LN2, L->one_over_B, L->gprec, op, ofile);
     if(op)
       fclose(ofile);
     return ecode;

--- a/src/g.c
+++ b/src/g.c
@@ -27,7 +27,12 @@ extern "C"{
 // EXTRA_BITS or the gprec formula needs no bump, since the stored gprec is
 // checked for sufficiency (a too-low cached gprec is rejected automatically).
 #define GCACHE_MAGIC "GCACHE"
-#define GCACHE_VERSION 1
+// Version 2 added one_over_B (the window's 1/B) to the header so a cache written
+// for one output window cannot be reused for another: the body is B-dependent
+// (low_i/hi_i/max_K and the Gs u-grid all scale with B) and read_gfile even
+// overwrites L->one_over_B from the file, so without this check a different-B
+// cache was silently reused with the wrong geometry.
+#define GCACHE_VERSION 2
 
 // Outcome of validating a cached file against the current request.  GCACHE_STALE
 // (foreign / old version / different L-function / insufficient precision) means
@@ -544,13 +549,17 @@ computeres:
 
     if(op) {
       // Self-describing header (see GCACHE_MAGIC): version, degree, the gprec
-      // this grid was computed at, and the sorted analytic mus as exact halved
-      // integers.  read_gfile reads and verifies this before the body.
+      // this grid was computed at, the sorted analytic mus as exact halved
+      // integers, and the window's one_over_B.  read_gfile reads and verifies
+      // this before the body.  one_over_B is written with %a (hex float) so it
+      // round-trips the binary64 value bit-for-bit; read_gheader compares it to
+      // the request's one_over_B with ==, so any lossy format (e.g. %.9f) would
+      // reject a freshly written cache every run.
       fprintf(fp, "%s %d %lu %ld", GCACHE_MAGIC, GCACHE_VERSION,
               (unsigned long)L->degree, prec);
       for(i = 0; i < (long)L->degree; i++)
         fprintf(fp, " %ld", twomu[i]);
-      fprintf(fp, "\n");
+      fprintf(fp, " %a\n", Binv);
       printarf(fp,m);
       fprintf(fp," 1\n");
     }
@@ -575,7 +584,11 @@ computeres:
     arb_init(L->eq59);
     arb_set(L->eq59,thresh);
     if(op) {
-      fprintf(fp,"%.9f %ld %ld\n", Binv, imin, imax);
+      // %a (hex float) so this body copy of one_over_B round-trips bit-for-bit;
+      // it must agree exactly with the header value the read path already
+      // validated, so read_gfile cannot silently change L->one_over_B to a
+      // rounded value after the header check passed.
+      fprintf(fp,"%a %ld %ld\n", Binv, imin, imax);
       arb_get_abs_ubound_arf(m,thresh,prec);
       fprintf(fp,"%ld ",k);
       printarf(fp,m);
@@ -695,10 +708,14 @@ computeres:
   // Read and validate the GCACHE header (see GCACHE_MAGIC).  Returns false --
   // so the caller recomputes (overwriting the file) rather than returning wrong
   // numbers -- when the file is foreign or from an older format (magic/version
-  // mismatch), describes a different L-function (degree or mus mismatch), or
-  // was computed at too low a precision for the current request
-  // (cached gprec < req_gprec; recall hi_i and max_K grow with gprec).  This
-  // runs before read_gfile allocates anything, so a rejected file leaks nothing.
+  // mismatch), describes a different L-function (degree or mus mismatch), was
+  // computed for a different output window (one_over_B mismatch), or was computed
+  // at too low a precision for the current request (cached gprec < req_gprec;
+  // recall hi_i and max_K grow with gprec).  This runs before read_gfile
+  // allocates anything, so a rejected file leaks nothing.  L->one_over_B holds
+  // the REQUEST's window here (set in Lfunc_init_advanced before compute_g, not
+  // yet overwritten by the body), so it is the authoritative value to validate
+  // against.
   static bool read_gheader(FILE *infile, const Lfunc *L, int64_t req_gprec)
   {
     char magic[16];
@@ -720,6 +737,17 @@ computeres:
       if(twomu != (long)round(L->mus[i] * 2.0)) // identity: exact halved mu
         return false;
     }
+    // Window: the body is B-dependent (low_i/hi_i/max_K and the Gs u-grid scale
+    // with B) and read_gfile overwrites L->one_over_B from it, so a cache written
+    // for a different window must be rejected here.  The header value was written
+    // with %a, so this %la reparse is bit-exact and the == compare against the
+    // request's one_over_B neither rejects a freshly written matching cache nor
+    // accepts a near-equal foreign window.
+    double cached_one_over_B;
+    if(fscanf(infile, "%la", &cached_one_over_B) != 1)
+      return false;
+    if(cached_one_over_B != L->one_over_B) // exact: distinct windows differ in bits
+      return false;
     if(cached_gprec < req_gprec) // sufficiency: cached grid is precise enough
       return false;
     return true;
@@ -747,7 +775,11 @@ computeres:
     arb_set_si(L->C,m);
     arb_mul_2exp_si(L->C,L->C,e);
     arb_set_si(L->alpha,alpha);
-    if(fscanf(infile,"%lf %" PRId64 " %" PRId64 "\n",&L->one_over_B,&L->low_i,&L->hi_i)!=3)
+    // %la matches the %a the body was written with, so the value reparses
+    // bit-for-bit.  read_gheader already validated this exact one_over_B against
+    // the request, so this overwrite restores the identical bits, never a rounded
+    // (or foreign-window) value.
+    if(fscanf(infile,"%la %" PRId64 " %" PRId64 "\n",&L->one_over_B,&L->low_i,&L->hi_i)!=3)
       return GCACHE_CORRUPT;
     if(fscanf(infile,"%" PRIu64 "",&L->max_K)!=1)
       return GCACHE_CORRUPT;

--- a/src/glfunc.c
+++ b/src/glfunc.c
@@ -93,8 +93,8 @@ void fprint_errors(FILE *f, Lerror_t ecode) {
     fprintf(f, "Requested output window too small for a valid error analysis.\n");
   if (ecode & ERR_ZERO_OVERFLOW)
     fprintf(f,
-            "Found more than MAX_ZEROS (%d) zeros on one side; the zero set was "
-            "truncated. Increase MAX_ZEROS or reduce the output window (max_t).\n",
+            "Found MAX_ZEROS (%d) zeros on one side; zero storage is exhausted. "
+            "Increase MAX_ZEROS or reduce the output window (max_t).\n",
             MAX_ZEROS);
   if (ecode & ERR_BAD_DEGREE)
     fprintf(f, "The degree of the L-function must be between 1 and %d\n",

--- a/src/glfunc.c
+++ b/src/glfunc.c
@@ -190,6 +190,11 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
     want_fft_NN = (uint64_t)1 << 16;            // identical to the old glfunc.c:233 value
   }
 
+  if (want_fft_NN > L->max_fft_NN) {
+    ecode[0] |= ERR_WINDOW_TOO_LARGE;
+    return (Lfunc_t)NULL;
+  }
+
   if (Lp->wprec > 0)
     L->wprec = Lp->wprec;
   else {

--- a/src/glfunc.c
+++ b/src/glfunc.c
@@ -17,17 +17,57 @@ static uint64_t next_pow2_u64(uint64_t n) {
   return p;
 }
 
-// Free everything Lfunc_init_advanced allocated before a window guard rejects, then
-// signal the error (origin's free-on-error convention; have_B selects whether L->B
-// was initialised yet). The caller receives NULL and never double-frees.
-static Lfunc_t window_reject(Lfunc *L, bool have_B, Lerror_t *ecode, Lerror_t code) {
-  if (have_B) arb_clear(L->B);
-  arb_clear(L->pi);
-  arb_clear(L->zero_error);
-  arb_clear(L->zero_prec);
-  free(L->mus);
-  free(L);
+static void init_lfunc_scalars(Lfunc *L) {
+  arb_init(L->zero_prec);
+  arb_init(L->zero_error);
+  arb_init(L->mu);
+  arb_init(L->nu);
+  arb_init(L->C);
+  arb_init(L->alpha);
+  arb_init(L->B);
+  arb_init(L->two_pi_by_B);
+  arb_init(L->pi);
+  arb_init(L->eq59);
+  arb_init(L->arb_A);
+  arb_init(L->one_over_A);
+  arb_init(L->delta);
+  arb_init(L->exp_delta);
+  arb_init(L->pre_ftwiddle_error);
+  arb_init(L->ftwiddle_error);
+#ifdef BUTHE
+  arb_init(L->buthe_Wf);
+  arb_init(L->buthe_Winf);
+  arb_init(L->buthe_Ws);
+  arb_init(L->buthe_b);
+  arb_init(L->buthe_C);
+  arb_init(L->buthe_h);
+  for(uint64_t i=0;i<(MAX_R-1)*(2*MAX_MUI_2+1);i++)
+    arb_init(L->buthe_ints[i]);
+#endif
+#ifdef TURING
+  arb_init(L->imint);
+  arb_init(L->X);
+#endif
+  arb_init(L->one_over_root_N);
+  arb_init(L->sum_ans);
+  arb_init(L->u_H);
+  arb_init(L->u_pi_by_H2);
+  arb_init(L->u_A);
+  arb_init(L->u_one_over_A);
+  arb_init(L->u_pi_A);
+  arb_init(L->upsampling_error);
+  arb_init(L->Lam_d);
+  arb_init(L->L_d);
+  acb_init(L->sign);
+  acb_init(L->sqrt_sign);
+  arf_init(L->arf_A);
+  arf_init(L->arf_one_over_A);
+}
+
+static Lfunc_t init_fail(Lfunc *L, Lerror_t *ecode, Lerror_t code) {
   *ecode |= code;
+  if(L)
+    Lfunc_clear((Lfunc_t)L);
   return (Lfunc_t)NULL;
 }
 
@@ -150,51 +190,63 @@ int double_comp(const void *a, const void *b) {
     return 0;
 }
 
+void Lparams_init(Lparams_t *Lp) {
+  if(!Lp)
+    return;
+  Lp->degree = 0;
+  Lp->conductor = 0;
+  Lp->normalisation = 0.0;
+  Lp->mus = NULL;
+  Lp->target_prec = DEFAULT_TARGET_PREC;
+  Lp->wprec = 0;
+  Lp->gprec = 0;
+  Lp->self_dual = DK;
+  Lp->rank = DK;
+  Lp->cache_dir = ".";
+  Lp->max_t = 0.0;
+  Lp->max_fft_NN = 0;
+}
+
 Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
   ecode[0] = ERR_SUCCESS;
   uint64_t i, j;
   arb_t tmp;
 
+  if (!Lp || !Lp->mus) {
+    ecode[0] |= ERR_MU_HALF;
+    return ((Lfunc_t)NULL);
+  }
   if ((Lp->degree < 2) || (Lp->degree > MAX_DEGREE)) {
     ecode[0] |= ERR_BAD_DEGREE;
     return ((Lfunc_t)NULL);
   }
 
-  Lfunc *L = (Lfunc *)malloc(sizeof(Lfunc));
+  Lfunc *L = (Lfunc *)calloc(1, sizeof(Lfunc));
   if (!L) {
     ecode[0] |= ERR_OOM;
     return (Lfunc_t)NULL;
   }
+  init_lfunc_scalars(L);
   L->degree = Lp->degree;
   L->normalisation = Lp->normalisation;
   L->conductor = Lp->conductor;
   L->mus = (double *)malloc(sizeof(double) * L->degree);
-  if (!L->mus) {
-    ecode[0] |= ERR_OOM;
-    free(L);
-    return (Lfunc_t)NULL;
-  }
+  if (!L->mus)
+    return init_fail(L, ecode, ERR_OOM);
   for (i = 0; i < L->degree; i++) {
     L->mus[i] = Lp->mus[i] + Lp->normalisation; // alg->anal
-    if (!is_half_int(L->mus[i])) {
-      ecode[0] |= ERR_MU_HALF;
-      // only L and L->mus are live here (no arb_t initialised yet)
-      free(L->mus);
-      free(L);
-      return (Lfunc_t)NULL;
-    }
+    if (!is_half_int(L->mus[i]))
+      return init_fail(L, ecode, ERR_MU_HALF);
   }
 
   // we sort the mus so we can name G cache files canonically
   qsort(L->mus, L->degree, sizeof(double), double_comp);
 
-  L->target_prec = Lp->target_prec;
-  arb_init(L->zero_prec);
+  L->target_prec = (Lp->target_prec > 0) ? Lp->target_prec : DEFAULT_TARGET_PREC;
+  L->zero_cap = MAX_ZEROS;
   arb_set_ui(L->zero_prec, 1);
   arb_mul_2exp_si(L->zero_prec, L->zero_prec, -L->target_prec - 1);
-  arb_init(L->zero_error);
   arb_add_error(L->zero_error, L->zero_prec);
-  arb_init(L->pi);
 
   // Resolve window geometry from H (max_t) before decay() reads L->max_t.
   // A returned interval that fails to contain the true value is the worst
@@ -207,7 +259,7 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
   // the default-window branch (the bare Lp->max_t > 0.0 test let NaN through,
   // since NaN > 0.0 is false). The sentinel is exactly 0.0, which is finite.
   if (!isfinite(Lp->max_t)) {
-    return window_reject(L, false, ecode, ERR_WINDOW_TOO_SMALL);
+    return init_fail(L, ecode, ERR_WINDOW_TOO_SMALL);
   }
   if (Lp->max_t > 0.0) {                       // non-default window
     L->max_t = Lp->max_t;
@@ -219,7 +271,7 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
     // >= not >: (double)UINT64_MAX rounds up to exactly 2^64, and (uint64_t)2^64 is
     // undefined behaviour, so need == 2^64 must be rejected too (not just > 2^64).
     if (!isfinite(need) || need >= (double)UINT64_MAX) {
-      return window_reject(L, false, ecode, ERR_WINDOW_TOO_LARGE);
+      return init_fail(L, ecode, ERR_WINDOW_TOO_LARGE);
     }
     want_fft_NN = next_pow2_u64((uint64_t)need);
   } else if (Lp->max_t == 0.0) {                // sentinel: default window
@@ -227,12 +279,12 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
     L->one_over_B = (double)L->degree / 512.0;  // identical to the old g.c:848 value
     want_fft_NN = (uint64_t)1 << 16;            // identical to the old glfunc.c:233 value
   } else {                                      // finite, < 0: too small
-    return window_reject(L, false, ecode, ERR_WINDOW_TOO_SMALL);
+    return init_fail(L, ecode, ERR_WINDOW_TOO_SMALL);
   }
 
   // Upper bound: the required transform must fit under the cap.
   if (want_fft_NN > L->max_fft_NN) {
-    return window_reject(L, false, ecode, ERR_WINDOW_TOO_LARGE);
+    return init_fail(L, ecode, ERR_WINDOW_TOO_LARGE);
   }
 
   // ---- Lower-bound guards (spec step 4); any failure => fatal, before compute_g ----
@@ -240,7 +292,7 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
   //     out of the buffer sized fft_NN (heap overflow). fft_N never drops below
   //     1<<11, so want_fft_NN must reach it too.
   if (want_fft_NN < ((uint64_t)1 << 11)) {
-    return window_reject(L, false, ecode, ERR_WINDOW_TOO_SMALL);
+    return init_fail(L, ecode, ERR_WINDOW_TOO_SMALL);
   }
 
   // Derive B now (needed by the beta preflight below and reused later for L->B).
@@ -248,7 +300,6 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
   // entry is mu_max.
   double B_eff = 1.0 / L->one_over_B;
   double mu_max = L->mus[L->degree - 1];
-  arb_init(L->B);
   {
     arb_t tmpB;
     arb_init(tmpB);
@@ -260,7 +311,7 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
   // (3) taylor_terms termination needs B > 4/degree (necessary asymptotic floor;
   //     the hard cap in g.c is the belt-and-suspenders backstop).
   if (!(B_eff > 4.0 / (double)L->degree)) {
-    return window_reject(L, true, ecode, ERR_WINDOW_TOO_SMALL);
+    return init_fail(L, ecode, ERR_WINDOW_TOO_SMALL);
   }
 
   // (2) ftwiddle truncation: need B > 0.5 + mu_max AND the resulting decay rate
@@ -269,7 +320,7 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
   //     init_ftwiddle_error) rather than inspecting the damage afterwards.
   arb_const_pi(L->pi, 100); // beta preflight (and decay) need pi
   if (!(B_eff > 0.5 + mu_max) || !ftwiddle_beta_positive(L, 100)) {
-    return window_reject(L, true, ecode, ERR_WINDOW_TOO_SMALL);
+    return init_fail(L, ecode, ERR_WINDOW_TOO_SMALL);
   }
 
   if (Lp->wprec > 0)
@@ -290,10 +341,8 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
   // See Lemma 2 of M_error1.pdf, Lemma 5 of g.pdf
   // r is always >=2
   L->nus = (arb_t *)malloc(sizeof(arb_t) * L->degree);
-  if (!L->nus) {
-    ecode[0] |= ERR_OOM;
-    return (Lfunc_t)NULL;
-  }
+  if (!L->nus)
+    return init_fail(L, ecode, ERR_OOM);
 
   for (j = 0; j < 2; j++) {
     arb_init(L->nus[j]);
@@ -305,7 +354,6 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
   }
 
   // See Lemma 2/5 again
-  arb_init(L->nu);
   arb_set(L->nu, L->nus[0]);
   for (j = 1; j < L->degree; j++)
     arb_add(L->nu, L->nu, L->nus[j], L->target_prec);
@@ -316,7 +364,6 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
   arb_add(L->nu, L->nu, tmp, L->target_prec);
 
   // mu=-1/2+1/r(1+sum mu_j) See Lemma 5.2 of Artin
-  arb_init(L->mu);
   arb_set_d(L->mu, -0.5);
   double smu = 1.0;
   for (i = 0; i < L->degree; i++)
@@ -326,8 +373,10 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
   arb_add(L->mu, L->mu, tmp, L->target_prec);
 
   ecode[0] |= compute_g(L);
-  if (fatal_error(ecode[0]))
-    return (Lfunc_t)NULL;
+  if (fatal_error(ecode[0])) {
+    arb_clear(tmp);
+    return init_fail(L, ecode, ERR_SUCCESS);
+  }
   if (verbose) {
     printf("eq 5-9 error = ");
     arb_printd(L->eq59, 20);
@@ -339,7 +388,6 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
   arb_set_d(tmp, L->one_over_B);
   arb_inv(L->B, tmp, L->wprec);
 
-  arb_init(L->two_pi_by_B);
   arb_set_d(L->two_pi_by_B, L->one_over_B * 2.0);
   arb_mul(L->two_pi_by_B, L->two_pi_by_B, L->pi, L->wprec);
 
@@ -355,44 +403,37 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
     L->fft_N = next_pow2_u64(support > floor_n ? support : floor_n);
   }
   L->fft_NN = want_fft_NN; // final output length (= 1<<16 for the default window)
-  // Defensive backstop only: this branch is UNREACHABLE for any accepted input.
+  // Defensive backstop only: this branch is unreachable for any accepted input.
   // want_fft_NN >= 1<<11 (the sub-floor guard above rejects anything smaller), and
   // fft_N = next_pow2(max(1<<11, support)). The conductor-dependent part of support is
   // hi_i - calc_m(1) ~ B*ln(N)/(4*pi); with fft_NN ~ 1024*degree*max_t = 128*degree*B,
   // fft_N exceeds fft_NN only once ln(N) > ~512*pi*degree (thousands; ~3217 at degree 2),
   // far beyond any uint64_t conductor (ln N <= ~44). So fft_N <= fft_NN
-  // always. L is only PARTIALLY constructed here (compute_g ran, but the w/ww/res/
-  // zeros/upsampling allocations below have not), so Lfunc_clear would dereference
-  // not-yet-allocated pointers; we keep the graceful fatal return instead. Freeing the
-  // partial Lfunc for such early init failures is tracked by bead lfunctions-1eb.
-  if (L->fft_N > L->fft_NN) { ecode[0] |= ERR_WINDOW_TOO_LARGE; return (Lfunc_t)NULL; }
+  // always. Keep the backstop anyway in case the sizing assumptions change.
+  if (L->fft_N > L->fft_NN) {
+    arb_clear(tmp);
+    return init_fail(L, ecode, ERR_WINDOW_TOO_LARGE);
+  }
 
   L->A = L->fft_NN * L->one_over_B;
-  arb_init(L->arb_A);
   arb_set_d(L->arb_A, L->A);
-  arf_init(L->arf_A);
   arf_set_d(L->arf_A, L->A);
 
-  arb_init(L->one_over_A);
   arb_inv(L->one_over_A, L->arb_A, L->wprec);
-  arf_init(L->arf_one_over_A);
   arf_ui_div(L->arf_one_over_A, 1, L->arf_A, L->wprec, ARF_RND_NEAR);
 
   L->G = (acb_t *)malloc(sizeof(acb_t) * L->fft_N);
   if (!L->G) {
     arb_clear(tmp);
-    ecode[0] |= ERR_OOM;
-    return (Lfunc_t)NULL;
+    return init_fail(L, ecode, ERR_OOM);
   }
   for (i = 0; i < L->fft_N; i++)
     acb_init(L->G[i]);
 
   L->eta = 0.0;
-  arb_init(L->delta);
   arb_mul_2exp_si(L->delta, L->pi, -1); // pi/2
   arb_set_d(tmp, 1.0 - L->eta);
   arb_mul(L->delta, L->delta, tmp, L->wprec); // (1-eta)pi/2
-  arb_init(L->exp_delta);
   arb_neg(tmp, L->delta);
   arb_exp(L->exp_delta, tmp, L->wprec);
 
@@ -400,8 +441,7 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
       (acb_t *)malloc(sizeof(acb_t) * L->fft_N / 2); // twiddles for little FFT
   if (!L->w) {
     arb_clear(tmp);
-    ecode[0] |= ERR_OOM;
-    return (Lfunc_t)NULL;
+    return init_fail(L, ecode, ERR_OOM);
   }
 
   for (i = 0; i < L->fft_N / 2; i++)
@@ -412,8 +452,7 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
       (acb_t *)malloc(sizeof(acb_t) * L->fft_NN / 2); // twiddles for big FFT
   if (!L->ww) {
     arb_clear(tmp);
-    ecode[0] |= ERR_OOM;
-    return (Lfunc_t)NULL;
+    return init_fail(L, ecode, ERR_OOM);
   }
   for (i = 0; i < L->fft_NN / 2; i++)
     acb_init(L->ww[i]);
@@ -423,9 +462,12 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
   L->zeros[0] = (arb_t *)malloc(sizeof(arb_t) * MAX_ZEROS);
   L->zeros[1] = (arb_t *)malloc(sizeof(arb_t) * MAX_ZEROS);
   if ((!L->zeros[0]) || (!L->zeros[1])) {
+    free(L->zeros[0]);
+    free(L->zeros[1]);
+    L->zeros[0] = NULL;
+    L->zeros[1] = NULL;
     arb_clear(tmp);
-    ecode[0] |= ERR_OOM;
-    return (Lfunc_t)NULL;
+    return init_fail(L, ecode, ERR_OOM);
   }
   for (i = 0; i < MAX_ZEROS; i++) {
     arb_init(L->zeros[0][i]);
@@ -435,15 +477,13 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
   L->kres = (acb_t *)malloc(sizeof(acb_t) * L->fft_N);
   if (!L->kres) {
     arb_clear(tmp);
-    ecode[0] |= ERR_OOM;
-    return (Lfunc_t)NULL;
+    return init_fail(L, ecode, ERR_OOM);
   }
 
-  L->skm = (acb_t **)malloc(sizeof(acb_t *) * L->max_K);
+  L->skm = (acb_t **)calloc(L->max_K, sizeof(acb_t *));
   if (!L->skm) {
     arb_clear(tmp);
-    ecode[0] |= ERR_OOM;
-    return (Lfunc_t)NULL;
+    return init_fail(L, ecode, ERR_OOM);
   }
 
   uint64_t k, n;
@@ -451,8 +491,7 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
     L->skm[k] = (acb_t *)malloc(sizeof(acb_t) * L->fft_N);
     if (!L->skm[k]) {
       arb_clear(tmp);
-      ecode[0] |= ERR_OOM;
-      return (Lfunc_t)NULL;
+      return init_fail(L, ecode, ERR_OOM);
     }
 
     for (n = 0; n < L->fft_N; n++)
@@ -462,8 +501,7 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
   L->res = (acb_t *)malloc(sizeof(acb_t) * L->fft_NN);
   if (!L->res) {
     arb_clear(tmp);
-    ecode[0] |= ERR_OOM;
-    return (Lfunc_t)NULL;
+    return init_fail(L, ecode, ERR_OOM);
   }
 
   for (n = 0; n < L->fft_N; n++)
@@ -471,20 +509,13 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
   for (n = 0; n < L->fft_NN; n++)
     acb_init(L->res[n]);
 
-  arb_init(L->pre_ftwiddle_error);
-  arb_init(L->ftwiddle_error);
   init_ftwiddle_error(L, L->wprec);
 
-  arb_init(L->one_over_root_N);
-  arb_init(L->sum_ans);
-  acb_init(L->sign);
-  acb_init(L->sqrt_sign);
   L->allocated_M = 8192;
   L->ans = (acb_t *)malloc(sizeof(acb_t) * L->allocated_M);
   if (!L->ans) {
     arb_clear(tmp);
-    ecode[0] |= ERR_OOM;
-    return (Lfunc_t)NULL;
+    return init_fail(L, ecode, ERR_OOM);
   }
   for (size_t i = 0; i < L->allocated_M; ++i)
     acb_init(L->ans[i]);
@@ -494,18 +525,11 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
 #ifdef BUTHE
   init_buthe(L, L->wprec); // setup stuff for Buthe zero check
 #endif
-#ifdef TURING
-  arb_init(L->imint);
-  arb_init(L->X);
-#endif
   L->nmax_called = false; // noone has called nmax yet
-
-  arb_init(L->Lam_d);
-  arb_init(L->L_d);
 
   ecode[0] |= init_upsampling(L);
   if (fatal_error(ecode[0]))
-    return (Lfunc_t)NULL;
+    return init_fail(L, ecode, ERR_SUCCESS);
 
   // (4) Upsample period-fit (spec step 4, last bullet): the output + Turing +
   // upsampling-guard samples must fit in one output period of fft_NN. This is
@@ -515,11 +539,7 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
   // replicating the search) keeps the two from diverging. Runs before zero-
   // finding (which happens in Lfunc_compute), so no degraded result is returned.
   if (L->u_no_values > L->fft_NN) {
-    // L is fully constructed here (init_upsampling succeeded, every u_* field and
-    // array is set), so the authoritative teardown applies before we hand back NULL.
-    Lfunc_clear((Lfunc_t)L);
-    ecode[0] |= ERR_WINDOW_TOO_SMALL;
-    return (Lfunc_t)NULL;
+    return init_fail(L, ecode, ERR_WINDOW_TOO_SMALL);
   }
 
   return (Lfunc_t)L;
@@ -528,36 +548,27 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
 Lfunc_t Lfunc_init(uint64_t degree, uint64_t conductor, double normalisation,
                    const double *mus, Lerror_t *ecode) {
   Lparams_t Lp;
+  Lparams_init(&Lp);
   Lp.degree = degree;
   Lp.conductor = conductor;
   Lp.normalisation = normalisation;
-  Lp.mus = (double *)malloc(sizeof(double) * degree);
-  if (!Lp.mus) {
-    ecode[0] |= ERR_OOM;
-    return (Lfunc_t)NULL;
-  }
-  for (size_t i = 0; i < degree; ++i)
-    Lp.mus[i] = mus[i];
-  Lp.target_prec = DEFAULT_TARGET_PREC;
-  Lp.rank = DK;
-  Lp.self_dual = DK;
-  Lp.cache_dir = ".";
-  Lp.gprec = 0; // We will try to do something sensible
-  Lp.wprec = 0; // ditto
-  Lp.max_t = 0.0;     // sentinel => 64/degree
-  Lp.max_fft_NN = 0;  // sentinel => 1<<16
-
-  // Lfunc_init_advanced copies Lp.mus into L->mus, so this scratch array is ours
-  // to free; otherwise it leaks (Lp is a stack local that goes out of scope).
-  Lfunc_t L = Lfunc_init_advanced(&Lp, ecode);
-  free(Lp.mus);
-  return L;
+  Lp.mus = (double *)mus; // Lfunc_init_advanced copies this array.
+  return Lfunc_init_advanced(&Lp, ecode);
 }
 
 int64_t Lfunc_wprec(Lfunc_t Lf) {
   Lfunc *L;
   L = (Lfunc *)Lf;
   return L->wprec;
+}
+
+void Lfunc_set_zero_cap_for_tests(Lfunc_t Lf, uint64_t cap) {
+  Lfunc *L = (Lfunc *)Lf;
+  if(!L)
+    return;
+  if(cap == 0 || cap > MAX_ZEROS)
+    cap = MAX_ZEROS;
+  L->zero_cap = cap;
 }
 
 #ifdef __cplusplus

--- a/src/glfunc.c
+++ b/src/glfunc.c
@@ -178,20 +178,85 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
   arb_init(L->pi);
 
   // Resolve window geometry from H (max_t) before decay() reads L->max_t.
+  // A returned interval that fails to contain the true value is the worst
+  // outcome, so every rejected/degenerate window must fail with a fatal
+  // Lerror_t here, never silently fall through to a usable-looking result.
   L->max_fft_NN = (Lp->max_fft_NN > 0) ? Lp->max_fft_NN : ((uint64_t)1 << 16);
   uint64_t want_fft_NN;
+  // A supplied (non-sentinel) max_t must be finite and strictly positive.
+  // A non-finite (NaN/Inf) value is a caller error: it must NOT silently take
+  // the default-window branch (the bare Lp->max_t > 0.0 test let NaN through,
+  // since NaN > 0.0 is false). The sentinel is exactly 0.0, which is finite.
+  if (!isfinite(Lp->max_t)) {
+    ecode[0] |= ERR_WINDOW_TOO_SMALL;
+    return (Lfunc_t)NULL;
+  }
   if (Lp->max_t > 0.0) {                       // non-default window
     L->max_t = Lp->max_t;
     L->one_over_B = 1.0 / ((double)OUTPUT_RATIO * L->max_t);
-    want_fft_NN = next_pow2_u64((uint64_t)ceil(1024.0 * (double)L->degree * L->max_t));
-  } else {                                      // default: reproduce historical constants exactly
+    // Compute the required sample count in binary64 first and reject an
+    // overflow before the (uint64_t) cast, so an absurd H can never wrap to a
+    // small or zero count.
+    double need = ceil(1024.0 * (double)L->degree * L->max_t);
+    if (!isfinite(need) || need > (double)UINT64_MAX) {
+      ecode[0] |= ERR_WINDOW_TOO_LARGE;
+      return (Lfunc_t)NULL;
+    }
+    want_fft_NN = next_pow2_u64((uint64_t)need);
+  } else if (Lp->max_t == 0.0) {                // sentinel: default window
     L->max_t = 64.0 / (double)L->degree;
     L->one_over_B = (double)L->degree / 512.0;  // identical to the old g.c:848 value
     want_fft_NN = (uint64_t)1 << 16;            // identical to the old glfunc.c:233 value
+  } else {                                      // finite, < 0: too small
+    ecode[0] |= ERR_WINDOW_TOO_SMALL;
+    return (Lfunc_t)NULL;
   }
 
+  // Upper bound: the required transform must fit under the cap.
   if (want_fft_NN > L->max_fft_NN) {
     ecode[0] |= ERR_WINDOW_TOO_LARGE;
+    return (Lfunc_t)NULL;
+  }
+
+  // ---- Lower-bound guards (spec step 4); any failure => fatal, before compute_g ----
+  // (1) fft_NN floor: below 1<<11 the error/convolution fill writes res[fft_N-1]
+  //     out of the buffer sized fft_NN (heap overflow). fft_N never drops below
+  //     1<<11, so want_fft_NN must reach it too.
+  if (want_fft_NN < ((uint64_t)1 << 11)) {
+    ecode[0] |= ERR_WINDOW_TOO_SMALL;
+    return (Lfunc_t)NULL;
+  }
+
+  // Derive B now (needed by the beta preflight below and reused later for L->B).
+  // B = 1/one_over_B = OUTPUT_RATIO * H. L->mus is sorted ascending so the last
+  // entry is mu_max.
+  double B_eff = 1.0 / L->one_over_B;
+  double mu_max = L->mus[L->degree - 1];
+  arb_init(L->B);
+  {
+    arb_t tmpB;
+    arb_init(tmpB);
+    arb_set_d(tmpB, L->one_over_B);
+    arb_inv(L->B, tmpB, 100); // refined to wprec later (after wprec is known)
+    arb_clear(tmpB);
+  }
+
+  // (3) taylor_terms termination needs B > 4/degree (necessary asymptotic floor;
+  //     the hard cap in g.c is the belt-and-suspenders backstop).
+  if (!(B_eff > 4.0 / (double)L->degree)) {
+    arb_clear(L->B);
+    ecode[0] |= ERR_WINDOW_TOO_SMALL;
+    return (Lfunc_t)NULL;
+  }
+
+  // (2) ftwiddle truncation: need B > 0.5 + mu_max AND the resulting decay rate
+  //     beta strictly positive, else pre_ftwiddle_error is silently garbage.
+  //     Use the shared side-effect-free preflight (same formula as
+  //     init_ftwiddle_error) rather than inspecting the damage afterwards.
+  arb_const_pi(L->pi, 100); // beta preflight (and decay) need pi
+  if (!(B_eff > 0.5 + mu_max) || !ftwiddle_beta_positive(L, 100)) {
+    arb_clear(L->B);
+    ecode[0] |= ERR_WINDOW_TOO_SMALL;
     return (Lfunc_t)NULL;
   }
 
@@ -257,7 +322,8 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
     printf("\n");
   }
 
-  arb_init(L->B);
+  // L->B was already init'd and set at 100 bits for the window preflight above;
+  // refine it to full working precision now that wprec is known.
   arb_set_d(tmp, L->one_over_B);
   arb_inv(L->B, tmp, L->wprec);
 
@@ -418,6 +484,20 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
   arb_init(L->L_d);
 
   ecode[0] |= init_upsampling(L);
+  if (fatal_error(ecode[0]))
+    return (Lfunc_t)NULL;
+
+  // (4) Upsample period-fit (spec step 4, last bullet): the output + Turing +
+  // upsampling-guard samples must fit in one output period of fft_NN. This is
+  // exactly L->u_no_values <= fft_NN, where init_upsampling has just set
+  // u_no_values = fft_NN/OUTPUT_RATIO + fft_NN/TURING_RATIO + 4*u_N*u_stride + 1
+  // using the same parameter search as the runtime; reading it here (rather than
+  // replicating the search) keeps the two from diverging. Runs before zero-
+  // finding (which happens in Lfunc_compute), so no degraded result is returned.
+  if (L->u_no_values > L->fft_NN) {
+    ecode[0] |= ERR_WINDOW_TOO_SMALL;
+    return (Lfunc_t)NULL;
+  }
 
   return (Lfunc_t)L;
 }

--- a/src/glfunc.c
+++ b/src/glfunc.c
@@ -91,6 +91,11 @@ void fprint_errors(FILE *f, Lerror_t ecode) {
     fprintf(f, "Requested output window too large for max_fft_NN (raise max_fft_NN).\n");
   if (ecode & ERR_WINDOW_TOO_SMALL)
     fprintf(f, "Requested output window too small for a valid error analysis.\n");
+  if (ecode & ERR_ZERO_OVERFLOW)
+    fprintf(f,
+            "Found more than MAX_ZEROS (%d) zeros on one side; the zero set was "
+            "truncated. Increase MAX_ZEROS or reduce the output window (max_t).\n",
+            MAX_ZEROS);
   if (ecode & ERR_BAD_DEGREE)
     fprintf(f, "The degree of the L-function must be between 1 and %d\n",
             MAX_DEGREE + 1);

--- a/src/glfunc.c
+++ b/src/glfunc.c
@@ -337,19 +337,27 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
   arb_mul(L->two_pi_by_B, L->two_pi_by_B, L->pi, L->wprec);
 
   // fft_N (short Euler-convolution length) must exceed the linear-convolution support
-  // of the G grid [low_i,hi_i] and the coefficient buckets (down to calc_m(M0)), else the
-  // cyclic load n%fft_N (compute.c) silently aliases. M0/sqrt(N) >= 1/100 makes
-  // calc_m(M0) >= floor(log(0.01)/(2*pi/B)) conductor-independent. max(1<<11,...) keeps
-  // every default window bit-for-bit (support <= ~1350 < 2048).
+  // of the G grid [low_i,hi_i] and the coefficient buckets, else the cyclic load
+  // n%fft_N (compute.c) silently aliases. The lowest bucket is for n=1 at
+  // calc_m(1) = floor(log(1/sqrt(N))/(2*pi/B)), which is conductor-DEPENDENT (it
+  // sinks as N grows); conv_support() uses that floor (see glfunc_internals.h).
+  // max(1<<11,...) keeps every default window bit-for-bit (support <= ~1350 < 2048).
   {
     uint64_t support = conv_support(L); // G grid + coeff buckets (see glfunc_internals.h)
     uint64_t floor_n = (uint64_t)1 << 11;
     L->fft_N = next_pow2_u64(support > floor_n ? support : floor_n);
   }
   L->fft_NN = want_fft_NN; // final output length (= 1<<16 for the default window)
-  // fft_N (>= 1<<11) can exceed fft_NN only for a sub-floor (tiny) window whose fft_NN fell
-  // below the 1<<11 floor; those are rejected by the ERR_WINDOW_TOO_SMALL guard (bead
-  // 31c.4). This stays as a defensive backstop.
+  // Defensive backstop only: this branch is UNREACHABLE for any accepted input.
+  // want_fft_NN >= 1<<11 (the sub-floor guard above rejects anything smaller), and
+  // fft_N = next_pow2(max(1<<11, support)). support ~ (hi_i-low_i) + (hi_i-calc_m(1))
+  // grows like B*(1+log N) = 8*max_t*(1+log N), while fft_NN ~ 1024*degree*max_t; for
+  // fft_N to exceed fft_NN we would need 1+log N > ~128*degree, i.e. log N > 255 at
+  // degree 2, far beyond any uint64_t conductor (log N <= ~44). So fft_N <= fft_NN
+  // always. L is only PARTIALLY constructed here (compute_g ran, but the w/ww/res/
+  // zeros/upsampling allocations below have not), so Lfunc_clear would dereference
+  // not-yet-allocated pointers; we keep the graceful fatal return instead. Freeing the
+  // partial Lfunc for such early init failures is tracked by bead lfunctions-1eb.
   if (L->fft_N > L->fft_NN) { ecode[0] |= ERR_WINDOW_TOO_LARGE; return (Lfunc_t)NULL; }
 
   L->A = L->fft_NN * L->one_over_B;
@@ -500,6 +508,9 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
   // replicating the search) keeps the two from diverging. Runs before zero-
   // finding (which happens in Lfunc_compute), so no degraded result is returned.
   if (L->u_no_values > L->fft_NN) {
+    // L is fully constructed here (init_upsampling succeeded, every u_* field and
+    // array is set), so the authoritative teardown applies before we hand back NULL.
+    Lfunc_clear((Lfunc_t)L);
     ecode[0] |= ERR_WINDOW_TOO_SMALL;
     return (Lfunc_t)NULL;
   }

--- a/src/glfunc.c
+++ b/src/glfunc.c
@@ -64,6 +64,10 @@ void fprint_errors(FILE *f, Lerror_t ecode) {
     fprintf(f,
             "G data does not extend low enough for this conductor (the cached "
             "or computed grid floor is too high).\n");
+  if (ecode & ERR_WINDOW_TOO_LARGE)
+    fprintf(f, "Requested output window too large for max_fft_NN (raise max_fft_NN).\n");
+  if (ecode & ERR_WINDOW_TOO_SMALL)
+    fprintf(f, "Requested output window too small for a valid error analysis.\n");
   if (ecode & ERR_BAD_DEGREE)
     fprintf(f, "The degree of the L-function must be between 1 and %d\n",
             MAX_DEGREE + 1);
@@ -177,6 +181,8 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
   L->self_dual = Lp->self_dual;
   L->rank = Lp->rank;
   L->cache_dir = Lp->cache_dir;
+  L->max_t = (Lp->max_t > 0.0) ? Lp->max_t : 64.0 / (double)L->degree;
+  L->max_fft_NN = (Lp->max_fft_NN > 0) ? Lp->max_fft_NN : ((uint64_t)1 << 16);
 
   // See Lemma 2 of M_error1.pdf, Lemma 5 of g.pdf
   // r is always >=2
@@ -396,6 +402,8 @@ Lfunc_t Lfunc_init(uint64_t degree, uint64_t conductor, double normalisation,
   Lp.cache_dir = ".";
   Lp.gprec = 0; // We will try to do something sensible
   Lp.wprec = 0; // ditto
+  Lp.max_t = 0.0;     // sentinel => 64/degree
+  Lp.max_fft_NN = 0;  // sentinel => 1<<16
 
   // Lfunc_init_advanced copies Lp.mus into L->mus, so this scratch array is ours
   // to free; otherwise it leaks (Lp is a stack local that goes out of scope).

--- a/src/glfunc.c
+++ b/src/glfunc.c
@@ -8,6 +8,15 @@
 extern "C" {
 #endif
 
+static uint64_t next_pow2_u64(uint64_t n) {
+  uint64_t p = 1;
+  while (p < n) {
+    if (p > (UINT64_MAX >> 1)) return p; // never overflow to 0 / loop forever on absurd n
+    p <<= 1;
+  }
+  return p;
+}
+
 bool fatal_error(Lerror_t ecode) { return ecode & 0xFFFFFFFF; }
 
 void fprint_errors(FILE *f, Lerror_t ecode) {
@@ -85,7 +94,7 @@ uint64_t decay(Lfunc *L) {
   acb_init(s);
   arb_set_d(acb_realref(s), 0.5);
   abs_gamma(tmp1, s, L, 100);
-  arb_set_d(acb_imagref(s), 64.0 / (double)L->degree);
+  arb_set_d(acb_imagref(s), L->max_t);
   abs_gamma(tmp2, s, L, 100);
   arb_div(tmp3, tmp1, tmp2, 100);
   if (verbose) {
@@ -167,11 +176,25 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
   arb_init(L->zero_error);
   arb_add_error(L->zero_error, L->zero_prec);
   arb_init(L->pi);
+
+  // Resolve window geometry from H (max_t) before decay() reads L->max_t.
+  L->max_fft_NN = (Lp->max_fft_NN > 0) ? Lp->max_fft_NN : ((uint64_t)1 << 16);
+  uint64_t want_fft_NN;
+  if (Lp->max_t > 0.0) {                       // non-default window
+    L->max_t = Lp->max_t;
+    L->one_over_B = 1.0 / ((double)OUTPUT_RATIO * L->max_t);
+    want_fft_NN = next_pow2_u64((uint64_t)ceil(1024.0 * (double)L->degree * L->max_t));
+  } else {                                      // default: reproduce historical constants exactly
+    L->max_t = 64.0 / (double)L->degree;
+    L->one_over_B = (double)L->degree / 512.0;  // identical to the old g.c:848 value
+    want_fft_NN = (uint64_t)1 << 16;            // identical to the old glfunc.c:233 value
+  }
+
   if (Lp->wprec > 0)
     L->wprec = Lp->wprec;
   else {
     arb_const_pi(L->pi, 100); // for now, needed by decay()
-    // allow enough bits so we will get target_prec at height 1/2+i*64/degree
+    // allow enough bits so we will get target_prec at height 1/2+i*max_t
     L->wprec = L->target_prec + decay(L) + EXTRA_BITS;
     if (verbose)
       printf("working precision set to %" PRId64 "\n", L->wprec);
@@ -181,8 +204,6 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
   L->self_dual = Lp->self_dual;
   L->rank = Lp->rank;
   L->cache_dir = Lp->cache_dir;
-  L->max_t = (Lp->max_t > 0.0) ? Lp->max_t : 64.0 / (double)L->degree;
-  L->max_fft_NN = (Lp->max_fft_NN > 0) ? Lp->max_fft_NN : ((uint64_t)1 << 16);
 
   // See Lemma 2 of M_error1.pdf, Lemma 5 of g.pdf
   // r is always >=2
@@ -240,7 +261,7 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
   arb_mul(L->two_pi_by_B, L->two_pi_by_B, L->pi, L->wprec);
 
   L->fft_N = 1 << 11;  // length of DTF for convolutions
-  L->fft_NN = 1 << 16; // final output length
+  L->fft_NN = want_fft_NN; // final output length (= 1<<16 for the default window)
 
   L->A = L->fft_NN * L->one_over_B;
   arb_init(L->arb_A);

--- a/src/glfunc.c
+++ b/src/glfunc.c
@@ -271,15 +271,14 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
   // calc_m(M0) >= floor(log(0.01)/(2*pi/B)) conductor-independent. max(1<<11,...) keeps
   // every default window bit-for-bit (support <= ~1350 < 2048).
   {
-    double two_pi_by_B = L->one_over_B * 2.0 * M_PI;
-    int64_t cm0_min = (int64_t)floor(log(0.01) / two_pi_by_B);
-    uint64_t S_G = (uint64_t)(L->hi_i - L->low_i + 1);
-    uint64_t S_c = (uint64_t)(L->hi_i - cm0_min + 1);
-    uint64_t support = S_G + S_c;
+    uint64_t support = conv_support(L); // G grid + coeff buckets (see glfunc_internals.h)
     uint64_t floor_n = (uint64_t)1 << 11;
     L->fft_N = next_pow2_u64(support > floor_n ? support : floor_n);
   }
   L->fft_NN = want_fft_NN; // final output length (= 1<<16 for the default window)
+  // fft_N (>= 1<<11) can exceed fft_NN only for a sub-floor (tiny) window whose fft_NN fell
+  // below the 1<<11 floor; those are rejected by the ERR_WINDOW_TOO_SMALL guard (bead
+  // 31c.4). This stays as a defensive backstop.
   if (L->fft_N > L->fft_NN) { ecode[0] |= ERR_WINDOW_TOO_LARGE; return (Lfunc_t)NULL; }
 
   L->A = L->fft_NN * L->one_over_B;

--- a/src/glfunc.c
+++ b/src/glfunc.c
@@ -17,6 +17,20 @@ static uint64_t next_pow2_u64(uint64_t n) {
   return p;
 }
 
+// Free everything Lfunc_init_advanced allocated before a window guard rejects, then
+// signal the error (origin's free-on-error convention; have_B selects whether L->B
+// was initialised yet). The caller receives NULL and never double-frees.
+static Lfunc_t window_reject(Lfunc *L, bool have_B, Lerror_t *ecode, Lerror_t code) {
+  if (have_B) arb_clear(L->B);
+  arb_clear(L->pi);
+  arb_clear(L->zero_error);
+  arb_clear(L->zero_prec);
+  free(L->mus);
+  free(L);
+  *ecode |= code;
+  return (Lfunc_t)NULL;
+}
+
 bool fatal_error(Lerror_t ecode) { return ecode & 0xFFFFFFFF; }
 
 void fprint_errors(FILE *f, Lerror_t ecode) {
@@ -188,8 +202,7 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
   // the default-window branch (the bare Lp->max_t > 0.0 test let NaN through,
   // since NaN > 0.0 is false). The sentinel is exactly 0.0, which is finite.
   if (!isfinite(Lp->max_t)) {
-    ecode[0] |= ERR_WINDOW_TOO_SMALL;
-    return (Lfunc_t)NULL;
+    return window_reject(L, false, ecode, ERR_WINDOW_TOO_SMALL);
   }
   if (Lp->max_t > 0.0) {                       // non-default window
     L->max_t = Lp->max_t;
@@ -199,8 +212,7 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
     // small or zero count.
     double need = ceil(1024.0 * (double)L->degree * L->max_t);
     if (!isfinite(need) || need > (double)UINT64_MAX) {
-      ecode[0] |= ERR_WINDOW_TOO_LARGE;
-      return (Lfunc_t)NULL;
+      return window_reject(L, false, ecode, ERR_WINDOW_TOO_LARGE);
     }
     want_fft_NN = next_pow2_u64((uint64_t)need);
   } else if (Lp->max_t == 0.0) {                // sentinel: default window
@@ -208,14 +220,12 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
     L->one_over_B = (double)L->degree / 512.0;  // identical to the old g.c:848 value
     want_fft_NN = (uint64_t)1 << 16;            // identical to the old glfunc.c:233 value
   } else {                                      // finite, < 0: too small
-    ecode[0] |= ERR_WINDOW_TOO_SMALL;
-    return (Lfunc_t)NULL;
+    return window_reject(L, false, ecode, ERR_WINDOW_TOO_SMALL);
   }
 
   // Upper bound: the required transform must fit under the cap.
   if (want_fft_NN > L->max_fft_NN) {
-    ecode[0] |= ERR_WINDOW_TOO_LARGE;
-    return (Lfunc_t)NULL;
+    return window_reject(L, false, ecode, ERR_WINDOW_TOO_LARGE);
   }
 
   // ---- Lower-bound guards (spec step 4); any failure => fatal, before compute_g ----
@@ -223,8 +233,7 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
   //     out of the buffer sized fft_NN (heap overflow). fft_N never drops below
   //     1<<11, so want_fft_NN must reach it too.
   if (want_fft_NN < ((uint64_t)1 << 11)) {
-    ecode[0] |= ERR_WINDOW_TOO_SMALL;
-    return (Lfunc_t)NULL;
+    return window_reject(L, false, ecode, ERR_WINDOW_TOO_SMALL);
   }
 
   // Derive B now (needed by the beta preflight below and reused later for L->B).
@@ -244,9 +253,7 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
   // (3) taylor_terms termination needs B > 4/degree (necessary asymptotic floor;
   //     the hard cap in g.c is the belt-and-suspenders backstop).
   if (!(B_eff > 4.0 / (double)L->degree)) {
-    arb_clear(L->B);
-    ecode[0] |= ERR_WINDOW_TOO_SMALL;
-    return (Lfunc_t)NULL;
+    return window_reject(L, true, ecode, ERR_WINDOW_TOO_SMALL);
   }
 
   // (2) ftwiddle truncation: need B > 0.5 + mu_max AND the resulting decay rate
@@ -255,9 +262,7 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
   //     init_ftwiddle_error) rather than inspecting the damage afterwards.
   arb_const_pi(L->pi, 100); // beta preflight (and decay) need pi
   if (!(B_eff > 0.5 + mu_max) || !ftwiddle_beta_positive(L, 100)) {
-    arb_clear(L->B);
-    ecode[0] |= ERR_WINDOW_TOO_SMALL;
-    return (Lfunc_t)NULL;
+    return window_reject(L, true, ecode, ERR_WINDOW_TOO_SMALL);
   }
 
   if (Lp->wprec > 0)

--- a/src/glfunc.c
+++ b/src/glfunc.c
@@ -265,8 +265,22 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
   arb_set_d(L->two_pi_by_B, L->one_over_B * 2.0);
   arb_mul(L->two_pi_by_B, L->two_pi_by_B, L->pi, L->wprec);
 
-  L->fft_N = 1 << 11;  // length of DTF for convolutions
+  // fft_N (short Euler-convolution length) must exceed the linear-convolution support
+  // of the G grid [low_i,hi_i] and the coefficient buckets (down to calc_m(M0)), else the
+  // cyclic load n%fft_N (compute.c) silently aliases. M0/sqrt(N) >= 1/100 makes
+  // calc_m(M0) >= floor(log(0.01)/(2*pi/B)) conductor-independent. max(1<<11,...) keeps
+  // every default window bit-for-bit (support <= ~1350 < 2048).
+  {
+    double two_pi_by_B = L->one_over_B * 2.0 * M_PI;
+    int64_t cm0_min = (int64_t)floor(log(0.01) / two_pi_by_B);
+    uint64_t S_G = (uint64_t)(L->hi_i - L->low_i + 1);
+    uint64_t S_c = (uint64_t)(L->hi_i - cm0_min + 1);
+    uint64_t support = S_G + S_c;
+    uint64_t floor_n = (uint64_t)1 << 11;
+    L->fft_N = next_pow2_u64(support > floor_n ? support : floor_n);
+  }
   L->fft_NN = want_fft_NN; // final output length (= 1<<16 for the default window)
+  if (L->fft_N > L->fft_NN) { ecode[0] |= ERR_WINDOW_TOO_LARGE; return (Lfunc_t)NULL; }
 
   L->A = L->fft_NN * L->one_over_B;
   arb_init(L->arb_A);

--- a/src/glfunc.c
+++ b/src/glfunc.c
@@ -211,7 +211,9 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
     // overflow before the (uint64_t) cast, so an absurd H can never wrap to a
     // small or zero count.
     double need = ceil(1024.0 * (double)L->degree * L->max_t);
-    if (!isfinite(need) || need > (double)UINT64_MAX) {
+    // >= not >: (double)UINT64_MAX rounds up to exactly 2^64, and (uint64_t)2^64 is
+    // undefined behaviour, so need == 2^64 must be rejected too (not just > 2^64).
+    if (!isfinite(need) || need >= (double)UINT64_MAX) {
       return window_reject(L, false, ecode, ERR_WINDOW_TOO_LARGE);
     }
     want_fft_NN = next_pow2_u64((uint64_t)need);
@@ -350,10 +352,10 @@ Lfunc_t Lfunc_init_advanced(Lparams_t *Lp, Lerror_t *ecode) {
   L->fft_NN = want_fft_NN; // final output length (= 1<<16 for the default window)
   // Defensive backstop only: this branch is UNREACHABLE for any accepted input.
   // want_fft_NN >= 1<<11 (the sub-floor guard above rejects anything smaller), and
-  // fft_N = next_pow2(max(1<<11, support)). support ~ (hi_i-low_i) + (hi_i-calc_m(1))
-  // grows like B*(1+log N) = 8*max_t*(1+log N), while fft_NN ~ 1024*degree*max_t; for
-  // fft_N to exceed fft_NN we would need 1+log N > ~128*degree, i.e. log N > 255 at
-  // degree 2, far beyond any uint64_t conductor (log N <= ~44). So fft_N <= fft_NN
+  // fft_N = next_pow2(max(1<<11, support)). The conductor-dependent part of support is
+  // hi_i - calc_m(1) ~ B*ln(N)/(4*pi); with fft_NN ~ 1024*degree*max_t = 128*degree*B,
+  // fft_N exceeds fft_NN only once ln(N) > ~512*pi*degree (thousands; ~3217 at degree 2),
+  // far beyond any uint64_t conductor (ln N <= ~44). So fft_N <= fft_NN
   // always. L is only PARTIALLY constructed here (compute_g ran, but the w/ww/res/
   // zeros/upsampling allocations below have not), so Lfunc_clear would dereference
   // not-yet-allocated pointers; we keep the graceful fatal return instead. Freeing the

--- a/src/io.c
+++ b/src/io.c
@@ -65,8 +65,7 @@ Lplot_t *Lfunc_plot_data(Lfunc_t LL, uint64_t side, double max_t, uint64_t n_poi
   if(!Lp)
     return (Lplot_t *) NULL;
 
-  if(max_t>512.0/(double) (L->degree*OUTPUT_RATIO))
-    max_t=512.0/(double) (L->degree*OUTPUT_RATIO);
+  if(max_t > L->max_t) max_t = L->max_t;
   double pts=max_t*L->A;
   uint64_t step=ceil(pts/(double)n_points);
   // we are going to return every <step>'th point upto max_t

--- a/src/rank.c
+++ b/src/rank.c
@@ -5,58 +5,13 @@
 extern "C"{
 #endif
 
-  /*
-  // see ARB
-  uint64_t guess_rank(Lfunc *L, uint64_t side, uint64_t prec) 
-  {
-  static bool init=false;
-  static arb_t t;
-  double ratio;
-
-  if (!init) 
-  {
-  init=true;
-  arb_init(t);
-  }
-  arb_div(t,L->u_values_off[side][2],L->u_values_off[side][1],prec);
-  ratio = arf_get_d(arb_midref(t),ARF_RND_NEAR);
-  if(verbose)
-  {
-  printf("Ratio = %10.8e\n",ratio);
-  printf("eps^2 = ");arb_printd(acb_realref(L->epsilon_sqr),20);printf("\n");
-  }
-
-  if(L->self_dual==NO)
-  {
-  if (ratio <= 1) return 0;
-  return (int)floor(log(ratio)/log(2.0)+0.5);
-  } 
-
-  if (arb_is_negative(acb_realref(L->epsilon_sqr)))
-  {
-  if (ratio <= 2) return 1;
-  return 1+2*(int)floor(log(ratio/2)/log(4.0)+0.5);
-  } 
-  else 
-  {
-  if (ratio <= 1) return 0;
-  return 2*(int)floor(log(ratio)/log(4.0)+0.5);
-  }
-  }
-  */
-
   // exp(Pi(r*n/(4*A)-n^2/(A^2*H^2)))
   void exp_term(arb_t res, int64_t n, Lfunc *L, int64_t prec)
   {
-    static bool init=false;
-    static arb_t tmp1, tmp2, tmp3;
-    if(!init)
-    {
-      init=true;
-      arb_init(tmp1);
-      arb_init(tmp2);
-      arb_init(tmp3);
-    }
+    arb_t tmp1, tmp2, tmp3;
+    arb_init(tmp1);
+    arb_init(tmp2);
+    arb_init(tmp3);
     arb_mul_si(tmp1,L->u_one_over_A,n,prec); // n/A
     arb_mul(tmp2,tmp1,tmp1,prec); // n^2/A^2
     arb_mul(tmp3,tmp2,L->u_pi_by_H2,prec); // -Pi n^2/(A^2H^2)
@@ -65,6 +20,9 @@ extern "C"{
     arb_mul_2exp_si(tmp1,tmp1,-2); // Pi r n/(4A)
     arb_add(tmp2,tmp1,tmp3,prec);
     arb_exp(res,tmp2,prec);
+    arb_clear(tmp1);
+    arb_clear(tmp2);
+    arb_clear(tmp3);
   }
 
 
@@ -75,44 +33,7 @@ extern "C"{
    *  (pi A)^d \sum |k| <= H W(k/A) sinc^(d)(-pi k)
   */
   bool df_zero(arb_t res, uint64_t d, Lfunc *L, int64_t prec) {
-    static int64_t init_prec=0;
-    static bool init=false;
-    static arb_t a_pi_d[MAX_L+1], d_bang_pi[MAX_L+1], tmp, tmp1, tmp2, an, term;
     bool neg_me;
-    if(!init) {
-      init=true;
-      arb_init(tmp);
-      arb_init(tmp1);
-      arb_init(tmp2);
-      arb_init(term);
-      arb_init(an);
-      for(uint64_t i=0;i<=MAX_L;i++) {
-        arb_init(a_pi_d[i]);
-        arb_init(d_bang_pi[i]);
-      }
-    }
-    if(prec > init_prec) { // precision has increased
-      init_prec=prec;
-      // d_bang_pi[i] = i!/Pi^i depends only on prec (Pi is a universal constant), so
-      // it is safe to cache across objects, keyed on prec.
-      arb_set_ui(d_bang_pi[0],1);
-      arb_inv(d_bang_pi[1],L->pi,prec); // 1/Pi
-      for(uint64_t i=2;i<=MAX_L;i++) {
-        // i!/Pi^i = (i-1)!/Pi^(i-1) * i / Pi
-        arb_mul_ui(d_bang_pi[i], d_bang_pi[i-1], i,prec);
-        arb_div(d_bang_pi[i],d_bang_pi[i],L->pi,prec);
-      }
-    }
-    // a_pi_d[i] = (pi A)^i depends on the output window through L->u_pi_A (A = fft_NN/B
-    // varies per object), so it must NOT be cached across objects. Recompute it every
-    // call: caching it keyed only on prec returned a stale (pi A)^d for a second,
-    // lower-precision object with a different window, silently corrupting the certified
-    // Lfunc_Taylor ball (the bug fired only when prec did not increase). Bead lfunctions-1yx.
-    arb_set_ui(a_pi_d[0],1);
-    arb_set(a_pi_d[1],L->u_pi_A);
-    for(uint64_t i=2;i<=MAX_L;i++)
-      arb_mul(a_pi_d[i],a_pi_d[i-1],L->u_pi_A,prec);
-
     if(d > MAX_L) {
       printf("Can't compute F^(d)(0) for d>%d.\n",MAX_L);
       return false;
@@ -121,6 +42,35 @@ extern "C"{
       arb_set(res,L->u_values_off[0][0]);
       return true;
     }
+
+    arb_t a_pi_d[MAX_L+1], d_bang_pi[MAX_L+1], tmp, tmp1, tmp2, an, term;
+    arb_init(tmp);
+    arb_init(tmp1);
+    arb_init(tmp2);
+    arb_init(term);
+    arb_init(an);
+    for(uint64_t i=0;i<=MAX_L;i++) {
+      arb_init(a_pi_d[i]);
+      arb_init(d_bang_pi[i]);
+    }
+
+    // d_bang_pi[i] = i!/Pi^i. This is universal, but computing it per call
+    // avoids a cross-object static cache keyed on precision.
+    arb_set_ui(d_bang_pi[0],1);
+    arb_inv(d_bang_pi[1],L->pi,prec); // 1/Pi
+    for(uint64_t i=2;i<=MAX_L;i++) {
+      // i!/Pi^i = (i-1)!/Pi^(i-1) * i / Pi
+      arb_mul_ui(d_bang_pi[i], d_bang_pi[i-1], i,prec);
+      arb_div(d_bang_pi[i],d_bang_pi[i],L->pi,prec);
+    }
+    // a_pi_d[i] = (pi A)^i depends on the output window through L->u_pi_A
+    // (A = fft_NN/B varies per object), so it must not be cached across
+    // objects. Bead lfunctions-1yx.
+    arb_set_ui(a_pi_d[0],1);
+    arb_set(a_pi_d[1],L->u_pi_A);
+    for(uint64_t i=2;i<=MAX_L;i++)
+      arb_mul(a_pi_d[i],a_pi_d[i-1],L->u_pi_A,prec);
+
     // do the n=0 term. We know L(1/2)=0
     arb_zero(res);
     for(int64_t n = 1; n <= (int64_t)L->u_N; ++n) {
@@ -221,6 +171,15 @@ extern "C"{
       printf("W^(%" PRIu64 ")(0) ~ ", d);
       arb_printd(res, 20);
       printf("\n");
+    }
+    arb_clear(tmp);
+    arb_clear(tmp1);
+    arb_clear(tmp2);
+    arb_clear(term);
+    arb_clear(an);
+    for(uint64_t i=0;i<=MAX_L;i++) {
+      arb_clear(a_pi_d[i]);
+      arb_clear(d_bang_pi[i]);
     }
     return true;
   }

--- a/src/rank.c
+++ b/src/rank.c
@@ -93,12 +93,8 @@ extern "C"{
     }
     if(prec > init_prec) { // precision has increased
       init_prec=prec;
-      // a_pi_d[i] = (pi A)^i
-      arb_set_ui(a_pi_d[0],1);
-      arb_set(a_pi_d[1],L->u_pi_A);
-      for(uint64_t i=2;i<=MAX_L;i++)
-        arb_mul(a_pi_d[i],a_pi_d[i-1],L->u_pi_A,prec);
-      // d_bang_pi[i] = i!/Pi^i
+      // d_bang_pi[i] = i!/Pi^i depends only on prec (Pi is a universal constant), so
+      // it is safe to cache across objects, keyed on prec.
       arb_set_ui(d_bang_pi[0],1);
       arb_inv(d_bang_pi[1],L->pi,prec); // 1/Pi
       for(uint64_t i=2;i<=MAX_L;i++) {
@@ -107,6 +103,15 @@ extern "C"{
         arb_div(d_bang_pi[i],d_bang_pi[i],L->pi,prec);
       }
     }
+    // a_pi_d[i] = (pi A)^i depends on the output window through L->u_pi_A (A = fft_NN/B
+    // varies per object), so it must NOT be cached across objects. Recompute it every
+    // call: caching it keyed only on prec returned a stale (pi A)^d for a second,
+    // lower-precision object with a different window, silently corrupting the certified
+    // Lfunc_Taylor ball (the bug fired only when prec did not increase). Bead lfunctions-1yx.
+    arb_set_ui(a_pi_d[0],1);
+    arb_set(a_pi_d[1],L->u_pi_A);
+    for(uint64_t i=2;i<=MAX_L;i++)
+      arb_mul(a_pi_d[i],a_pi_d[i-1],L->u_pi_A,prec);
 
     if(d > MAX_L) {
       printf("Can't compute F^(d)(0) for d>%d.\n",MAX_L);

--- a/src/special_values.c
+++ b/src/special_values.c
@@ -188,21 +188,16 @@ extern "C"{
   // estimate W(1/2+iz) by upsampling off Lu->u_values_off
   Lerror_t s_upsample_stride_dash(acb_ptr res, acb_ptr z, double t0, Lfunc *L, int64_t prec, arb_t pi_by_H2, arb_t err, int64_t N, uint64_t stride)
   {
-    static arb_t A,pi; // the A for upsampling = usual A / stride
-    static acb_t diff,this_diff,term,sin_diff,cos_diff;
-    static bool init=false;
-    if(!init)
-    {
-      init=true;
-      arb_init(A);
-      acb_init(diff);
-      acb_init(this_diff);
-      acb_init(term);
-      acb_init(sin_diff);
-      acb_init(cos_diff);
-      arb_init(pi);
-      arb_const_pi(pi,prec);
-    }
+    Lerror_t ecode=ERR_SUCCESS;
+    arb_t A,pi; // the A for upsampling = usual A / stride
+    acb_t diff,term,sin_diff,cos_diff;
+    arb_init(A);
+    arb_init(pi);
+    arb_const_pi(pi,prec);
+    acb_init(diff);
+    acb_init(term);
+    acb_init(sin_diff);
+    acb_init(cos_diff);
 
     // sum runs for |k-t_0*A|<N
     int64_t k0=-(N-t0*L->A/stride-1);
@@ -220,9 +215,12 @@ extern "C"{
     int64_t n=k0*stride;
     for(int64_t k=k0;k<=k1;k++)
       {
-	Lerror_t ecode=s_do_point_dash(term,L,n,z,diff,sin_diff,cos_diff,L->arb_A,prec,pi_by_H2);
-	if(fatal_error(ecode))
-	  return ecode;
+	Lerror_t step_ecode=s_do_point_dash(term,L,n,z,diff,sin_diff,cos_diff,L->arb_A,prec,pi_by_H2);
+	if(fatal_error(step_ecode))
+	  {
+	    ecode=step_ecode;
+	    goto cleanup;
+	  }
 	acb_add(res,res,term,prec);
 	acb_neg(sin_diff,sin_diff);
 	acb_neg(cos_diff,cos_diff);
@@ -233,28 +231,29 @@ extern "C"{
     arb_add_error(acb_realref(res),err);
     arb_add_error(acb_imagref(res),err);
 
-    return ERR_SUCCESS;
+cleanup:
+    arb_clear(A);
+    arb_clear(pi);
+    acb_clear(diff);
+    acb_clear(term);
+    acb_clear(sin_diff);
+    acb_clear(cos_diff);
+    return ecode;
   }
 
   
   // estimate W(1/2+iz) by upsampling off Lu->u_values_off
   Lerror_t s_upsample_stride(acb_ptr res, acb_ptr z, double t0, Lfunc *L, int64_t prec, arb_t pi_by_H2, arb_t err, int64_t N, uint64_t stride)
   {
-    static arb_t A,pi; // the A for upsampling = usual A / stride
-    static acb_t diff,this_diff,term,sin_diff,neg_sin_diff;
-    static bool init=false;
-    if(!init)
-    {
-      init=true;
-      arb_init(A);
-      acb_init(diff);
-      acb_init(this_diff);
-      acb_init(term);
-      acb_init(sin_diff);
-      acb_init(neg_sin_diff);
-      arb_init(pi);
-      arb_const_pi(pi,prec);
-    }
+    Lerror_t ecode=ERR_SUCCESS;
+    arb_t A,pi; // the A for upsampling = usual A / stride
+    acb_t diff,term,sin_diff;
+    arb_init(A);
+    arb_init(pi);
+    arb_const_pi(pi,prec);
+    acb_init(diff);
+    acb_init(term);
+    acb_init(sin_diff);
 
     // sum runs for |k-t_0*A|<N
     int64_t k0=-(N-t0*L->A/stride-1);
@@ -269,15 +268,18 @@ extern "C"{
     int64_t n=k0*stride;
     for(int64_t k=k0;k<=k1;k++)
       {
-	Lerror_t ecode=s_do_point(term,L,n,z,diff,sin_diff,L->arb_A,prec,pi_by_H2);
+	Lerror_t step_ecode=s_do_point(term,L,n,z,diff,sin_diff,L->arb_A,prec,pi_by_H2);
 	if(verbose&&(k==0))
 	  {
 	    printf("W(0)sinc(stuff)  returned ");
 	    acb_printd(term,20);
 	    printf("\n");
 	  }
-	if(fatal_error(ecode))
-	  return ecode;
+	if(fatal_error(step_ecode))
+	  {
+	    ecode=step_ecode;
+	    goto cleanup;
+	  }
 	acb_add(res,res,term,prec);
 	acb_neg(sin_diff,sin_diff);
 	n+=stride;
@@ -286,7 +288,13 @@ extern "C"{
     arb_add_error(acb_realref(res),err);
     arb_add_error(acb_imagref(res),err);
 
-    return ERR_SUCCESS;
+cleanup:
+    arb_clear(A);
+    arb_clear(pi);
+    acb_clear(diff);
+    acb_clear(term);
+    acb_clear(sin_diff);
+    return ecode;
       
   }
 

--- a/src/turing.c
+++ b/src/turing.c
@@ -39,20 +39,16 @@ bool imint(arb_t res, arb_t sigma, arb_t a, arb_t b, uint64_t prec) {
     arb_printd(b, 10);
     printf("\n");
   }
-  static arb_t a2, b2, s2, b2s2, a2s2, tmp1, tmp2, tmp3, shalf;
-  static bool init = false;
-  if (!init) {
-    init = true;
-    arb_init(a2);
-    arb_init(b2);
-    arb_init(s2);
-    arb_init(b2s2);
-    arb_init(a2s2);
-    arb_init(tmp1);
-    arb_init(tmp2);
-    arb_init(tmp3);
-    arb_init(shalf);
-  }
+  arb_t a2, b2, s2, b2s2, a2s2, tmp1, tmp2, tmp3, shalf;
+  arb_init(a2);
+  arb_init(b2);
+  arb_init(s2);
+  arb_init(b2s2);
+  arb_init(a2s2);
+  arb_init(tmp1);
+  arb_init(tmp2);
+  arb_init(tmp3);
+  arb_init(shalf);
   arb_set_d(tmp1, -0.5);
   arb_add(shalf, sigma, tmp1, prec); // sigma-1/2
 
@@ -104,26 +100,31 @@ bool imint(arb_t res, arb_t sigma, arb_t a, arb_t b, uint64_t prec) {
     arb_printd(res, 10);
     printf("\n");
   }
+  arb_clear(a2);
+  arb_clear(b2);
+  arb_clear(s2);
+  arb_clear(b2s2);
+  arb_clear(a2s2);
+  arb_clear(tmp1);
+  arb_clear(tmp2);
+  arb_clear(tmp3);
+  arb_clear(shalf);
   return (true);
 }
 
 // Q(s) is analytic conductor defined pg 387 col 2
 void logQ(arb_t res, acb_t s, Lfunc *L, int64_t prec) {
   // printf("In logQ with s=");acb_printd(s,10);printf("\n");
-  static bool init = false;
-  static arb_t two_pi, tmp1, tmp2;
-  static acb_t stmp1, stmp2, stmp3;
-  if (!init) {
-    init = true;
-    arb_init(two_pi);
-    arb_init(tmp1);
-    arb_init(tmp2);
-    acb_init(stmp1);
-    acb_init(stmp2);
-    acb_init(stmp3);
-    arb_const_pi(two_pi, prec);
-    arb_mul_2exp_si(two_pi, two_pi, 1);
-  }
+  arb_t two_pi, tmp1, tmp2;
+  acb_t stmp1, stmp2, stmp3;
+  arb_init(two_pi);
+  arb_init(tmp1);
+  arb_init(tmp2);
+  acb_init(stmp1);
+  acb_init(stmp2);
+  acb_init(stmp3);
+  arb_const_pi(two_pi, prec);
+  arb_mul_2exp_si(two_pi, two_pi, 1);
   acb_set_ui(stmp1, L->conductor);
   arb_set(acb_imagref(stmp2), acb_imagref(s));
   for (uint64_t j = 0; j < L->degree; j++) {
@@ -144,6 +145,12 @@ void logQ(arb_t res, acb_t s, Lfunc *L, int64_t prec) {
     arb_printd(res, 10);
     printf("\n");
   }
+  arb_clear(two_pi);
+  arb_clear(tmp1);
+  arb_clear(tmp2);
+  acb_clear(stmp1);
+  acb_clear(stmp2);
+  acb_clear(stmp3);
 }
 
 // see 4-10.
@@ -186,27 +193,22 @@ bool set_X(arb_t res, uint64_t r, double *mus, double one_over_B,
 // see Remark 4.2 of https://arxiv.org/pdf/2508.03023 PALOJARVI + ZHAO
 // times 2 for l-function and its conjugate.
 bool St_int(arb_t res, arb_t h, arb_t t0, Lfunc *L, int64_t prec) {
-  static bool init = false;
-  static acb_t s;
-  static arb_t Q1, Q2, l2_half, pi, rc_theta_etc, tmp, tmp1;
-  if (!init) {
-    init = true;
-    arb_init(tmp);
-    arb_init(tmp1);
-    acb_init(s);
-    arb_init(pi);
-    arb_set_d(acb_realref(s), 1.5);
-    arb_init(Q1);
-    arb_init(Q2);
-    arb_init(l2_half);
-    arb_log_ui(Q1, 2, prec);
-    arb_set_d(Q2, -0.5);
-    arb_add(l2_half, Q1, Q2, prec);
-    arb_init(rc_theta_etc);
-    arb_const_pi(pi, prec);
-  }
-  // rc_theta_etc depends on L (via L->X and L->degree), so it must be
-  // recomputed for every L-function, not cached in the init block.
+  acb_t s;
+  arb_t Q1, Q2, l2_half, pi, rc_theta_etc, tmp, tmp1;
+  arb_init(tmp);
+  arb_init(tmp1);
+  acb_init(s);
+  arb_init(pi);
+  arb_set_d(acb_realref(s), 1.5);
+  arb_init(Q1);
+  arb_init(Q2);
+  arb_init(l2_half);
+  arb_log_ui(Q1, 2, prec);
+  arb_set_d(Q2, -0.5);
+  arb_add(l2_half, Q1, Q2, prec);
+  arb_init(rc_theta_etc);
+  arb_const_pi(pi, prec);
+
   // c_theta for theta=0 (Booker Thm 4.6). The paper's printed bound 5.65055 is
   // loose by exactly log zeta(3/2)=0.96026; the displayed-expression value is
   // 4.69028764131 (verified, and equal to Palojarvi-Zhao c_0(eps=1/2)). 4.6902877
@@ -235,6 +237,14 @@ bool St_int(arb_t res, arb_t h, arb_t t0, Lfunc *L, int64_t prec) {
   arb_mul_2exp_si(tmp1, tmp1, 1); // this is an upper bound
   arb_neg(tmp, tmp1);             // lower bound
   arb_union(res, tmp, tmp1, prec);
+  arb_clear(tmp);
+  arb_clear(tmp1);
+  acb_clear(s);
+  arb_clear(pi);
+  arb_clear(Q1);
+  arb_clear(Q2);
+  arb_clear(l2_half);
+  arb_clear(rc_theta_etc);
   return true;
 }
 
@@ -242,13 +252,9 @@ bool St_int(arb_t res, arb_t h, arb_t t0, Lfunc *L, int64_t prec) {
 // simultaneously (see 4 of Booker)
 bool turing_int(arb_t res, arb_t t0, arb_t h, Lfunc *L, uint64_t *count,
                 uint64_t side, int64_t prec) {
-  static bool init = false;
-  static arb_t tmp, t0_plus_h;
-  if (!init) {
-    init = true;
-    arb_init(tmp);
-    arb_init(t0_plus_h);
-  }
+  arb_t tmp, t0_plus_h;
+  arb_init(tmp);
+  arb_init(t0_plus_h);
 
   arb_add(t0_plus_h, t0, h, prec);
   arb_zero(res);
@@ -258,6 +264,8 @@ bool turing_int(arb_t res, arb_t t0, arb_t h, Lfunc *L, uint64_t *count,
     if (z_ptr >= MAX_ZEROS) {
       fprintf(stderr,
               "Ran out of room for zeros before end of Turing Region.\n");
+      arb_clear(tmp);
+      arb_clear(t0_plus_h);
       return false;
     }
     if (arb_is_zero(L->zeros[side][z_ptr])) // end of zeros
@@ -276,29 +284,26 @@ bool turing_int(arb_t res, arb_t t0, arb_t h, Lfunc *L, uint64_t *count,
     z_ptr++;
   }
   count[0] = N_t0;
+  arb_clear(tmp);
+  arb_clear(t0_plus_h);
   return true;
 }
 
 // computes Turing's integral into res and returns # zeros actually found.
 uint64_t turing_count(arb_t res, Lfunc *L, int64_t prec) {
-  static bool init = false;
-  static arb_t tint, tmp, tmp1, h, t0, sint, pi, rlogpi, t0hbit;
-  if (!init) {
-    init = true;
-    arb_init(tint);
-    arb_init(sint);
-    arb_init(tmp);
-    arb_init(tmp1);
-    arb_init(h);
-    arb_init(t0);
-    arb_init(pi);
-    arb_const_pi(pi, prec);
-    arb_init(rlogpi);
-    arb_init(t0hbit);
-  }
-  // h, t0, rlogpi and t0hbit all depend on L (via L->B = 512/degree and
-  // L->degree), so they must be recomputed for every L-function rather than
-  // cached once in the init block.
+  arb_t tint, tmp, tmp1, h, t0, sint, pi, rlogpi, t0hbit;
+  uint64_t zeros_found = 0;
+  arb_init(tint);
+  arb_init(sint);
+  arb_init(tmp);
+  arb_init(tmp1);
+  arb_init(h);
+  arb_init(t0);
+  arb_init(pi);
+  arb_const_pi(pi, prec);
+  arb_init(rlogpi);
+  arb_init(t0hbit);
+
   arb_div_ui(h, L->B, TURING_RATIO, prec);
   if (verbose) {
     printf("Turing h set to ");
@@ -319,9 +324,8 @@ uint64_t turing_count(arb_t res, Lfunc *L, int64_t prec) {
   arb_add(sint, tmp1, tmp, prec);
   arb_div(t0hbit, sint, pi, prec);
   arb_mul_2exp_si(t0hbit, t0hbit, -1); // (2t0h+h^2)/2Pi
-  uint64_t zeros_found = 0;
   if (!turing_int(tint, t0, h, L, &zeros_found, 0, prec))
-    return 0;
+    goto cleanup;
   if (verbose) {
     printf("Turing int [0] = ");
     arb_printd(tint, 20);
@@ -332,8 +336,10 @@ uint64_t turing_count(arb_t res, Lfunc *L, int64_t prec) {
     arb_mul_2exp_si(tint, tint, 1);
   } else {
     uint64_t conj_zeros_found;
-    if (!turing_int(tmp, t0, h, L, &conj_zeros_found, 1, prec))
-      return 0;
+    if (!turing_int(tmp, t0, h, L, &conj_zeros_found, 1, prec)) {
+      zeros_found = 0;
+      goto cleanup;
+    }
     zeros_found += conj_zeros_found;
     arb_add(tint, tint, tmp, prec);
   }
@@ -344,8 +350,10 @@ uint64_t turing_count(arb_t res, Lfunc *L, int64_t prec) {
     arb_printd(tint, 20);
     printf("\n");
   }
-  if (!St_int(sint, h, t0, L, prec))
-    return 0;
+  if (!St_int(sint, h, t0, L, prec)) {
+    zeros_found = 0;
+    goto cleanup;
+  }
   if (verbose) {
     printf("St_int returned ");
     arb_printd(sint, 10);
@@ -368,22 +376,29 @@ uint64_t turing_count(arb_t res, Lfunc *L, int64_t prec) {
     arb_printd(res, 10);
     printf("\n");
   }
+cleanup:
+  arb_clear(tint);
+  arb_clear(sint);
+  arb_clear(tmp);
+  arb_clear(tmp1);
+  arb_clear(h);
+  arb_clear(t0);
+  arb_clear(pi);
+  arb_clear(rlogpi);
+  arb_clear(t0hbit);
   return zeros_found;
 }
 
 Lerror_t turing_check_RH(Lfunc *L, int64_t prec) {
-  static bool init = false;
-  static arb_t tmp, sigma, a, b, t0, h, tcount;
-  if (!init) {
-    init = true;
-    arb_init(tmp);
-    arb_init(sigma);
-    arb_init(a);
-    arb_init(b);
-    arb_init(t0);
-    arb_init(h);
-    arb_init(tcount);
-  }
+  Lerror_t ecode = ERR_SUCCESS;
+  arb_t tmp, sigma, a, b, t0, h, tcount;
+  arb_init(tmp);
+  arb_init(sigma);
+  arb_init(a);
+  arb_init(b);
+  arb_init(t0);
+  arb_init(h);
+  arb_init(tcount);
 
   arb_zero(L->imint);
   arb_div_ui(t0, L->B, OUTPUT_RATIO, prec);
@@ -404,8 +419,10 @@ Lerror_t turing_check_RH(Lfunc *L, int64_t prec) {
   // t0 to t0+h
   for (uint64_t r = 0; r < L->degree; r++) {
     arb_set_d(sigma, L->mus[r] / 2.0 + 0.25);
-    if (!imint(tmp, sigma, a, b, prec))
-      return ERR_RH_ERROR;
+    if (!imint(tmp, sigma, a, b, prec)) {
+      ecode = ERR_RH_ERROR;
+      goto cleanup;
+    }
     arb_add(L->imint, L->imint, tmp, prec);
   }
   arb_mul_2exp_si(L->imint, L->imint, 2);
@@ -415,8 +432,10 @@ Lerror_t turing_check_RH(Lfunc *L, int64_t prec) {
     printf("\n");
   }
 
-  if (!set_X(L->X, L->degree, L->mus, L->one_over_B, prec))
-    return ERR_RH_ERROR;
+  if (!set_X(L->X, L->degree, L->mus, L->one_over_B, prec)) {
+    ecode = ERR_RH_ERROR;
+    goto cleanup;
+  }
   if (verbose) {
     printf("X set to ");
     arb_printd(L->X, 20);
@@ -429,8 +448,10 @@ Lerror_t turing_check_RH(Lfunc *L, int64_t prec) {
     arb_printd(tcount, 20);
     printf("\n");
   }
-  if (zeros_found == 0)
-    return ERR_RH_ERROR;
+  if (zeros_found == 0) {
+    ecode = ERR_RH_ERROR;
+    goto cleanup;
+  }
 
   if (verbose)
     printf("We found %lu zeros.\n", zeros_found);
@@ -440,15 +461,25 @@ Lerror_t turing_check_RH(Lfunc *L, int64_t prec) {
   arb_sub_ui(tmp, tcount, zeros_found - 1, prec);
   if (!arb_is_positive(tmp)) {
     fprintf(stderr, "Found too many zeros.\n");
-    return ERR_RH_ERROR;
+    ecode = ERR_RH_ERROR;
+    goto cleanup;
   }
   arb_sub_ui(tmp, tmp, 2, prec);
   if (!arb_is_negative(tmp)) {
     fprintf(stderr, "Found too few zeros.\n");
-    return ERR_RH_ERROR;
+    ecode = ERR_RH_ERROR;
+    goto cleanup;
   }
 
-  return 0; // success
+cleanup:
+  arb_clear(tmp);
+  arb_clear(sigma);
+  arb_clear(a);
+  arb_clear(b);
+  arb_clear(t0);
+  arb_clear(h);
+  arb_clear(tcount);
+  return ecode;
 }
 
 #ifdef __cplusplus

--- a/src/turing.c
+++ b/src/turing.c
@@ -1,10 +1,10 @@
 // Copyright Dave Platt 2024
 // See LICENSE file for license details.
 //
-// Use Booker's generalisation of Turing's method to confirm RH
-// to height B/(OUTPUT_RATIO*degree).
+// Use Booker’s generalisation of Turing’s method to confirm RH
+// to height H = B/OUTPUT_RATIO, where B = OUTPUT_RATIO*H is derived
+// from the requested window H (default H = 64/degree).
 // see Artin’s Conjecture, Turing’s Method, and the Riemann Hypothesis
-// B is hard wired to 512 in g.c so height is 64/degree
 
 // Note that RH is only verifiable for rank <=1
 // This code will trust larger values of rank and will

--- a/src/upsample.c
+++ b/src/upsample.c
@@ -196,8 +196,14 @@ Lerror_t arb_upsampling_error(
   arb_div(delta,delta,pi,prec);
   arb_mul_2exp_si(delta,delta,-2);
   arb_sub_ui(tmp,delta,1,prec);
-  if(!arb_is_negative(tmp))
+  if(!arb_is_negative(tmp)) {
+    arb_clear(tmp);
+    arb_clear(tmp1);
+    arb_clear(tmp2);
+    arb_clear(tmp3);
+    arb_clear(delta);
     return ecode|ERR_SPEC_VALUE;
+  }
 
   arb_t E0,E1,E2;
   arb_init(E0);
@@ -301,10 +307,7 @@ Lerror_t init_upsampling(Lfunc *L)
 
   // we allow for sampling a less than every point
   L->u_stride=1; // but actually sample at every point!
-  arb_init(L->u_pi_A);
-  arb_init(L->u_A);
   arb_mul_ui(L->u_A,L->arb_A,L->u_stride,prec);
-  arb_init(L->u_one_over_A);
   arb_inv(L->u_one_over_A,L->u_A,prec);
   if(verbose){printf("A for upsampling set to ");arb_printd(L->u_A,10);printf("\n");}
   arb_mul(L->u_pi_A,L->pi,L->u_A,prec);
@@ -314,7 +317,6 @@ Lerror_t init_upsampling(Lfunc *L)
   double h=sqrt(1.0/A)*1.001;
   double H=ceil(A*A*h*h/2.0);
   double M=H/A;
-  arb_init(L->upsampling_error);
   arb_t tmp,zero;
   arb_init(tmp);arb_init(zero);
   while(true)
@@ -339,11 +341,9 @@ Lerror_t init_upsampling(Lfunc *L)
   if(verbose){printf("Upsampling error set to ");arb_printd(L->upsampling_error,10);printf("\n");}
 
 
-  arb_init(L->u_H);
   arb_set_d(L->u_H, h);
   L->u_N=H;
   if(verbose){printf("Upsampling H set to ");arb_printd(L->u_H,20);printf("\n");}
-  arb_init(L->u_pi_by_H2); // -pi/H^2
   arb_inv(L->u_pi_by_H2,L->u_H,prec); // 1/H
   arb_mul(L->u_pi_by_H2,L->u_pi_by_H2,L->u_pi_by_H2,prec); // 1/H^2
   arb_mul(L->u_pi_by_H2,L->u_pi_by_H2,L->pi,prec);
@@ -360,6 +360,13 @@ Lerror_t init_upsampling(Lfunc *L)
   L->u_no_values=L->fft_NN/OUTPUT_RATIO+L->fft_NN/TURING_RATIO+L->u_N*4*L->u_stride+1;
   L->u_values[0]=(arb_t *)malloc(sizeof(arb_t)*L->u_no_values);
   L->u_values[1]=(arb_t *)malloc(sizeof(arb_t)*L->u_no_values);
+  if(!L->u_values[0] || !L->u_values[1]) {
+    free(L->u_values[0]);
+    free(L->u_values[1]);
+    L->u_values[0] = NULL;
+    L->u_values[1] = NULL;
+    return ERR_OOM;
+  }
   L->u_no_values_off=L->u_no_values-L->u_N*L->u_stride*2;
   L->u_values_off[0]=L->u_values[0]+L->u_N*L->u_stride*2;
   L->u_values_off[1]=L->u_values[1]+L->u_N*L->u_stride*2;

--- a/src/upsample.c
+++ b/src/upsample.c
@@ -309,7 +309,7 @@ Lerror_t init_upsampling(Lfunc *L)
   if(verbose){printf("A for upsampling set to ");arb_printd(L->u_A,10);printf("\n");}
   arb_mul(L->u_pi_A,L->pi,L->u_A,prec);
 
-  double T=512.0/(double)L->degree/(double)OUTPUT_RATIO;
+  double T=L->max_t;
   double A=L->A*L->u_stride;
   double h=sqrt(1.0/A)*1.001;
   double H=ceil(A*A*h*h/2.0);

--- a/src/zeros.c
+++ b/src/zeros.c
@@ -15,8 +15,6 @@ extern "C"{
 #define sign_t uint8_t
 #define direction_t uint8_t
 
-#define MAX_ZEROS (256)
-
 sign_t sign(arb_t x) {
   if(arb_contains_zero(x))
     return UNK;

--- a/src/zeros.c
+++ b/src/zeros.c
@@ -290,8 +290,10 @@ Lerror_t find_zeros(Lfunc *L, uint64_t side)
         printf(" and ");arb_printd(tmp2, 20);printf("\n");
       }
       ecode|=isolate_zero(L->zeros[side][count++], tmp1, tmp2, L->u_values_off[side][n-1], L->u_values_off[side][n], last_sign, L, side, prec);
-      if(fatal_error(ecode)||(count==MAX_ZEROS))
+      if(fatal_error(ecode))
         return ecode;
+      if(count==MAX_ZEROS)
+        return ecode|ERR_ZERO_OVERFLOW;
       continue;
     }
 
@@ -317,11 +319,11 @@ Lerror_t find_zeros(Lfunc *L, uint64_t side)
         arb_set(L->zeros[side][count], z1);
         count++;
         if(count==MAX_ZEROS)
-          return ecode;
+          return ecode|ERR_ZERO_OVERFLOW;
         arb_set(L->zeros[side][count], z2);
         count++;
         if(count==MAX_ZEROS)
-          return ecode;
+          return ecode|ERR_ZERO_OVERFLOW;
       }
     }
   }

--- a/src/zeros.c
+++ b/src/zeros.c
@@ -292,7 +292,7 @@ Lerror_t find_zeros(Lfunc *L, uint64_t side)
       ecode|=isolate_zero(L->zeros[side][count++], tmp1, tmp2, L->u_values_off[side][n-1], L->u_values_off[side][n], last_sign, L, side, prec);
       if(fatal_error(ecode))
         return ecode;
-      if(count==MAX_ZEROS)
+      if(count==L->zero_cap)
         return ecode|ERR_ZERO_OVERFLOW;
       continue;
     }
@@ -318,11 +318,11 @@ Lerror_t find_zeros(Lfunc *L, uint64_t side)
           arb_printd(z1, 20);printf(" ");arb_printd(z2, 20);printf("\n");}
         arb_set(L->zeros[side][count], z1);
         count++;
-        if(count==MAX_ZEROS)
+        if(count==L->zero_cap)
           return ecode|ERR_ZERO_OVERFLOW;
         arb_set(L->zeros[side][count], z2);
         count++;
-        if(count==MAX_ZEROS)
+        if(count==L->zero_cap)
           return ecode|ERR_ZERO_OVERFLOW;
       }
     }

--- a/test/error_propagation_test.c
+++ b/test/error_propagation_test.c
@@ -1,0 +1,152 @@
+/*
+ * Regression test for the error-propagation bug in src/error.c
+ * do_pre_iFFT_errors (bead lfunctions-fxm).
+ *
+ * Bug: the loop at lines ~537-543 iterated j=0..i-1 over the populated output
+ * bins but added the F_hat_twiddle aliasing error and the eq-59 G-truncation
+ * error to res[i] (the post-break bin) i times instead of to res[j].  The
+ * populated bins res[0..i-1] received neither error term; res[i] received both
+ * i times, then was immediately zeroed by acb_zero() in the subsequent loop
+ * (line ~623).  The certified radius of every output ball was therefore
+ * under-reported.
+ *
+ * Fix: change the four L->res[i] to L->res[j] in that loop.
+ *
+ * Distinguishing signal attempted:
+ *   The F_hat_twiddle bound (fhattwiddle) and the eq-59 G-tail bound (err)
+ *   are both exponentially small by design -- they are the per-request
+ *   G-truncation and aliasing bounds, each chosen to be ~2^{-wprec}.
+ *   For ec_37.a1 at default precision (wprec ~165 bits):
+ *     fhattwiddle  ~= 0  (the G-function decays to ~0 before the grid edge)
+ *     eq59_err     ~= 2.15e-62
+ *   The contribution of eq59_err to the iFFT output is roughly
+ *     i * eq59_err / fft_NN ~= 203 * 2.15e-62 / 65536  ~  6.7e-65
+ *   which is ~12 orders of magnitude below the dominant M_error contribution
+ *   (~1.09e-52 for the Taylor coefficient).
+ *   r_broken = 1.094285e-52, r_fixed = 1.094363e-52 (differ by ~7e-57, <0.01%).
+ *   No robust radius threshold exists to separate them (ratio ~1.000000064).
+ *
+ * This is a soundness hole, not a numerical regression detectable via
+ * public-API ball radii at default precision.  The test therefore verifies
+ * code correctness: the computation completes without fatal error and the
+ * Taylor coefficient overlaps the known BSD constant, catching any regression
+ * the fix might introduce.
+ */
+
+#include <assert.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <flint/acb_poly.h>
+#include <flint/mag.h>
+#include "glfunc.h"
+
+/* Euler factors for ec_37.a1 (from the LMFDB sidebar).
+ * https://www.lmfdb.org/EllipticCurve/Q/37/a/1 */
+static const int64_t ef_p[]  = {
+  2,  3,  5,  7, 11, 13, 17, 19, 23, 29, 31, 37,
+  41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97,
+  101, 103, 107, 109, 113, 127, 131, 137, 139
+};
+/* a1 coefficient for each prime (a0 = 1 always) */
+static const int64_t ef_a1[] = {
+   2,  3,  2,  1,  5,  2,  0,  0, -2, -6,  4,  1,
+   9, -2,  9, -1, -8,  8, -8, -9,  1, -4, 15, -4, -4,
+  -3, -18, 12, 16, 18, -1, 12,  6, -4
+};
+/* a2 = p for good primes; p=37 is bad (conductor factor) => a2=0 */
+static const int64_t ef_a2[] = {
+   2,  3,  5,  7, 11, 13, 17, 19, 23, 29, 31,  0,
+  41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97,
+  101, 103, 107, 109, 113, 127, 131, 137, 139
+};
+#define N_PRIMES ((int)(sizeof(ef_p)/sizeof(ef_p[0])))
+
+static void lpoly_callback(acb_poly_t poly, uint64_t p,
+                           int d __attribute__((unused)),
+                           int64_t prec __attribute__((unused)),
+                           void *param __attribute__((unused)))
+{
+  for (int k = 0; k < N_PRIMES; k++) {
+    if ((uint64_t)ef_p[k] == p) {
+      acb_poly_zero(poly);
+      acb_poly_set_coeff_si(poly, 0, 1);
+      acb_poly_set_coeff_si(poly, 1, ef_a1[k]);
+      if (ef_a2[k] != 0)
+        acb_poly_set_coeff_si(poly, 2, ef_a2[k]);
+      return;
+    }
+  }
+  /* prime not in table: signal end of factors */
+  acb_poly_zero(poly);
+}
+
+int main(void)
+{
+  Lerror_t ecode = ERR_SUCCESS;
+  double mus[2] = {0.0, 1.0};
+
+  Lfunc_t L = Lfunc_init(2, 37, 0.5, mus, &ecode);
+  if (fatal_error(ecode)) {
+    fprint_errors(stderr, ecode);
+    return 1;
+  }
+
+  ecode |= Lfunc_use_all_lpolys(L, lpoly_callback, NULL);
+  if (fatal_error(ecode)) {
+    fprint_errors(stderr, ecode);
+    Lfunc_clear(L);
+    return 1;
+  }
+
+  ecode |= Lfunc_compute(L);
+  if (fatal_error(ecode)) {
+    fprint_errors(stderr, ecode);
+    Lfunc_clear(L);
+    return 1;
+  }
+
+  /* Report the Taylor radius (informational). */
+  arb_srcptr taylor = Lfunc_Taylor(L);
+  double r_d = mag_get_d(arb_radref(taylor));
+  printf("Taylor = ");
+  arb_printd(taylor, 20);
+  printf("\nTaylor radius = %.6e\n", r_d);
+
+  /*
+   * Verify the Taylor coefficient overlaps the known BSD constant.
+   * This catches any regression introduced by the fix (the certified ball
+   * must still contain the truth).
+   *
+   * NOTE: a radius-threshold test to distinguish the broken res[i] from the
+   * fixed res[j] is not feasible.  The two omitted error terms (fhattwiddle
+   * ~= 0 and eq59_err ~= 2.15e-62) contribute ~6.7e-65 to the output ball
+   * radius after the iFFT, while M_error contributes ~1.09e-52.  The ratio
+   * (r_fixed - r_broken) / r_broken < 1e-6, so no robust threshold exists.
+   * The bug is a soundness hole; correctness verification (BSD overlap) is the
+   * appropriate test here.
+   */
+  arb_t bsd;
+  arb_init(bsd);
+  arb_set_str(bsd,
+    "0.305999773834052301820483683321676474452637774590771998534541832481"
+    "016050469290169911495257337795897237898682879524967997997869651621709"
+    "648704953228700", 400);
+  assert(arb_overlaps(taylor, bsd));
+  printf("Taylor overlaps BSD constant: PASS\n");
+  arb_clear(bsd);
+
+  /* Verify rank and first zero. */
+  assert(Lfunc_rank(L) == 1);
+  arb_srcptr zeros = Lfunc_zeros(L, 0);
+  arb_t ref;
+  arb_init(ref);
+  arb_set_str(ref, "5.0031700140066586953", 300);
+  arb_add_error_2exp_si(ref, -50);
+  assert(arb_overlaps(zeros, ref));
+  printf("First zero overlaps reference: PASS\n");
+  arb_clear(ref);
+
+  Lfunc_clear(L);
+  printf("PASS: error_propagation_test\n");
+  return 0;
+}

--- a/test/error_propagation_test.c
+++ b/test/error_propagation_test.c
@@ -12,25 +12,23 @@
  *
  * Fix: change the four L->res[i] to L->res[j] in that loop.
  *
- * Distinguishing signal attempted:
- *   The F_hat_twiddle bound (fhattwiddle) and the eq-59 G-tail bound (err)
- *   are both exponentially small by design -- they are the per-request
- *   G-truncation and aliasing bounds, each chosen to be ~2^{-wprec}.
- *   For ec_37.a1 at default precision (wprec ~165 bits):
- *     fhattwiddle  ~= 0  (the G-function decays to ~0 before the grid edge)
- *     eq59_err     ~= 2.15e-62
- *   The contribution of eq59_err to the iFFT output is roughly
- *     i * eq59_err / fft_NN ~= 203 * 2.15e-62 / 65536  ~  6.7e-65
- *   which is ~12 orders of magnitude below the dominant M_error contribution
- *   (~1.09e-52 for the Taylor coefficient).
- *   r_broken = 1.094285e-52, r_fixed = 1.094363e-52 (differ by ~7e-57, <0.01%).
- *   No robust radius threshold exists to separate them (ratio ~1.000000064).
+ * Why public-API ball radii do NOT distinguish fixed from broken:
+ *   fhattwiddle and err (= L->eq59 * L->sum_ans) are ~2^{-wprec} and, on every
+ *   reachable configuration, are dominated by M_error on the SAME populated bins.
+ *   Lowering gprec inflates eq59 but inflates M_error in lockstep (the G grid
+ *   shrinks, so the coefficient cutoff M drops), so the output radius moves
+ *   together for both versions -- e.g. at gprec 50 the Taylor radius is ~4.7e-9
+ *   either way.  No radius threshold on a public output separates them.
  *
- * This is a soundness hole, not a numerical regression detectable via
- * public-API ball radii at default precision.  The test therefore verifies
- * code correctness: the computation completes without fatal error and the
- * Taylor coefficient overlaps the known BSD constant, catching any regression
- * the fix might introduce.
+ * The test therefore has two parts:
+ *   (1) Correctness/regression (full public compute): rank, first zero, and the
+ *       Taylor coefficient overlapping the known BSD constant.
+ *   (2) A white-box discriminator that FAILS on the broken res[i] code.  M_error
+ *       does not depend on sum_ans, so inflating sum_ans on a fresh handle and
+ *       calling do_pre_iFFT_errors directly makes err dominate res[0]: the fix
+ *       (res[j]) leaves res[0] with radius ~= eq59*sum_ans (~1e-33), while the bug
+ *       (res[i]) sends err to res[break] -- which src/error.c ~683 then zeroes --
+ *       leaving res[0] at ~= M_error[0] (~1e-61).
  */
 
 #include <assert.h>
@@ -39,6 +37,7 @@
 #include <flint/acb_poly.h>
 #include <flint/mag.h>
 #include "glfunc.h"
+#include "glfunc_internals.h"  /* white-box: Lfunc, L->res/sum_ans, do_pre_iFFT_errors */
 
 /* Euler factors for ec_37.a1 (from the LMFDB sidebar).
  * https://www.lmfdb.org/EllipticCurve/Q/37/a/1 */
@@ -117,13 +116,10 @@ int main(void)
    * This catches any regression introduced by the fix (the certified ball
    * must still contain the truth).
    *
-   * NOTE: a radius-threshold test to distinguish the broken res[i] from the
-   * fixed res[j] is not feasible.  The two omitted error terms (fhattwiddle
-   * ~= 0 and eq59_err ~= 2.15e-62) contribute ~6.7e-65 to the output ball
-   * radius after the iFFT, while M_error contributes ~1.09e-52.  The ratio
-   * (r_fixed - r_broken) / r_broken < 1e-6, so no robust threshold exists.
-   * The bug is a soundness hole; correctness verification (BSD overlap) is the
-   * appropriate test here.
+   * NOTE: a radius threshold on this PUBLIC output cannot distinguish the broken
+   * res[i] from the fixed res[j] (M_error dominates the omitted terms on the same
+   * bins, in lockstep across gprec).  The distinguishing check is the white-box
+   * res[0] assertion at the end of this file.
    */
   arb_t bsd;
   arb_init(bsd);
@@ -145,6 +141,32 @@ int main(void)
   assert(arb_overlaps(zeros, ref));
   printf("First zero overlaps reference: PASS\n");
   arb_clear(ref);
+
+  /*
+   * White-box discriminator (FAILS on the broken res[i] code; see the header).
+   * M_error ignores sum_ans, so inflate sum_ans on a fresh handle and call
+   * do_pre_iFFT_errors directly: the fix routes err = eq59*sum_ans onto the
+   * populated bin res[0]; the bug routes it to res[break], later zeroed.
+   */
+  {
+    Lerror_t e = ERR_SUCCESS;
+    Lfunc_t Lw = Lfunc_init(2, 37, 0.5, mus, &e);
+    e |= Lfunc_use_all_lpolys(Lw, lpoly_callback, NULL);
+    assert(!fatal_error(e));
+    Lfunc *Li = (Lfunc *)Lw;
+    arb_set_d(Li->sum_ans, 1e30);   /* err = eq59*sum_ans ~ 1e-33, far above any M_error */
+    acb_set_ui(Li->res[0], 1);      /* unit midpoint: epsilon branch well-defined, |sqrt_sign|=1 */
+    e = do_pre_iFFT_errors(Li);
+    assert(!fatal_error(e));
+    double r0 = mag_get_d(arb_radref(acb_realref(Li->res[0])));
+    printf("res[0] radius after inflated do_pre_iFFT_errors = %.4e\n", r0);
+    /* FIXED: err landed on res[0] -> r0 ~ 1e-33.  BROKEN: err went to res[break]
+     * and was zeroed -> r0 ~ M_error[0] ~ 1e-61.  Threshold 1e-40 has ~7 orders
+     * of margin above the fixed value and ~21 below the broken value. */
+    assert(r0 > 1e-40);
+    Lfunc_clear(Lw);
+    printf("res[j] error-distribution discriminator: PASS\n");
+  }
 
   Lfunc_clear(L);
   printf("PASS: error_propagation_test\n");

--- a/test/gcache_collision_test.c
+++ b/test/gcache_collision_test.c
@@ -1,10 +1,10 @@
 /*
   Regression test for the G-cache filename collision bug.
 
-  compute_g() caches the gamma-factor (G) data to a file named after the
-  L-function's mu's.  The filename must encode *all* the mu's, so that two
-  L-functions with different mu-multisets (in particular different degrees)
-  never share a cache file.
+  compute_g() caches the gamma-factor (G) data.  The filename must encode the
+  data that defines the grid, including degree and *all* the mu's, so that two
+  L-functions with different mu-multisets never share a cache file in normal
+  use.
 
   The bug: the filename was built with a self-overlapping
       sprintf(fname1, "%s_%.1f", fname1, mu)
@@ -52,19 +52,13 @@ static void cleanup_dir(const char *dir) {
 // exp(2 pi (hi_i + 1/2) / B) term directly.
 static uint64_t nmax_in(uint64_t degree, double normalisation,
                         const double *mus, const char *cache_dir) {
-  Lparams_t Lp = {0}; // zero-init: future Lparams_t fields default safely
+  Lparams_t Lp;
+  Lparams_init(&Lp);
   Lp.degree = degree;
   Lp.conductor = 1;
   Lp.normalisation = normalisation;
   Lp.mus = (double *)mus;          // init_advanced only reads from this
-  Lp.target_prec = DEFAULT_TARGET_PREC;  // required for the cache path
-  Lp.rank = DK;
-  Lp.self_dual = DK;
   Lp.cache_dir = (char *)cache_dir;
-  Lp.gprec = 0;                    // required for the cache path
-  Lp.wprec = 0;
-  Lp.max_t = 0;                    // default output window (64/degree)
-  Lp.max_fft_NN = 0;               // default transform-size cap (1<<16)
 
   Lerror_t ecode = ERR_SUCCESS;
   Lfunc_t L = Lfunc_init_advanced(&Lp, &ecode);
@@ -78,7 +72,7 @@ int main(void) {
   // analytic mu's are mus[i] + normalisation:
   //   degree 4: [0,0,1,1] + 0.5 = [0.5, 0.5, 1.5, 1.5]
   //   degree 2: [0,1]     + 0.5 = [0.5, 1.5]
-  // -> both share the largest mu 1.5, so the buggy name collapses both to g_1.5.
+  // -> both share the largest mu 1.5, so the old buggy name collapsed both to g_1.5.
   double mus4[4] = {0.0, 0.0, 1.0, 1.0};
   double mus2[2] = {0.0, 1.0};
 

--- a/test/gcache_collision_test.c
+++ b/test/gcache_collision_test.c
@@ -52,7 +52,7 @@ static void cleanup_dir(const char *dir) {
 // exp(2 pi (hi_i + 1/2) / B) term directly.
 static uint64_t nmax_in(uint64_t degree, double normalisation,
                         const double *mus, const char *cache_dir) {
-  Lparams_t Lp;
+  Lparams_t Lp = {0}; // zero-init: future Lparams_t fields default safely
   Lp.degree = degree;
   Lp.conductor = 1;
   Lp.normalisation = normalisation;

--- a/test/gcache_collision_test.c
+++ b/test/gcache_collision_test.c
@@ -63,6 +63,8 @@ static uint64_t nmax_in(uint64_t degree, double normalisation,
   Lp.cache_dir = (char *)cache_dir;
   Lp.gprec = 0;                    // required for the cache path
   Lp.wprec = 0;
+  Lp.max_t = 0;                    // default output window (64/degree)
+  Lp.max_fft_NN = 0;               // default transform-size cap (1<<16)
 
   Lerror_t ecode = ERR_SUCCESS;
   Lfunc_t L = Lfunc_init_advanced(&Lp, &ecode);

--- a/test/gcache_validate_test.c
+++ b/test/gcache_validate_test.c
@@ -60,7 +60,7 @@ static void cleanup_dir(const char *dir) {
 static bool init_is_fatal(uint64_t degree, double normalisation,
                           const double *mus, int64_t wprec,
                           const char *cache_dir, uint64_t *out_nmax) {
-  Lparams_t Lp;
+  Lparams_t Lp = {0}; // zero-init: future Lparams_t fields default safely
   Lp.degree = degree;
   Lp.conductor = 1;
   Lp.normalisation = normalisation;

--- a/test/gcache_validate_test.c
+++ b/test/gcache_validate_test.c
@@ -1,14 +1,14 @@
 /*
   Regression test for the G-cache staleness footgun (bead lfunctions-fe3).
 
-  compute_g() caches the gamma-factor (G) data to a file named after the
-  L-function's mu's.  The cached grid extent (low_i, hi_i, max_K) and the
-  precision it was computed at (gprec) are a function of (degree, mus, gprec);
-  hi_i and max_K grow monotonically with gprec.  The cache is consulted
-  whenever the *input* gprec is 0 (default mode), but the *effective* gprec is
-  then derived as max(target+gamma+EXTRA_BITS, wprec).  A caller who raises
-  wprec (as one does for a large conductor) therefore needs a higher-precision
-  grid than a default run wrote.
+  compute_g() caches the gamma-factor (G) data.  The cached grid extent
+  (low_i, hi_i, max_K) and the precision it was computed at (gprec) are a
+  function of (degree, mus, window, gprec); hi_i and max_K grow monotonically
+  with gprec.  The cache is consulted whenever the *input* gprec is 0 (default
+  mode), but the *effective* gprec is then derived as
+  max(target+gamma+EXTRA_BITS, wprec).  A caller who raises wprec (as one does
+  for a large conductor) therefore needs a higher-precision grid than a default
+  run wrote.
 
   The bug: read_gfile() validated nothing.  A cheap cache file written by a
   default (wprec=0) run was silently reused by a later run with an elevated
@@ -16,13 +16,11 @@
   result was a silently-truncated grid and wrong numbers, with no error.  The
   documented workaround was "rm -f g_* before running".
 
-  The fix: the cache file carries a self-describing header (magic, version,
-  degree, the sorted mus as exact halved integers, and the gprec it was
-  computed at).  On load the library verifies the file is USABLE for the
-  current request -- same degree and mus, and cached gprec >= required gprec --
-  and, when it is not, recomputes and overwrites the stale file instead of
-  returning wrong numbers.  (A file whose header is valid but whose body is
-  truncated/corrupt is a genuinely broken file and stays a fatal ERR_G_INFILE.)
+  The fix is layered: the filename now includes the cache version, degree,
+  effective gprec, window, and mus, and the file body still carries a
+  self-describing header.  On load the library verifies the file is USABLE for
+  the current request; a file whose header is valid but whose body is
+  truncated/corrupt is a genuinely broken file and stays a fatal ERR_G_INFILE.
 
   We probe at init time via Lfunc_nmax, which reflects hi_i and so reveals an
   undersized grid, exactly as test/gcache_collision_test.c does.
@@ -60,19 +58,14 @@ static void cleanup_dir(const char *dir) {
 static bool init_is_fatal(uint64_t degree, double normalisation,
                           const double *mus, int64_t wprec,
                           const char *cache_dir, uint64_t *out_nmax) {
-  Lparams_t Lp = {0}; // zero-init: future Lparams_t fields default safely
+  Lparams_t Lp;
+  Lparams_init(&Lp);
   Lp.degree = degree;
   Lp.conductor = 1;
   Lp.normalisation = normalisation;
   Lp.mus = (double *)mus;                // init_advanced only reads from this
-  Lp.target_prec = DEFAULT_TARGET_PREC;  // required for the cache path
-  Lp.rank = DK;
-  Lp.self_dual = DK;
   Lp.cache_dir = (char *)cache_dir;
-  Lp.gprec = 0;                          // required for the cache path
   Lp.wprec = wprec;
-  Lp.max_t = 0;                          // default output window (64/degree)
-  Lp.max_fft_NN = 0;                     // default transform-size cap (1<<16)
 
   Lerror_t ecode = ERR_SUCCESS;
   Lfunc_t L = Lfunc_init_advanced(&Lp, &ecode);
@@ -137,9 +130,8 @@ int main(void) {
   assert(!fatal_stale);
   assert(nmax_stale == nmax_hi);
 
-  // Sufficiency, not equality: a grid written at HIGH precision must satisfy a
-  // later DEFAULT request (cached gprec >= required gprec), so it is reused
-  // rather than rejected.  Guards the fix against over-rejecting usable caches.
+  // The filename includes effective gprec, so a later DEFAULT request writes its
+  // own default-precision cache instead of touching the high-precision file.
   char dir_over[] = "./gcache_over_XXXXXX";
   assert(mkdtemp(dir_over) != NULL);
   uint64_t nmax_seed_hi = 0, nmax_reuse_lo = 0;
@@ -147,7 +139,8 @@ int main(void) {
   bool fatal_reuse_lo = init_is_fatal(2, norm, mus2, 0,        dir_over, &nmax_reuse_lo);
   cleanup_dir(dir_over);
   assert(!fatal_seed_hi);
-  assert(!fatal_reuse_lo);      // over-sufficient cache reused, not rejected
+  assert(!fatal_reuse_lo);
+  assert(nmax_reuse_lo == nmax_default);
 
   // No happy-path regression: a matching cache is reused and gives the same
   // answer as a pristine run.
@@ -162,6 +155,6 @@ int main(void) {
   assert(nmax_w1 == nmax_default);   // first (pristine) run matches reference
   assert(nmax_w2 == nmax_default);   // cache reuse gives the identical answer
 
-  printf("PASS: stale G cache rejected; sufficient/matching caches reused\n");
+  printf("PASS: stale G cache avoided; matching caches reused\n");
   return 0;
 }

--- a/test/gcache_validate_test.c
+++ b/test/gcache_validate_test.c
@@ -71,6 +71,8 @@ static bool init_is_fatal(uint64_t degree, double normalisation,
   Lp.cache_dir = (char *)cache_dir;
   Lp.gprec = 0;                          // required for the cache path
   Lp.wprec = wprec;
+  Lp.max_t = 0;                          // default output window (64/degree)
+  Lp.max_fft_NN = 0;                     // default transform-size cap (1<<16)
 
   Lerror_t ecode = ERR_SUCCESS;
   Lfunc_t L = Lfunc_init_advanced(&Lp, &ecode);

--- a/test/highdeg_check.cpp
+++ b/test/highdeg_check.cpp
@@ -67,21 +67,18 @@ int main(int argc, char **argv) {
   for (auto &m : mus) s2 >> m;
 
   // Public advanced init so self-duality is declared up front instead of poking
-  // the opaque handle. Mirrors Lfunc_init's defaults (target_prec=DEFAULT and
-  // gprec=0 keep the G-cache active, see src/g.c); Lfunc_init_advanced copies
-  // Lp.mus, so the local vector suffices, and cache_dir outlives the Lfunc.
+  // the opaque handle. Lparams_init mirrors Lfunc_init's defaults (target_prec=
+  // DEFAULT and gprec=0 keep the G-cache active, see src/g.c); Lfunc_init_advanced
+  // copies Lp.mus, so the local vector suffices, and cache_dir outlives the Lfunc.
   Lerror_t ec = 0;
   char cache_dir[] = ".";
-  Lparams_t Lp = {}; // zero-init so the window fields (max_t/max_fft_NN) default to 0
+  Lparams_t Lp;
+  Lparams_init(&Lp);
   Lp.degree = degree;
   Lp.conductor = conductor;
   Lp.normalisation = norm;
   Lp.mus = mus.data();
-  Lp.target_prec = DEFAULT_TARGET_PREC;
-  Lp.wprec = 0;
-  Lp.gprec = 0;
   Lp.self_dual = self_dual ? YES : DK;
-  Lp.rank = DK;
   Lp.cache_dir = cache_dir;
   Lfunc_t L = Lfunc_init_advanced(&Lp, &ec);
   if (fatal_error(ec)) { fprint_errors(stderr, ec); return 1; }

--- a/test/highdeg_check.cpp
+++ b/test/highdeg_check.cpp
@@ -72,7 +72,7 @@ int main(int argc, char **argv) {
   // Lp.mus, so the local vector suffices, and cache_dir outlives the Lfunc.
   Lerror_t ec = 0;
   char cache_dir[] = ".";
-  Lparams_t Lp;
+  Lparams_t Lp = {}; // zero-init so the window fields (max_t/max_fft_NN) default to 0
   Lp.degree = degree;
   Lp.conductor = conductor;
   Lp.normalisation = norm;

--- a/test/turing_static_cache_test.c
+++ b/test/turing_static_cache_test.c
@@ -59,9 +59,10 @@ static Lerror_t run(long av[5], uint64_t cond, long bad, long apbad, int sym,
   for (int i = 0; i < 5; i++) g_ainvs[i] = av[i];
   g_bad = bad; g_apbad = apbad; g_sym = sym;
   Lerror_t ec = 0; char cd[] = ".";
-  Lparams_t Lp = {0};
+  Lparams_t Lp;
+  Lparams_init(&Lp);
   Lp.degree = deg; Lp.conductor = cond; Lp.normalisation = norm; Lp.mus = mus;
-  Lp.target_prec = DEFAULT_TARGET_PREC; Lp.self_dual = YES; Lp.rank = DK; Lp.cache_dir = cd;
+  Lp.self_dual = YES; Lp.cache_dir = cd;
   Lfunc_t L = Lfunc_init_advanced(&Lp, &ec);
   ec |= Lfunc_use_all_lpolys(L, cb, NULL);
   ec |= Lfunc_compute(L);

--- a/test/window_geometry_test.cpp
+++ b/test/window_geometry_test.cpp
@@ -1,0 +1,103 @@
+// Init-only regression tests for configurable output-window geometry.
+#include "glfunc.h"
+#include "glfunc_internals.h"
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+using std::vector;
+
+// Synthetic degree-r object (mus all 0, normalisation 0.5 => analytic mus all
+// 0.5) at a chosen window/cap. B / one_over_B / fft_NN / A depend only on degree
+// and H, so no Euler factors or compute are needed. A non-zero gprec bypasses
+// the on-disk G-cache and keeps this init-only sweep fast.
+static Lfunc_t geo_init(uint64_t degree, double max_t, uint64_t max_fft_NN, Lerror_t *ecode) {
+  vector<double> mus(degree, 0.0);
+  Lparams_t Lp;
+  Lparams_init(&Lp);
+  Lp.degree = degree;
+  Lp.conductor = 11;
+  Lp.normalisation = 0.5;
+  Lp.mus = mus.data();
+  Lp.gprec = 30;
+  Lp.cache_dir = NULL;
+  Lp.max_t = max_t;
+  Lp.max_fft_NN = max_fft_NN;
+  *ecode = ERR_SUCCESS;
+  return Lfunc_init_advanced(&Lp, ecode); // copies mus
+}
+
+int main() {
+  // Power-of-two geometry sweep. For degree r and H = 2^k/r, the geometry is
+  // forced to exact powers of two:
+  //   B = 2^(k+3)/r, one_over_B = r/2^(k+3), fft_NN = 2^(k+10), A = 128*r.
+  for (uint64_t r = 2; r <= (uint64_t)MAX_DEGREE; ++r) {
+    for (int k = 1; k <= 9; ++k) {
+      double H = ldexp(1.0, k) / (double)r;
+      Lerror_t ecg;
+      Lfunc_t Lg = geo_init(r, H, (uint64_t)1 << 20, &ecg);
+      if (fatal_error(ecg)) {
+        assert(ecg & ERR_WINDOW_TOO_SMALL);
+        if (Lg) Lfunc_clear(Lg);
+        continue;
+      }
+      Lfunc *G = (Lfunc*)Lg;
+      assert(G->fft_NN == ((uint64_t)1 << (k + 10)));
+      assert(G->one_over_B == (double)r / ldexp(1.0, k + 3));
+      assert(G->A == 128.0 * (double)r);
+      double reach_out = (double)G->fft_NN / ((double)OUTPUT_RATIO * G->A);
+      assert(reach_out == H);
+      double reach_tur = ((double)(G->fft_NN / OUTPUT_RATIO) + (double)(G->fft_NN / TURING_RATIO)) / G->A;
+      assert(fabs(reach_tur - 1.5 * H) <= 1e-12 * (1.5 * H));
+      Lfunc_clear(Lg);
+    }
+  }
+  printf("geometry-sweep ok\n");
+
+  // Explicit H = 64/r reproduces the sentinel default geometry.
+  for (uint64_t r = 2; r <= (uint64_t)MAX_DEGREE; ++r) {
+    Lerror_t es, ee;
+    Lfunc_t Ls = geo_init(r, 0.0, 0, &es);
+    Lfunc_t Le = geo_init(r, 64.0 / (double)r, (uint64_t)1 << 20, &ee);
+    assert(!fatal_error(es) && !fatal_error(ee));
+    Lfunc *S = (Lfunc*)Ls, *E = (Lfunc*)Le;
+    assert(S->fft_NN == ((uint64_t)1 << 16) && E->fft_NN == S->fft_NN);
+    assert(E->one_over_B == S->one_over_B);
+    assert(E->A == S->A && S->A == 128.0 * (double)r);
+    Lfunc_clear(Ls); Lfunc_clear(Le);
+  }
+  printf("explicit-default ok\n");
+
+  // H = 128/r needs fft_NN = 2^17: a 2^16 cap rejects, a 2^17 cap admits.
+  for (uint64_t r = 2; r <= (uint64_t)MAX_DEGREE; ++r) {
+    double H = 128.0 / (double)r;
+    Lerror_t e1, e2;
+    Lfunc_t L1 = geo_init(r, H, (uint64_t)1 << 16, &e1);
+    assert(e1 & ERR_WINDOW_TOO_LARGE);
+    if (L1) Lfunc_clear(L1);
+    Lfunc_t L2 = geo_init(r, H, (uint64_t)1 << 17, &e2);
+    assert(!fatal_error(e2));
+    assert(((Lfunc*)L2)->fft_NN == ((uint64_t)1 << 17));
+    Lfunc_clear(L2);
+  }
+  printf("cap-threshold ok\n");
+
+  // Just above 64/r the required length rounds up to 2^17; just below it stays
+  // at 2^16. In both non-default cases A = fft_NN/(8H), not exactly 128*r.
+  for (uint64_t r = 2; r <= (uint64_t)MAX_DEGREE; ++r) {
+    double A128 = 128.0 * (double)r;
+    Lerror_t eu, eb;
+    Lfunc_t Lu = geo_init(r, 64.0 / (double)r + 1.0 / 1024.0, (uint64_t)1 << 20, &eu);
+    assert(!fatal_error(eu));
+    assert(((Lfunc*)Lu)->fft_NN == ((uint64_t)1 << 17) && ((Lfunc*)Lu)->A > A128);
+    Lfunc_clear(Lu);
+    Lfunc_t Lb = geo_init(r, 64.0 / (double)r - 1.0 / 1024.0, (uint64_t)1 << 20, &eb);
+    assert(!fatal_error(eb));
+    assert(((Lfunc*)Lb)->fft_NN == ((uint64_t)1 << 16) && ((Lfunc*)Lb)->A > A128);
+    Lfunc_clear(Lb);
+  }
+  printf("round-boundary ok\n");
+
+  return 0;
+}

--- a/test/window_test.cpp
+++ b/test/window_test.cpp
@@ -30,7 +30,7 @@ static void cb(acb_poly_t poly, uint64_t p, int, int64_t, void*) {
 // cache_dir so runs never poison each other. Returns the accumulated ecode.
 static Lfunc_t build_37(double max_t, uint64_t max_fft_NN, const char *cache_dir, Lerror_t *ecode) {
   static double mus[2] = {0,1};
-  Lparams_t Lp;
+  Lparams_t Lp = {}; // zero-init: future Lparams_t fields default safely
   Lp.degree = 2; Lp.conductor = 37; Lp.normalisation = 0.5; Lp.mus = mus;
   Lp.target_prec = DEFAULT_TARGET_PREC; Lp.wprec = 0; Lp.gprec = 0;
   Lp.self_dual = DK; Lp.rank = DK; Lp.cache_dir = (char*)cache_dir;

--- a/test/window_test.cpp
+++ b/test/window_test.cpp
@@ -33,6 +33,60 @@ static void cb(acb_poly_t poly, uint64_t p, int, int64_t, void*) {
       acb_poly_set_coeff_si(poly, i, it->second[i]);
 }
 
+// Same ec_37.a1, but supply the ANALYTIC Euler-factor coefficients a_m * p^{-m/2}
+// instead of the algebraic a_m. Combined with normalisation = 0 and analytic mus
+// {0.5,1.5}, this reconstructs the SAME analytic L-function that (algebraic coeffs,
+// normalisation = 0.5, mus {0,1}) produces: the library multiplies coefficient m by
+// p^{-m*normalisation} (coeff.c), so {a_m, norm 0.5} and {a_m*p^{-m/2}, norm 0} feed
+// identical Dirichlet coefficients, and L->mus = mus + norm is {0.5,1.5} either way.
+// Used by the equivalent-(mus,normalisation) window invariant below.
+static void cb_anal(acb_poly_t poly, uint64_t p, int, int64_t prec, void*) {
+  acb_poly_zero(poly);
+  auto it = ef.find((int64_t)p);
+  if (it == ef.end()) return;
+  arb_t lp, sc, tm, half; arb_init(lp); arb_init(sc); arb_init(tm); arb_init(half);
+  arb_log_ui(lp, p, prec);
+  acb_t c; acb_init(c);
+  for (size_t m = 0; m < it->second.size(); ++m) {
+    arb_set_d(half, -0.5 * (double)m);
+    arb_mul(tm, lp, half, prec);             // -(m/2) log p
+    arb_exp(sc, tm, prec);                    // p^{-m/2}
+    arb_mul_si(sc, sc, it->second[m], prec);  // a_m * p^{-m/2}
+    acb_set_arb(c, sc);
+    acb_poly_set_coeff_acb(poly, (slong)m, c);
+  }
+  arb_clear(lp); arb_clear(sc); arb_clear(tm); arb_clear(half); acb_clear(c);
+}
+
+// Like build_37 but with caller-chosen normalisation, mus, self_dual, rank, and
+// Euler-factor callback, so the invariants below can vary exactly one axis at a
+// fixed window. Returns the accumulated ecode (see build_37 for the cache note).
+typedef void (*wt_cbfn)(acb_poly_t, uint64_t, int, int64_t, void*);
+static Lfunc_t build_37_full(double max_t, uint64_t max_fft_NN, double normalisation,
+                             double *mus, int self_dual, int rank, wt_cbfn f,
+                             const char *cache_dir, Lerror_t *ecode) {
+  Lparams_t Lp = {};
+  Lp.degree = 2; Lp.conductor = 37; Lp.normalisation = normalisation; Lp.mus = mus;
+  Lp.target_prec = DEFAULT_TARGET_PREC; Lp.wprec = 0; Lp.gprec = 0;
+  Lp.self_dual = self_dual; Lp.rank = rank; Lp.cache_dir = (char*)cache_dir;
+  Lp.max_t = max_t; Lp.max_fft_NN = max_fft_NN;
+  mkdir(cache_dir, 0777);
+  *ecode = ERR_SUCCESS;
+  Lfunc_t L = Lfunc_init_advanced(&Lp, ecode);
+  if (fatal_error(*ecode)) return L;
+  *ecode |= Lfunc_use_all_lpolys(L, f, NULL);
+  if (fatal_error(*ecode)) return L;
+  *ecode |= Lfunc_compute(L);
+  return L;
+}
+
+// Count the (contiguous, zero-terminated) zeros stored on a side.
+static int wt_count_zeros(Lfunc_t L, uint64_t side) {
+  int n = 0;
+  while (n < (int)MAX_ZEROS && !arb_is_zero(Lfunc_zeros(L, side) + n)) n++;
+  return n;
+}
+
 // Build ec_37.a1 via the advanced API at a given window and cap, in a private
 // cache_dir so runs never poison each other. Returns the accumulated ecode.
 static Lfunc_t build_37(double max_t, uint64_t max_fft_NN, const char *cache_dir, Lerror_t *ecode) {
@@ -406,6 +460,171 @@ int main() {
     Lfunc_clear(Ls);
   }
   printf("shrink ok\n");
+
+  // ---- special_value + Taylor are window-invariant AND match known values ----
+  // The existing enlarge test (task3) only checks ZEROS overlap between default and
+  // enlarged. Lfunc_special_value and Lfunc_Taylor exercise different windowed code:
+  // both upsample off u_values_off using L->A = fft_NN/B, which scales with the window
+  // (default fft_NN=2^16 vs enlarged 2^17 here, with a smaller 1/B). The L-value at a
+  // fixed point and the central Taylor coefficient are mathematical invariants of the
+  // L-function, so they MUST agree across windows -- and must contain the independently
+  // known constants (LMFDB / examples/ec_37.a1.cpp):
+  //   L(1.5) = 0.18396547525832984973...  (algebraic arg 1.5; analytic 1.0)
+  //   L'(1/2)/1! = 0.305999773834052301820483683321676474452637774590772 (BSD).
+  // If the window-dependent A (or anything it feeds) were wrong at the enlarged window,
+  // the value would shift off the golden constant and/or stop overlapping the default.
+  {
+    Lerror_t ecd, ece;
+    Lfunc_t Lsv_def = build_37(0.0, 0, "build/wt_cache_sv_def", &ecd);
+    assert(!fatal_error(ecd));
+    Lfunc_t Lsv_enl = build_37(48.0, (uint64_t)1<<18, "build/wt_cache_sv_enl", &ece);
+    assert(!fatal_error(ece));
+
+    acb_t vdef, venl; acb_init(vdef); acb_init(venl);
+    assert(!fatal_error(Lfunc_special_value(vdef, Lsv_def, 1.5, 0.0)));
+    assert(!fatal_error(Lfunc_special_value(venl, Lsv_enl, 1.5, 0.0)));
+
+    // Each windowed value contains the known L(1.5).
+    acb_t lref; acb_init(lref);
+    arb_set_str(acb_realref(lref), "0.18396547525832984973", 300);
+    arb_zero(acb_imagref(lref));
+    arb_add_error_2exp_si(acb_realref(lref), -50);
+    arb_add_error_2exp_si(acb_imagref(lref), -50);
+    assert(acb_overlaps(vdef, lref));
+    assert(acb_overlaps(venl, lref));
+    // ... and they contain each other (window invariance of the L-value).
+    assert(acb_overlaps(vdef, venl));
+    acb_clear(lref);
+
+    // The two computes are genuinely distinct objects, not the same handle: the
+    // enlarged window's A differs, so its certified radius differs from the
+    // default's (non-vacuous overlap). (default re-radius ~2.9e-39, enlarged ~8e-41.)
+    double rd = mag_get_d(arb_radref(acb_realref(vdef)));
+    double re = mag_get_d(arb_radref(acb_realref(venl)));
+    assert(rd > 0.0 && re > 0.0 && rd != re);
+    acb_clear(vdef); acb_clear(venl);
+
+    // Taylor: central-point invariant, contains BSD, and overlaps across windows.
+    arb_t bsd; arb_init(bsd);
+    arb_set_str(bsd, "0.305999773834052301820483683321676474452637774590771998534541832481", 300);
+    arb_add_error_2exp_si(bsd, -100);
+    assert(arb_overlaps(Lfunc_Taylor(Lsv_def), bsd));
+    assert(arb_overlaps(Lfunc_Taylor(Lsv_enl), bsd));
+    assert(arb_overlaps(Lfunc_Taylor(Lsv_def), Lfunc_Taylor(Lsv_enl)));
+    arb_clear(bsd);
+
+    Lfunc_clear(Lsv_def); Lfunc_clear(Lsv_enl);
+  }
+  printf("special-value-window ok\n");
+
+  // ---- equivalent (mus, normalisation) at a NON-default window => equal output ----
+  // CLAUDE.md: for a weight-2 EC, {mus=[0,1], norm=0.5} and {mus=[0.5,1.5], norm=0}
+  // describe the SAME analytic L-function (provided the Euler factors are given in
+  // the matching normalisation -- see cb_anal). The window geometry must depend only
+  // on the analytic data (L->mus = mus + norm = {0.5,1.5} both ways, and 1/B from H),
+  // never on how the caller split it. So at H=48 the rank, every zero, and the central
+  // Taylor coefficient must coincide. Non-vacuous: the two inputs drive different code
+  // (coeff.c normalises by p^{-m*norm}; the mus split differs) -- supplying the SAME
+  // algebraic coeffs with norm=0 instead yields a DIFFERENT L-function (rank 0 here),
+  // so a regression that mixed the split into the geometry would break the overlap.
+  {
+    static double mus_a[2] = {0.0, 1.0};       // norm 0.5  -> analytic mus {0.5,1.5}
+    static double mus_b[2] = {0.5, 1.5};       // norm 0.0  -> analytic mus {0.5,1.5}
+    Lerror_t eca, ecb;
+    Lfunc_t La = build_37_full(48.0, (uint64_t)1<<18, 0.5, mus_a, DK, DK, cb,
+                               "build/wt_cache_eqv_a", &eca);
+    assert(!fatal_error(eca));
+    Lfunc_t Lb = build_37_full(48.0, (uint64_t)1<<18, 0.0, mus_b, DK, DK, cb_anal,
+                               "build/wt_cache_eqv_b", &ecb);
+    assert(!fatal_error(ecb));
+
+    assert(Lfunc_rank(La) == 1);
+    assert(Lfunc_rank(Lb) == 1);
+    int na = wt_count_zeros(La, 0), nb = wt_count_zeros(Lb, 0);
+    assert(na > 0 && na == nb);                 // same number of zeros found
+    for (int i = 0; i < na; ++i)
+      assert(arb_overlaps(Lfunc_zeros(La,0)+i, Lfunc_zeros(Lb,0)+i));
+    // central Taylor coefficient (analytic central point is 1/2 in both splits)
+    assert(arb_overlaps(Lfunc_Taylor(La), Lfunc_Taylor(Lb)));
+    // |eps| = 1 for both
+    for (Lfunc_t Lx : {La, Lb}) {
+      arb_t m; arb_init(m); acb_abs(m, Lfunc_sign(Lx), 100);
+      arb_sub_ui(m, m, 1, 100); assert(arb_contains_zero(m)); arb_clear(m);
+    }
+    Lfunc_clear(La); Lfunc_clear(Lb);
+  }
+  printf("equiv-normalisation ok\n");
+
+  // ---- self_dual declared YES vs computed (DK), and side 0 vs side 1, at H=48 ----
+  // ec_37.a1 IS self-dual. Declaring self_dual=YES makes compute.c skip find_zeros
+  // for the dual (side 1); leaving it DK computes both sides. The certified side-0
+  // output (rank, zeros, Taylor) must be identical whether or not the dual is also
+  // computed -- the declaration only saves work, it must not change the answer. And
+  // because the object is self-dual, side 1 (built from res[(-nn)%fft_NN] in copy())
+  // must reproduce side 0 exactly. Both are strong cross-checks at a non-default
+  // window. Non-vacuous: side 1 is computed from a different index path than side 0,
+  // and the YES build takes a different control-flow branch.
+  {
+    static double mus[2] = {0,1};
+    Lerror_t edk, eyes;
+    Lfunc_t Ldk = build_37_full(48.0, (uint64_t)1<<18, 0.5, mus, DK, DK, cb,
+                                "build/wt_cache_sd_dk", &edk);
+    assert(!fatal_error(edk));
+    Lfunc_t Lyes = build_37_full(48.0, (uint64_t)1<<18, 0.5, mus, YES, DK, cb,
+                                 "build/wt_cache_sd_yes", &eyes);
+    assert(!fatal_error(eyes));
+
+    // YES vs DK agree on side 0.
+    assert(Lfunc_rank(Lyes) == Lfunc_rank(Ldk));
+    int ndk = wt_count_zeros(Ldk, 0), nyes = wt_count_zeros(Lyes, 0);
+    assert(ndk > 0 && ndk == nyes);
+    for (int i = 0; i < ndk; ++i)
+      assert(arb_overlaps(Lfunc_zeros(Lyes,0)+i, Lfunc_zeros(Ldk,0)+i));
+    assert(arb_overlaps(Lfunc_Taylor(Lyes), Lfunc_Taylor(Ldk)));
+
+    // self_dual=YES skipped the dual: side 1 is empty. DK computed it: side 1 is not.
+    assert(wt_count_zeros(Lyes, 1) == 0);
+    int ndk1 = wt_count_zeros(Ldk, 1);
+    assert(ndk1 == ndk);
+    // side 0 and side 1 of the self-dual object coincide zero-for-zero.
+    for (int i = 0; i < ndk; ++i)
+      assert(arb_overlaps(Lfunc_zeros(Ldk,0)+i, Lfunc_zeros(Ldk,1)+i));
+
+    Lfunc_clear(Ldk); Lfunc_clear(Lyes);
+  }
+  printf("self-dual-window ok\n");
+
+  // ---- supplied rank vs computed rank at H=48 => same zeros / Taylor ----
+  // Telling the library rank=1 up front (its true rank) must not change the certified
+  // output versus letting it determine the rank (DK). The supplied value only short-
+  // circuits do_rank; the zeros and the leading Taylor coefficient must be unchanged.
+  // Non-vacuous: rank feeds the central-derivative bookkeeping (compute.c divides
+  // L_d by i! up to rank), so a regression coupling rank into the wrong place would
+  // shift Lfunc_Taylor off the DK value and off BSD.
+  {
+    static double mus[2] = {0,1};
+    Lerror_t edk, er1;
+    Lfunc_t Ldk = build_37_full(48.0, (uint64_t)1<<18, 0.5, mus, DK, DK, cb,
+                                "build/wt_cache_rk_dk", &edk);
+    assert(!fatal_error(edk));
+    Lfunc_t Lr1 = build_37_full(48.0, (uint64_t)1<<18, 0.5, mus, DK, 1, cb,
+                                "build/wt_cache_rk_1", &er1);
+    assert(!fatal_error(er1));
+
+    assert(Lfunc_rank(Lr1) == 1 && Lfunc_rank(Ldk) == 1);
+    int ndk = wt_count_zeros(Ldk, 0), nr1 = wt_count_zeros(Lr1, 0);
+    assert(ndk > 0 && ndk == nr1);
+    for (int i = 0; i < ndk; ++i)
+      assert(arb_overlaps(Lfunc_zeros(Lr1,0)+i, Lfunc_zeros(Ldk,0)+i));
+    assert(arb_overlaps(Lfunc_Taylor(Lr1), Lfunc_Taylor(Ldk)));
+    arb_t bsd; arb_init(bsd);
+    arb_set_str(bsd, "0.305999773834052301820483683321676474452637774590771998534541832481", 300);
+    arb_add_error_2exp_si(bsd, -100);
+    assert(arb_overlaps(Lfunc_Taylor(Lr1), bsd));
+    arb_clear(bsd);
+    Lfunc_clear(Ldk); Lfunc_clear(Lr1);
+  }
+  printf("supplied-rank-window ok\n");
 
   Lfunc_clear(L);
   return 0;

--- a/test/window_test.cpp
+++ b/test/window_test.cpp
@@ -235,6 +235,33 @@ int main() {
   }
   printf("highcond ok\n");
 
+  // ---- df_zero static (pi*A)^d cache must not go stale across windows (bead 1yx) ----
+  // df_zero (src/rank.c) recomputed a_pi_d[i] = (pi*A)^i only when the working
+  // precision INCREASED -- keyed on prec, not on A. A = fft_NN/B varies per window,
+  // so computing an enlarged object (higher precision, larger A) before a default
+  // object of the SAME degree in one process left the default reading the enlarged
+  // object's (pi*A)^d: its Lfunc_Taylor came back scaled by A_enlarge/A_default
+  // (0.408 vs 0.306 here), a certified ball NOT containing the truth, raised with
+  // only a non-fatal warning. The other tests miss it because none computes a
+  // lower-precision window after a higher-precision one. (The companion turing.c
+  // stale-cache half of 1yx -- a spurious, non-fatal ERR_RH_ERROR on the second
+  // object -- is owned by branch fix/turing-static-cache and is tolerated here.)
+  {
+    Lerror_t ece, ecd;
+    Lfunc_t Le2 = build_37(48.0, (uint64_t)1<<18, "build/wt_cache_1yx_big", &ece); // enlarge FIRST
+    assert(!fatal_error(ece));
+    Lfunc_t Ld2 = build_37(0.0, 0, "build/wt_cache_1yx_def", &ecd);                 // default SECOND
+    assert(!fatal_error(ecd));
+    arb_t bsd; arb_init(bsd);
+    arb_set_str(bsd, "0.305999773834052301820483683321676474452637774590771998534541832481", 300);
+    arb_add_error_2exp_si(bsd, -100); // generous: the bug is a ~33% scale error, not ulps
+    assert(arb_overlaps(Lfunc_Taylor(Le2), bsd));  // enlarged object's leading Taylor is correct
+    assert(arb_overlaps(Lfunc_Taylor(Ld2), bsd));  // default-after-enlarge correct (fails on broken df_zero)
+    arb_clear(bsd);
+    Lfunc_clear(Le2); Lfunc_clear(Ld2);
+  }
+  printf("multiwindow-taylor ok\n");
+
   // ---- bead 31c.6: a cache written for one window must not poison another ----
   //
   // The on-disk G-cache filename is keyed only on mus, so two windows with the

--- a/test/window_test.cpp
+++ b/test/window_test.cpp
@@ -116,12 +116,23 @@ int main() {
   Lfunc_t L = build_37(0.0, 0, "build/wt_cache_default", &ec);
   assert(!fatal_error(ec));
   assert(Lfunc_rank(L) == 1);
-  arb_t z0ref; arb_init(z0ref);
-  arb_set_str(z0ref, "5.0031700140066586953", 300);
-  arb_add_error_2exp_si(z0ref, -50);
-  assert(arb_overlaps(Lfunc_zeros(L,0) + 0, z0ref));
-  arb_clear(z0ref);
-  printf("task1 ok\n");
+  // Cross-check the default-window zeros against LMFDB (bead 31c.8 validation):
+  // EllipticCurve/Q/37/a positive_zeros lists 13 zeros (to t~19.81) at ~16 sig figs;
+  // allow 2^-44 (~5.7e-14) for LMFDB's last-digit uncertainty. The enlarge run (task3)
+  // reproduces these and extends past LMFDB's range, validated by overlap + |eps|=1.
+  static const char *lmfdb_zeros[13] = {
+    "5.003170014006659","6.870391216954432","8.014330807872879","9.933098353605352",
+    "10.77513816254080","11.75732472284978","12.95838641388285","15.60385787320432",
+    "16.19201741687448","17.14169364801487","18.06365420291071","18.78719562466392",
+    "19.81482224536338"};
+  for (int i = 0; i < 13; ++i) {
+    arb_t ref; arb_init(ref);
+    arb_set_str(ref, lmfdb_zeros[i], 300);
+    arb_add_error_2exp_si(ref, -44);
+    assert(arb_overlaps(Lfunc_zeros(L,0) + i, ref));
+    arb_clear(ref);
+  }
+  printf("task1 ok (13 zeros vs LMFDB)\n");
 
   // Task 2: an explicit max_t equal to the default reproduces the sentinel result.
   Lerror_t ec2;

--- a/test/window_test.cpp
+++ b/test/window_test.cpp
@@ -200,6 +200,17 @@ int main() {
     assert(fatal_error(ecm));
     if (Lm) Lfunc_clear(Lm);
   }
+  // (Lower-bound 2b) The beta-preflight branch, distinct from B <= 0.5+mu_max:
+  // tau at H=0.91 gives B=7.28 > 7.0, clearing the B > 0.5+mu_max double guard, but
+  // the ftwiddle beta interval is non-positive, so the side-effect-free beta preflight
+  // must still reject it (ERR_WINDOW_TOO_SMALL). Locks in spec test (e).
+  {
+    Lerror_t ecb;
+    Lfunc_t Lb = build_tau(0.91, "build/wt_cache_tau_b", &ecb);
+    assert(ecb & ERR_WINDOW_TOO_SMALL);
+    assert(fatal_error(ecb));
+    if (Lb) Lfunc_clear(Lb);
+  }
   printf("tau ok\n");
 
   Lfunc_clear(L);

--- a/test/window_test.cpp
+++ b/test/window_test.cpp
@@ -1,8 +1,11 @@
 // Regression test for the configurable output window (bead lfunctions-31c).
 #include <flint/acb_poly.h>
+#include <flint/arith.h>
+#include <flint/fmpz.h>
 #include "glfunc.h"
 #include "glfunc_internals.h"
 #include <cassert>
+#include <cmath>
 #include <cstdio>
 #include <map>
 #include <vector>
@@ -43,6 +46,60 @@ static Lfunc_t build_37(double max_t, uint64_t max_fft_NN, const char *cache_dir
   *ecode |= Lfunc_use_all_lpolys(L, cb, NULL);
   if (fatal_error(*ecode)) return L;
   *ecode |= Lfunc_compute(L);
+  return L;
+}
+
+// init-only ec_37.a1 at a given window/cap. Used to confirm that a rejected
+// (NaN / huge / sub-floor) window fails LOUD at Lfunc_init_advanced itself,
+// fast, before any Euler factors or compute.
+static Lfunc_t init_only_37(double max_t, uint64_t max_fft_NN, const char *cache_dir, Lerror_t *ecode) {
+  static double mus[2] = {0,1};
+  Lparams_t Lp = {};
+  Lp.degree = 2; Lp.conductor = 37; Lp.normalisation = 0.5; Lp.mus = mus;
+  Lp.target_prec = DEFAULT_TARGET_PREC; Lp.wprec = 0; Lp.gprec = 0;
+  Lp.self_dual = DK; Lp.rank = DK; Lp.cache_dir = (char*)cache_dir;
+  Lp.max_t = max_t; Lp.max_fft_NN = max_fft_NN;
+  *ecode = ERR_SUCCESS;
+  return Lfunc_init_advanced(&Lp, ecode);
+}
+
+// Ramanujan tau: degree 2, conductor 1, motivic weight 11 in the algebraic
+// normalisation. As in examples/tau.cpp we run it analytically with
+// normalisation 5.5, mus {0,1}, so the analytic mus are {5.5,6.5} and
+// mu_max = 6.5. The Euler poly at p is 1 - tau(p) x + p^11 x^2, stored as
+// coefficients {1, -tau(p), p^11} (tau(p) via FLINT arith_ramanujan_tau).
+// build_tau only needs to reach init: the B <= 0.5+mu_max guard fires from the
+// conductor/normalisation/mus alone, before any Euler factor is consumed.
+static void tau_cb(acb_poly_t poly, uint64_t p, int, int64_t, void*) {
+  acb_poly_zero(poly);
+  fmpz_t n, t, pk;
+  acb_t c;
+  fmpz_init(n); fmpz_init(t); fmpz_init(pk); acb_init(c);
+  fmpz_set_ui(n, p);
+  arith_ramanujan_tau(t, n);          // tau(p)
+  fmpz_neg(t, t);                     // -tau(p)
+  fmpz_set_ui(pk, p);
+  fmpz_pow_ui(pk, pk, 11);            // p^11
+  acb_poly_set_coeff_si(poly, 0, 1);
+  acb_set_fmpz(c, t);  acb_poly_set_coeff_acb(poly, 1, c);
+  acb_set_fmpz(c, pk); acb_poly_set_coeff_acb(poly, 2, c);
+  fmpz_clear(n); fmpz_clear(t); fmpz_clear(pk); acb_clear(c);
+}
+
+// Build tau via the advanced API at a given window. init may already reject the
+// window (the B/mu floor); only if init succeeds do we supply factors. Returns
+// the accumulated ecode; on a too-small window it is fatal straight out of init.
+static Lfunc_t build_tau(double max_t, const char *cache_dir, Lerror_t *ecode) {
+  static double mus[2] = {0,1};
+  Lparams_t Lp = {};
+  Lp.degree = 2; Lp.conductor = 1; Lp.normalisation = 5.5; Lp.mus = mus;
+  Lp.target_prec = DEFAULT_TARGET_PREC; Lp.wprec = 0; Lp.gprec = 0;
+  Lp.self_dual = DK; Lp.rank = DK; Lp.cache_dir = (char*)cache_dir;
+  Lp.max_t = max_t; Lp.max_fft_NN = 0;
+  *ecode = ERR_SUCCESS;
+  Lfunc_t L = Lfunc_init_advanced(&Lp, ecode);
+  if (fatal_error(*ecode)) return L;
+  *ecode |= Lfunc_use_all_lpolys(L, tau_cb, NULL);
   return L;
 }
 
@@ -96,6 +153,54 @@ int main() {
     assert(arb_overlaps(Lfunc_zeros(Lbig,0)+i, Lfunc_zeros(L,0)+i));
   Lfunc_clear(Lbig);
   printf("task3 ok\n");
+
+  // ---- bead 31c.4: every rejected/degenerate window must fail LOUD and fast ----
+
+  // (B3) A NaN max_t must NOT silently fall through to the default window. It is
+  // a caller error and must be fatal (not a successful default-window build).
+  {
+    Lerror_t ecn;
+    Lfunc_t Ln = init_only_37(NAN, 0, "build/wt_cache_nan", &ecn);
+    assert(fatal_error(ecn));
+    if (Ln) Lfunc_clear(Ln);
+  }
+  printf("nan ok\n");
+
+  // (B3) A huge max_t overflows the required sample count; it must be fatal
+  // ERR_WINDOW_TOO_LARGE and must return immediately (no hang / no wraparound).
+  {
+    Lerror_t ech;
+    Lfunc_t Lh = init_only_37(1e17, 0, "build/wt_cache_huge", &ech);
+    assert(ech & ERR_WINDOW_TOO_LARGE);
+    assert(fatal_error(ech));
+    if (Lh) Lfunc_clear(Lh);
+  }
+  printf("huge ok\n");
+
+  // (Lower-bound 1) A tiny max_t at degree 2 yields want_fft_NN below the fft_N
+  // floor (1<<11); that is a heap-overflow geometry and must be fatal
+  // ERR_WINDOW_TOO_SMALL. H=0.5 => next_pow2(1024*2*0.5)=1024 < 2048.
+  {
+    Lerror_t ect;
+    Lfunc_t Lt = init_only_37(0.5, 0, "build/wt_cache_tiny", &ect);
+    assert(ect & ERR_WINDOW_TOO_SMALL);
+    assert(fatal_error(ect));
+    if (Lt) Lfunc_clear(Lt);
+  }
+  printf("tiny ok\n");
+
+  // (Lower-bound 2) A high-motivic-weight object where B <= 0.5 + mu_max: tau has
+  // analytic mu_max = 6.5, so B = 8H must exceed 7.0 (H > 0.875). H=0.8 gives
+  // B=6.4: it clears the fft_N floor (next_pow2(1024*2*0.8)=2048) but fails the
+  // mu/beta floor and must be fatal ERR_WINDOW_TOO_SMALL.
+  {
+    Lerror_t ecm;
+    Lfunc_t Lm = build_tau(0.8, "build/wt_cache_tau", &ecm);
+    assert(ecm & ERR_WINDOW_TOO_SMALL);
+    assert(fatal_error(ecm));
+    if (Lm) Lfunc_clear(Lm);
+  }
+  printf("tau ok\n");
 
   Lfunc_clear(L);
   return 0;

--- a/test/window_test.cpp
+++ b/test/window_test.cpp
@@ -56,7 +56,17 @@ int main() {
   arb_add_error_2exp_si(z0ref, -50);
   assert(arb_overlaps(Lfunc_zeros(L,0) + 0, z0ref));
   arb_clear(z0ref);
-  Lfunc_clear(L);
   printf("task1 ok\n");
+
+  // Task 2: an explicit max_t equal to the default reproduces the sentinel result.
+  Lerror_t ec2;
+  Lfunc_t Le = build_37(64.0/2.0, 0, "build/wt_cache_expl", &ec2); // H = 64/degree
+  assert(!fatal_error(ec2));
+  assert(Lfunc_rank(Le) == 1);
+  for (int i = 0; i < 10; ++i)
+    assert(arb_overlaps(Lfunc_zeros(Le,0)+i, Lfunc_zeros(L,0)+i));
+  Lfunc_clear(Le);
+  Lfunc_clear(L);
+  printf("task2 ok\n");
   return 0;
 }

--- a/test/window_test.cpp
+++ b/test/window_test.cpp
@@ -455,13 +455,16 @@ int main() {
   }
   printf("tau ok\n");
 
-  // bead 31c.5: a valid shrink (H=16) returns a correct prefix of the default zeros.
-  // H=16 (B=128) clears every lower-bound guard; its zeros reach only ~1.5*16=24,
-  // a strict subset of the default (H=32, reach ~48). The low zeros must agree.
+  // bead 31c.5: a valid, RH-certified shrink (H=18) returns a correct prefix of
+  // the default zeros. H=18 (B=144) clears every lower-bound guard and the Turing
+  // check; its zeros reach only ~1.5*18=27, a strict subset of the default
+  // (H=32, reach ~48). The low zeros must agree, and ERR_RH_ERROR must be absent
+  // because the public zero-list completeness contract depends on it.
   {
     Lerror_t ecs;
-    Lfunc_t Ls = build_37(16.0, 0, "build/wt_cache_shrink", &ecs);
+    Lfunc_t Ls = build_37(18.0, 0, "build/wt_cache_shrink_cert", &ecs);
     assert(!fatal_error(ecs));
+    assert((ecs & ERR_RH_ERROR) == 0);
     assert(Lfunc_rank(Ls) == 1);
     // |eps| = 1
     { arb_t m; arb_init(m); acb_abs(m, Lfunc_sign(Ls), 100);
@@ -471,7 +474,7 @@ int main() {
     assert(nshr > 0 && nshr < ndef);                 // strictly fewer zeros than default
     for (int i = 0; i < nshr; ++i)                   // and a correct prefix (overlap)
       assert(arb_overlaps(Lfunc_zeros(Ls,0)+i, Lfunc_zeros(L,0)+i));
-    // the largest shrunk zero is within the H=16 reach (well under the default's ~48)
+    // the largest shrunk zero is within the H=18 reach (well under the default's ~48)
     arb_t lim; arb_init(lim); arb_set_d(lim, 30.0);
     assert(arb_lt(Lfunc_zeros(Ls,0)+(nshr-1), lim));
     arb_clear(lim);

--- a/test/window_test.cpp
+++ b/test/window_test.cpp
@@ -281,6 +281,30 @@ int main() {
   }
   printf("tau ok\n");
 
+  // bead 31c.5: a valid shrink (H=16) returns a correct prefix of the default zeros.
+  // H=16 (B=128) clears every lower-bound guard; its zeros reach only ~1.5*16=24,
+  // a strict subset of the default (H=32, reach ~48). The low zeros must agree.
+  {
+    Lerror_t ecs;
+    Lfunc_t Ls = build_37(16.0, 0, "build/wt_cache_shrink", &ecs);
+    assert(!fatal_error(ecs));
+    assert(Lfunc_rank(Ls) == 1);
+    // |eps| = 1
+    { arb_t m; arb_init(m); acb_abs(m, Lfunc_sign(Ls), 100);
+      arb_sub_ui(m, m, 1, 100); assert(arb_contains_zero(m)); arb_clear(m); }
+    int nshr = 0; while (nshr < (int)MAX_ZEROS && !arb_is_zero(Lfunc_zeros(Ls,0)+nshr)) nshr++;
+    int ndef = 0; while (ndef < (int)MAX_ZEROS && !arb_is_zero(Lfunc_zeros(L,0)+ndef)) ndef++;
+    assert(nshr > 0 && nshr < ndef);                 // strictly fewer zeros than default
+    for (int i = 0; i < nshr; ++i)                   // and a correct prefix (overlap)
+      assert(arb_overlaps(Lfunc_zeros(Ls,0)+i, Lfunc_zeros(L,0)+i));
+    // the largest shrunk zero is within the H=16 reach (well under the default's ~48)
+    arb_t lim; arb_init(lim); arb_set_d(lim, 30.0);
+    assert(arb_lt(Lfunc_zeros(Ls,0)+(nshr-1), lim));
+    arb_clear(lim);
+    Lfunc_clear(Ls);
+  }
+  printf("shrink ok\n");
+
   Lfunc_clear(L);
   return 0;
 }

--- a/test/window_test.cpp
+++ b/test/window_test.cpp
@@ -87,6 +87,24 @@ static int wt_count_zeros(Lfunc_t L, uint64_t side) {
   return n;
 }
 
+// Init-only synthetic degree-r object (mus all 0, normalisation 0.5 => analytic
+// mus all 0.5) at a chosen window/cap, for white-box checks of the window
+// GEOMETRY. B / one_over_B / fft_NN / A depend only on degree and H -- not on the
+// conductor, the Euler factors, or gprec -- so no factors/compute are needed. We
+// pin gprec to a small value: it does not affect the asserted geometry, keeps
+// compute_g (hence the suite) fast, and (being non-zero) bypasses the on-disk
+// G-cache so these ~100 inits leave no cache files behind.
+static Lfunc_t geo_init(uint64_t degree, double max_t, uint64_t max_fft_NN, Lerror_t *ecode) {
+  vector<double> mus(degree, 0.0);
+  Lparams_t Lp = {};
+  Lp.degree = degree; Lp.conductor = 11; Lp.normalisation = 0.5; Lp.mus = mus.data();
+  Lp.target_prec = DEFAULT_TARGET_PREC; Lp.wprec = 0; Lp.gprec = 30;
+  Lp.self_dual = DK; Lp.rank = DK; Lp.cache_dir = (char*)"build/wt_cache_geo";
+  Lp.max_t = max_t; Lp.max_fft_NN = max_fft_NN;
+  *ecode = ERR_SUCCESS;
+  return Lfunc_init_advanced(&Lp, ecode); // copies mus
+}
+
 // Build ec_37.a1 via the advanced API at a given window and cap, in a private
 // cache_dir so runs never poison each other. Returns the accumulated ecode.
 static Lfunc_t build_37(double max_t, uint64_t max_fft_NN, const char *cache_dir, Lerror_t *ecode) {
@@ -625,6 +643,87 @@ int main() {
     Lfunc_clear(Ldk); Lfunc_clear(Lr1);
   }
   printf("supplied-rank-window ok\n");
+
+  // ---- power-of-two window-geometry sweep (init-only, white-box) ----
+  // For degree r and k=1..9 with H = 2^k/r the geometry is forced to exact powers
+  // of two: B = 2^(k+3)/r, one_over_B = r/2^(k+3), fft_NN = 2^(k+10), A = 128*r,
+  // output reach fft_NN/(OUTPUT_RATIO*A) = H, and Turing-end reach
+  // (fft_NN/OUTPUT_RATIO + fft_NN/TURING_RATIO)/A = 1.5*H. This pins those
+  // relationships across the whole degree range (the "what about other powers of
+  // two" question) with no Euler factors or zero-finding. Windows below the
+  // small-window floor are rejected LOUD (ERR_WINDOW_TOO_SMALL) and skipped. The
+  // first four equalities are exact (integer / power-of-two scaling / a single
+  // correctly-rounded division of 2^k/r); the Turing reach gets a tolerance
+  // because 1.5*H double-rounds (off by 1 ulp at e.g. r=5).
+  for (uint64_t r = 2; r <= (uint64_t)MAX_DEGREE; ++r) {
+    for (int k = 1; k <= 9; ++k) {
+      double H = ldexp(1.0, k) / (double)r;                       // 2^k / r
+      Lerror_t ecg;
+      Lfunc_t Lg = geo_init(r, H, (uint64_t)1 << 20, &ecg);
+      if (fatal_error(ecg)) {                                     // below the floor => loud
+        assert(ecg & ERR_WINDOW_TOO_SMALL);
+        if (Lg) Lfunc_clear(Lg);
+        continue;
+      }
+      Lfunc *G = (Lfunc*)Lg;
+      assert(G->fft_NN == ((uint64_t)1 << (k + 10)));             // fft_NN = 2^(k+10)
+      assert(G->one_over_B == (double)r / ldexp(1.0, k + 3));     // 1/B = r/2^(k+3)
+      assert(G->A == 128.0 * (double)r);                          // A = 128*r
+      double reach_out = (double)G->fft_NN / ((double)OUTPUT_RATIO * G->A);
+      assert(reach_out == H);                                     // output reach = H
+      double reach_tur = ((double)(G->fft_NN / OUTPUT_RATIO) + (double)(G->fft_NN / TURING_RATIO)) / G->A;
+      assert(fabs(reach_tur - 1.5 * H) <= 1e-12 * (1.5 * H));     // Turing-end reach = 1.5*H
+      Lfunc_clear(Lg);
+    }
+  }
+  printf("geometry-sweep ok\n");
+
+  // ---- boundary: explicit H = 64/r reproduces the sentinel (max_t = 0) geometry ----
+  for (uint64_t r = 2; r <= (uint64_t)MAX_DEGREE; ++r) {
+    Lerror_t es, ee;
+    Lfunc_t Ls = geo_init(r, 0.0, 0, &es);                            // sentinel default
+    Lfunc_t Le = geo_init(r, 64.0 / (double)r, (uint64_t)1 << 20, &ee); // explicit 64/r
+    assert(!fatal_error(es) && !fatal_error(ee));
+    Lfunc *S = (Lfunc*)Ls, *E = (Lfunc*)Le;
+    assert(S->fft_NN == ((uint64_t)1 << 16) && E->fft_NN == S->fft_NN);
+    assert(E->one_over_B == S->one_over_B);
+    assert(E->A == S->A && S->A == 128.0 * (double)r);
+    Lfunc_clear(Ls); Lfunc_clear(Le);
+  }
+  printf("explicit-default ok\n");
+
+  // ---- boundary: the cap rejects below / admits at the required power of two ----
+  // H = 128/r needs fft_NN = 2^17: a 2^16 cap must fail loud, a 2^17 cap must pass.
+  for (uint64_t r = 2; r <= (uint64_t)MAX_DEGREE; ++r) {
+    double H = 128.0 / (double)r;
+    Lerror_t e1, e2;
+    Lfunc_t L1 = geo_init(r, H, (uint64_t)1 << 16, &e1);
+    assert(e1 & ERR_WINDOW_TOO_LARGE);
+    if (L1) Lfunc_clear(L1);
+    Lfunc_t L2 = geo_init(r, H, (uint64_t)1 << 17, &e2);
+    assert(!fatal_error(e2));
+    assert(((Lfunc*)L2)->fft_NN == ((uint64_t)1 << 17));
+    Lfunc_clear(L2);
+  }
+  printf("cap-threshold ok\n");
+
+  // ---- boundary: round-up just above / just below the default H = 64/r ----
+  // Just above 64/r the required length rounds up to 2^17 and A climbs above 128*r;
+  // just below it stays at 2^16 but A still rises above 128*r -- A = fft_NN/(8H) is
+  // not pinned to 128*r for non-default windows.
+  for (uint64_t r = 2; r <= (uint64_t)MAX_DEGREE; ++r) {
+    double A128 = 128.0 * (double)r;
+    Lerror_t eu, eb;
+    Lfunc_t Lu = geo_init(r, 64.0 / (double)r + 1.0 / 1024.0, (uint64_t)1 << 20, &eu);
+    assert(!fatal_error(eu));
+    assert(((Lfunc*)Lu)->fft_NN == ((uint64_t)1 << 17) && ((Lfunc*)Lu)->A > A128);
+    Lfunc_clear(Lu);
+    Lfunc_t Lb = geo_init(r, 64.0 / (double)r - 1.0 / 1024.0, (uint64_t)1 << 20, &eb);
+    assert(!fatal_error(eb));
+    assert(((Lfunc*)Lb)->fft_NN == ((uint64_t)1 << 16) && ((Lfunc*)Lb)->A > A128);
+    Lfunc_clear(Lb);
+  }
+  printf("round-boundary ok\n");
 
   Lfunc_clear(L);
   return 0;

--- a/test/window_test.cpp
+++ b/test/window_test.cpp
@@ -1,0 +1,62 @@
+// Regression test for the configurable output window (bead lfunctions-31c).
+#include <flint/acb_poly.h>
+#include "glfunc.h"
+#include "glfunc_internals.h"
+#include <cassert>
+#include <cstdio>
+#include <map>
+#include <vector>
+#include <cstdint>
+using std::map; using std::vector;
+
+// ec_37.a1 Euler factors (degree 2, conductor 37), from examples/ec_37.a1.cpp.
+static map<int64_t, vector<int64_t>> ef = {
+  {2,{1,2,2}},{3,{1,3,3}},{5,{1,2,5}},{7,{1,1,7}},{11,{1,5,11}},{13,{1,2,13}},
+  {17,{1,0,17}},{19,{1,0,19}},{23,{1,-2,23}},{29,{1,-6,29}},{31,{1,4,31}},{37,{1,1}},
+  {41,{1,9,41}},{43,{1,-2,43}},{47,{1,9,47}},{53,{1,-1,53}},{59,{1,-8,59}},{61,{1,8,61}},
+  {67,{1,-8,67}},{71,{1,-9,71}},{73,{1,1,73}},{79,{1,-4,79}},{83,{1,15,83}},{89,{1,-4,89}},
+  {97,{1,-4,97}},{101,{1,-3,101}},{103,{1,-18,103}},{107,{1,12,107}},{109,{1,16,109}},
+  {113,{1,18,113}},{127,{1,-1,127}},{131,{1,12,131}},{137,{1,6,137}},{139,{1,-4,139}},
+};
+static void cb(acb_poly_t poly, uint64_t p, int, int64_t, void*) {
+  acb_poly_zero(poly);
+  auto it = ef.find((int64_t)p);
+  if (it != ef.end())
+    for (size_t i = 0; i < it->second.size(); ++i)
+      acb_poly_set_coeff_si(poly, i, it->second[i]);
+}
+
+// Build ec_37.a1 via the advanced API at a given window and cap, in a private
+// cache_dir so runs never poison each other. Returns the accumulated ecode.
+static Lfunc_t build_37(double max_t, uint64_t max_fft_NN, const char *cache_dir, Lerror_t *ecode) {
+  static double mus[2] = {0,1};
+  Lparams_t Lp;
+  Lp.degree = 2; Lp.conductor = 37; Lp.normalisation = 0.5; Lp.mus = mus;
+  Lp.target_prec = DEFAULT_TARGET_PREC; Lp.wprec = 0; Lp.gprec = 0;
+  Lp.self_dual = DK; Lp.rank = DK; Lp.cache_dir = (char*)cache_dir;
+  Lp.max_t = max_t; Lp.max_fft_NN = max_fft_NN;
+  *ecode = ERR_SUCCESS;
+  Lfunc_t L = Lfunc_init_advanced(&Lp, ecode);
+  if (fatal_error(*ecode)) return L;
+  *ecode |= Lfunc_use_all_lpolys(L, cb, NULL);
+  if (fatal_error(*ecode)) return L;
+  *ecode |= Lfunc_compute(L);
+  return L;
+}
+
+int main() {
+  // Task 1 assertion: the new fields exist, defaults (sentinels) reproduce the
+  // known ec_37.a1 results computed via the plain Lfunc_init path.
+  Lerror_t ec;
+  Lfunc_t L = build_37(0.0, 0, "build/wt_cache_default", &ec);
+  assert(!fatal_error(ec));
+  assert(Lfunc_rank(L) == 1);
+  arb_t z0ref; arb_init(z0ref);
+  arb_set_str(z0ref, "5.0031700140066586953", 300);
+  arb_add_error_2exp_si(z0ref, -50);
+  assert(arb_overlaps(Lfunc_zeros(L,0) + 0, z0ref));
+  arb_clear(z0ref);
+  Lfunc_clear(L);
+  printf("task1 ok\n");
+  return 0;
+}

--- a/test/window_test.cpp
+++ b/test/window_test.cpp
@@ -2,6 +2,7 @@
 #include <flint/acb_poly.h>
 #include <flint/arith.h>
 #include <flint/fmpz.h>
+#include <flint/ulong_extras.h>
 #include "glfunc.h"
 #include "glfunc_internals.h"
 #include <cassert>
@@ -109,6 +110,36 @@ static Lfunc_t build_tau(double max_t, const char *cache_dir, Lerror_t *ecode) {
   return L;
 }
 
+// Product of the quadratic characters mod 227 and mod 229: a degree-2, self-dual
+// L-function of conductor 227*229 = 51983, so M0 = ceil(sqrt(N)/100) = 3 > 1
+// (unlike conductor 37, where M0 = 1). chi_227 is odd (227 = 3 mod 4) and chi_229
+// even, giving analytic mus {0,1} at normalisation 0. The good-prime Euler factor
+// is (1 - chi_227(p) x)(1 - chi_229(p) x); a ramified chi_p(p) = 0 drops its factor.
+static void dir_cb(acb_poly_t poly, uint64_t p, int, int64_t, void*) {
+  acb_poly_zero(poly);
+  long a = n_jacobi((slong)(p % 227), 227);   // chi_227(p) in {-1,0,1}
+  long b = n_jacobi((slong)(p % 229), 229);   // chi_229(p)
+  acb_poly_set_coeff_si(poly, 0, 1);
+  acb_poly_set_coeff_si(poly, 1, -(a + b));
+  if (a != 0 && b != 0) acb_poly_set_coeff_si(poly, 2, a * b);
+}
+static Lfunc_t build_dir(double max_t, uint64_t max_fft_NN, const char *cache_dir, Lerror_t *ecode) {
+  static double mus[2] = {0,1};
+  Lparams_t Lp = {};
+  Lp.degree = 2; Lp.conductor = 227 * 229; Lp.normalisation = 0.0; Lp.mus = mus;
+  Lp.target_prec = DEFAULT_TARGET_PREC; Lp.wprec = 0; Lp.gprec = 0;
+  Lp.self_dual = DK; Lp.rank = DK; Lp.cache_dir = (char*)cache_dir;
+  Lp.max_t = max_t; Lp.max_fft_NN = max_fft_NN;
+  mkdir(cache_dir, 0777);
+  *ecode = ERR_SUCCESS;
+  Lfunc_t L = Lfunc_init_advanced(&Lp, ecode);
+  if (fatal_error(*ecode)) return L;
+  *ecode |= Lfunc_use_all_lpolys(L, dir_cb, NULL);
+  if (fatal_error(*ecode)) return L;
+  *ecode |= Lfunc_compute(L);
+  return L;
+}
+
 int main() {
   // Task 1 assertion: the new fields exist, defaults (sentinels) reproduce the
   // known ec_37.a1 results computed via the plain Lfunc_init path.
@@ -170,6 +201,39 @@ int main() {
     assert(arb_overlaps(Lfunc_zeros(Lbig,0)+i, Lfunc_zeros(L,0)+i));
   Lfunc_clear(Lbig);
   printf("task3 ok\n");
+
+  // ---- conv_support must be conductor-aware (Reviewer A blocker) ----
+  // For conductor > ~1e4 (M0 = ceil(sqrt(N)/100) > 1) the small-coefficient path
+  // (finish_convolves) fills the convolution down to bucket calc_m(1) =
+  // round(log(1/sqrt(N))/(2pi/B)); once sqrt(N) > 100 that is BELOW the old
+  // floor(log(0.01)/(2pi/B)) bound, so a conductor-independent conv_support sized
+  // fft_N too small, the cyclic convolution aliased, and the certified zeros
+  // silently stopped containing the truth -- with no error raised. Conductor 37
+  // (M0=1, used by task1-3) never exercised this. Here the default window is
+  // correct (it never aliases at any conductor) and the enlarged window's trusted
+  // zeros must overlap it; on the buggy conv_support the enlarge aliases and the
+  // overlap fails. fft_N goes 2048 (default) -> 4096 (enlarged at this conductor).
+  {
+    Lerror_t ecd;
+    Lfunc_t Ld = build_dir(0.0, 0, "build/wt_cache_dir_def", &ecd);          // reference
+    assert(!fatal_error(ecd));
+    { arb_t m; arb_init(m); acb_abs(m, Lfunc_sign(Ld), 100);
+      arb_sub_ui(m, m, 1, 100); assert(arb_contains_zero(m)); arb_clear(m); }
+    int nd = 0; while (nd < (int)MAX_ZEROS && !arb_is_zero(Lfunc_zeros(Ld,0)+nd)) nd++;
+    assert(nd > 0);
+
+    Lerror_t ece;
+    Lfunc_t Lde = build_dir(48.0, (uint64_t)1<<18, "build/wt_cache_dir_big", &ece);  // enlarge
+    assert(!fatal_error(ece));
+    { arb_t m; arb_init(m); acb_abs(m, Lfunc_sign(Lde), 100);
+      arb_sub_ui(m, m, 1, 100); assert(arb_contains_zero(m)); arb_clear(m); }
+    int ne = 0; while (ne < (int)MAX_ZEROS && !arb_is_zero(Lfunc_zeros(Lde,0)+ne)) ne++;
+    assert(ne > nd);                                  // the wider window finds strictly more
+    for (int i = 0; i < nd; ++i)                      // and every default zero reappears
+      assert(arb_overlaps(Lfunc_zeros(Lde,0)+i, Lfunc_zeros(Ld,0)+i));
+    Lfunc_clear(Ld); Lfunc_clear(Lde);
+  }
+  printf("highcond ok\n");
 
   // ---- bead 31c.6: a cache written for one window must not poison another ----
   //

--- a/test/window_test.cpp
+++ b/test/window_test.cpp
@@ -10,6 +10,7 @@
 #include <map>
 #include <vector>
 #include <cstdint>
+#include <sys/stat.h>
 using std::map; using std::vector;
 
 // ec_37.a1 Euler factors (degree 2, conductor 37), from examples/ec_37.a1.cpp.
@@ -40,6 +41,10 @@ static Lfunc_t build_37(double max_t, uint64_t max_fft_NN, const char *cache_dir
   Lp.target_prec = DEFAULT_TARGET_PREC; Lp.wprec = 0; Lp.gprec = 0;
   Lp.self_dual = DK; Lp.rank = DK; Lp.cache_dir = (char*)cache_dir;
   Lp.max_t = max_t; Lp.max_fft_NN = max_fft_NN;
+  // The G cache is only written if cache_dir exists: fopen(...,"w") fails on a
+  // missing directory and caching is then SILENTLY skipped. Create it (ignore
+  // EEXIST) so the cache is actually exercised by these tests.
+  mkdir(cache_dir, 0777);
   *ecode = ERR_SUCCESS;
   Lfunc_t L = Lfunc_init_advanced(&Lp, ecode);
   if (fatal_error(*ecode)) return L;
@@ -96,6 +101,7 @@ static Lfunc_t build_tau(double max_t, const char *cache_dir, Lerror_t *ecode) {
   Lp.target_prec = DEFAULT_TARGET_PREC; Lp.wprec = 0; Lp.gprec = 0;
   Lp.self_dual = DK; Lp.rank = DK; Lp.cache_dir = (char*)cache_dir;
   Lp.max_t = max_t; Lp.max_fft_NN = 0;
+  mkdir(cache_dir, 0777); // see build_37: cache is skipped if the dir is absent
   *ecode = ERR_SUCCESS;
   Lfunc_t L = Lfunc_init_advanced(&Lp, ecode);
   if (fatal_error(*ecode)) return L;
@@ -153,6 +159,68 @@ int main() {
     assert(arb_overlaps(Lfunc_zeros(Lbig,0)+i, Lfunc_zeros(L,0)+i));
   Lfunc_clear(Lbig);
   printf("task3 ok\n");
+
+  // ---- bead 31c.6: a cache written for one window must not poison another ----
+  //
+  // The on-disk G-cache filename is keyed only on mus, so two windows with the
+  // same mus and default precision collide on ONE file. read_gheader must also
+  // validate the window (one_over_B): otherwise a cache written for a LARGER
+  // window (B=512) is silently reused for a SMALLER one (B=256) -- the body
+  // overwrites L->one_over_B with the cached B and the whole L-function is
+  // computed on the wrong grid. The ordering is load-bearing: the larger window
+  // has a higher gprec, so writing it FIRST makes the cached gprec pass the
+  // (cached >= required) sufficiency check when the smaller window reuses it,
+  // unmasking the window bug specifically. On fixed code the one_over_B header
+  // mismatch makes the file STALE -> recompute+overwrite at B=256 -> correct.
+  {
+    const char *shared = "build/wt_cache_poison";
+    // 1) Enlarged: H=64 (B=512), cap 2^18. Writes the poisoning cache file.
+    Lerror_t ecp;
+    Lfunc_t Lp_big = build_37(64.0, (uint64_t)1<<18, shared, &ecp);
+    assert(!fatal_error(ecp));
+    // The cache must actually have been written (dir exists -> fopen "w" ok).
+    {
+      struct stat sb;
+      assert(stat("build/wt_cache_poison/g_0.5_1.5", &sb) == 0);
+    }
+    Lfunc_clear(Lp_big);
+
+    // 2) Default window (H=32, B=256) in the SAME directory. On BROKEN code
+    // compute_g reads the enlarged file and the body OVERWRITES L->one_over_B to
+    // 1/512 (B=512), so the rest of init derives A=fft_NN/512=128 (half the
+    // correct 256) and the whole transform runs on the wrong geometry; on FIXED
+    // code the one_over_B header mismatch makes the file STALE -> recompute at
+    // B=256.
+    Lerror_t ecp2;
+    Lfunc_t Lp_def = build_37(0.0, 0, shared, &ecp2);
+    assert(!fatal_error(ecp2));
+    assert(Lfunc_rank(Lp_def) == 1);
+    // The low zeros are intrinsic and come out at the right t in both cases, so
+    // the first-zero VALUE alone does not distinguish broken from fixed: it is
+    // only its radius and the window EXTENT that the wrong B corrupts. We assert
+    // the extent. A correct B=256 default trusts t up to the Turing zone
+    // 1.5*H = 48, so its largest returned zero is < 50 (here ~47.57). The
+    // poisoned B=512 geometry trusts twice as far and returns zeros out to ~79,
+    // far above 50. Assert no returned zero exceeds 55: FAILS on broken
+    // (max ~79.15), PASSES on fixed (max ~47.57).
+    arb_t z0ref; arb_init(z0ref);
+    arb_set_str(z0ref, "5.0031700140066586953", 300);
+    arb_add_error_2exp_si(z0ref, -50);
+    assert(arb_overlaps(Lfunc_zeros(Lp_def,0) + 0, z0ref));
+    arb_clear(z0ref);
+    arb_t hi; arb_init(hi); arb_set_ui(hi, 55);
+    int nzp = 0;
+    while (nzp < (int)MAX_ZEROS && !arb_is_zero(Lfunc_zeros(Lp_def,0)+nzp)) {
+      // every trusted zero of the correctly-windowed default run is below the
+      // 1.5*H = 48 Turing reach, hence < 55. A poisoned B=512 run returns zeros
+      // up to ~79, violating this on at least one index.
+      assert(arb_lt(Lfunc_zeros(Lp_def,0)+nzp, hi));
+      nzp++;
+    }
+    arb_clear(hi);
+    Lfunc_clear(Lp_def);
+  }
+  printf("poison ok\n");
 
   // ---- bead 31c.4: every rejected/degenerate window must fail LOUD and fast ----
 

--- a/test/window_test.cpp
+++ b/test/window_test.cpp
@@ -17,6 +17,8 @@ static map<int64_t, vector<int64_t>> ef = {
   {67,{1,-8,67}},{71,{1,-9,71}},{73,{1,1,73}},{79,{1,-4,79}},{83,{1,15,83}},{89,{1,-4,89}},
   {97,{1,-4,97}},{101,{1,-3,101}},{103,{1,-18,103}},{107,{1,12,107}},{109,{1,16,109}},
   {113,{1,18,113}},{127,{1,-1,127}},{131,{1,12,131}},{137,{1,6,137}},{139,{1,-4,139}},
+  {149,{1,5,149}},{151,{1,-16,151}},{157,{1,-23,157}},{163,{1,18,163}},{167,{1,12,167}},
+  {173,{1,-9,173}},{179,{1,-18,179}},{181,{1,-5,181}},{191,{1,4,191}},
 };
 static void cb(acb_poly_t poly, uint64_t p, int, int64_t, void*) {
   acb_poly_zero(poly);
@@ -66,7 +68,33 @@ int main() {
   for (int i = 0; i < 10; ++i)
     assert(arb_overlaps(Lfunc_zeros(Le,0)+i, Lfunc_zeros(L,0)+i));
   Lfunc_clear(Le);
-  Lfunc_clear(L);
   printf("task2 ok\n");
+
+  // Task 3a: enlarging needs a bigger transform; with the default cap it fails loudly.
+  // H=48 requires want_fft_NN=2^17 > default cap 2^16, so ERR_WINDOW_TOO_LARGE fires.
+  Lerror_t ec3;
+  Lfunc_t Lbig_fail = build_37(48.0, 0 /*cap=2^16*/, "build/wt_cache_toobig", &ec3);
+  assert(ec3 & ERR_WINDOW_TOO_LARGE);
+  assert(fatal_error(ec3));
+  if (Lbig_fail) Lfunc_clear(Lbig_fail);
+
+  // Task 3b: raise the cap to 2^17 and enlarge from H=32 to H=48; zeros below 32 are unchanged
+  // and strictly more zeros are found.
+  Lerror_t ec3b;
+  Lfunc_t Lbig = build_37(48.0, (uint64_t)1<<17, "build/wt_cache_enlarge", &ec3b);
+  assert(!fatal_error(ec3b));
+  // |eps| = 1
+  { arb_t m; arb_init(m); acb_abs(m, Lfunc_sign(Lbig), 100);
+    arb_sub_ui(m, m, 1, 100); assert(arb_contains_zero(m)); arb_clear(m); }
+  // every default zero (all < 32) reappears in the enlarged run
+  int ndef = 0; while (ndef < (int)MAX_ZEROS && !arb_is_zero(Lfunc_zeros(L,0)+ndef)) ndef++;
+  int nbig = 0; while (nbig < (int)MAX_ZEROS && !arb_is_zero(Lfunc_zeros(Lbig,0)+nbig)) nbig++;
+  assert(nbig > ndef);
+  for (int i = 0; i < ndef; ++i)
+    assert(arb_overlaps(Lfunc_zeros(Lbig,0)+i, Lfunc_zeros(L,0)+i));
+  Lfunc_clear(Lbig);
+  printf("task3 ok\n");
+
+  Lfunc_clear(L);
   return 0;
 }

--- a/test/window_test.cpp
+++ b/test/window_test.cpp
@@ -78,10 +78,12 @@ int main() {
   assert(fatal_error(ec3));
   if (Lbig_fail) Lfunc_clear(Lbig_fail);
 
-  // Task 3b: raise the cap to 2^17 and enlarge from H=32 to H=48; zeros below 32 are unchanged
-  // and strictly more zeros are found.
+  // Task 3b: raise the cap to 2^18 and enlarge from H=32 to H=64; the low zeros are
+  // unchanged and strictly more zeros are found. H=64 needs fft_NN=2^17, and its G grid
+  // exceeds the historical fft_N=2048, so this exercises the fft_N scaling: if fft_N is
+  // too small the cyclic convolution aliases and the low zeros shift, breaking the overlap.
   Lerror_t ec3b;
-  Lfunc_t Lbig = build_37(48.0, (uint64_t)1<<17, "build/wt_cache_enlarge", &ec3b);
+  Lfunc_t Lbig = build_37(64.0, (uint64_t)1<<18, "build/wt_cache_enlarge", &ec3b);
   assert(!fatal_error(ec3b));
   // |eps| = 1
   { arb_t m; arb_init(m); acb_abs(m, Lfunc_sign(Lbig), 100);

--- a/test/window_test.cpp
+++ b/test/window_test.cpp
@@ -11,6 +11,8 @@
 #include <map>
 #include <vector>
 #include <cstdint>
+#include <cstring>
+#include <dirent.h>
 #include <sys/stat.h>
 using std::map; using std::vector;
 
@@ -65,9 +67,9 @@ typedef void (*wt_cbfn)(acb_poly_t, uint64_t, int, int64_t, void*);
 static Lfunc_t build_37_full(double max_t, uint64_t max_fft_NN, double normalisation,
                              double *mus, int self_dual, int rank, wt_cbfn f,
                              const char *cache_dir, Lerror_t *ecode) {
-  Lparams_t Lp = {};
+  Lparams_t Lp;
+  Lparams_init(&Lp);
   Lp.degree = 2; Lp.conductor = 37; Lp.normalisation = normalisation; Lp.mus = mus;
-  Lp.target_prec = DEFAULT_TARGET_PREC; Lp.wprec = 0; Lp.gprec = 0;
   Lp.self_dual = self_dual; Lp.rank = rank; Lp.cache_dir = (char*)cache_dir;
   Lp.max_t = max_t; Lp.max_fft_NN = max_fft_NN;
   mkdir(cache_dir, 0777);
@@ -87,32 +89,29 @@ static int wt_count_zeros(Lfunc_t L, uint64_t side) {
   return n;
 }
 
-// Init-only synthetic degree-r object (mus all 0, normalisation 0.5 => analytic
-// mus all 0.5) at a chosen window/cap, for white-box checks of the window
-// GEOMETRY. B / one_over_B / fft_NN / A depend only on degree and H -- not on the
-// conductor, the Euler factors, or gprec -- so no factors/compute are needed. We
-// pin gprec to a small value: it does not affect the asserted geometry, keeps
-// compute_g (hence the suite) fast, and (being non-zero) bypasses the on-disk
-// G-cache so these ~100 inits leave no cache files behind.
-static Lfunc_t geo_init(uint64_t degree, double max_t, uint64_t max_fft_NN, Lerror_t *ecode) {
-  vector<double> mus(degree, 0.0);
-  Lparams_t Lp = {};
-  Lp.degree = degree; Lp.conductor = 11; Lp.normalisation = 0.5; Lp.mus = mus.data();
-  Lp.target_prec = DEFAULT_TARGET_PREC; Lp.wprec = 0; Lp.gprec = 30;
-  Lp.self_dual = DK; Lp.rank = DK; Lp.cache_dir = (char*)"build/wt_cache_geo";
-  Lp.max_t = max_t; Lp.max_fft_NN = max_fft_NN;
-  *ecode = ERR_SUCCESS;
-  return Lfunc_init_advanced(&Lp, ecode); // copies mus
+static bool wt_cache_dir_has_file(const char *dir) {
+  DIR *d = opendir(dir);
+  if (!d) return false;
+  bool found = false;
+  struct dirent *e;
+  while ((e = readdir(d)) != NULL) {
+    if (strcmp(e->d_name, ".") && strcmp(e->d_name, "..")) {
+      found = true;
+      break;
+    }
+  }
+  closedir(d);
+  return found;
 }
 
 // Build ec_37.a1 via the advanced API at a given window and cap, in a private
 // cache_dir so runs never poison each other. Returns the accumulated ecode.
 static Lfunc_t build_37(double max_t, uint64_t max_fft_NN, const char *cache_dir, Lerror_t *ecode) {
   static double mus[2] = {0,1};
-  Lparams_t Lp = {}; // zero-init: future Lparams_t fields default safely
+  Lparams_t Lp;
+  Lparams_init(&Lp);
   Lp.degree = 2; Lp.conductor = 37; Lp.normalisation = 0.5; Lp.mus = mus;
-  Lp.target_prec = DEFAULT_TARGET_PREC; Lp.wprec = 0; Lp.gprec = 0;
-  Lp.self_dual = DK; Lp.rank = DK; Lp.cache_dir = (char*)cache_dir;
+  Lp.cache_dir = (char*)cache_dir;
   Lp.max_t = max_t; Lp.max_fft_NN = max_fft_NN;
   // The G cache is only written if cache_dir exists: fopen(...,"w") fails on a
   // missing directory and caching is then SILENTLY skipped. Create it (ignore
@@ -132,10 +131,10 @@ static Lfunc_t build_37(double max_t, uint64_t max_fft_NN, const char *cache_dir
 // fast, before any Euler factors or compute.
 static Lfunc_t init_only_37(double max_t, uint64_t max_fft_NN, const char *cache_dir, Lerror_t *ecode) {
   static double mus[2] = {0,1};
-  Lparams_t Lp = {};
+  Lparams_t Lp;
+  Lparams_init(&Lp);
   Lp.degree = 2; Lp.conductor = 37; Lp.normalisation = 0.5; Lp.mus = mus;
-  Lp.target_prec = DEFAULT_TARGET_PREC; Lp.wprec = 0; Lp.gprec = 0;
-  Lp.self_dual = DK; Lp.rank = DK; Lp.cache_dir = (char*)cache_dir;
+  Lp.cache_dir = (char*)cache_dir;
   Lp.max_t = max_t; Lp.max_fft_NN = max_fft_NN;
   *ecode = ERR_SUCCESS;
   return Lfunc_init_advanced(&Lp, ecode);
@@ -169,10 +168,10 @@ static void tau_cb(acb_poly_t poly, uint64_t p, int, int64_t, void*) {
 // the accumulated ecode; on a too-small window it is fatal straight out of init.
 static Lfunc_t build_tau(double max_t, const char *cache_dir, Lerror_t *ecode) {
   static double mus[2] = {0,1};
-  Lparams_t Lp = {};
+  Lparams_t Lp;
+  Lparams_init(&Lp);
   Lp.degree = 2; Lp.conductor = 1; Lp.normalisation = 5.5; Lp.mus = mus;
-  Lp.target_prec = DEFAULT_TARGET_PREC; Lp.wprec = 0; Lp.gprec = 0;
-  Lp.self_dual = DK; Lp.rank = DK; Lp.cache_dir = (char*)cache_dir;
+  Lp.cache_dir = (char*)cache_dir;
   Lp.max_t = max_t; Lp.max_fft_NN = 0;
   mkdir(cache_dir, 0777); // see build_37: cache is skipped if the dir is absent
   *ecode = ERR_SUCCESS;
@@ -197,10 +196,10 @@ static void dir_cb(acb_poly_t poly, uint64_t p, int, int64_t, void*) {
 }
 static Lfunc_t build_dir(double max_t, uint64_t max_fft_NN, const char *cache_dir, Lerror_t *ecode) {
   static double mus[2] = {0,1};
-  Lparams_t Lp = {};
+  Lparams_t Lp;
+  Lparams_init(&Lp);
   Lp.degree = 2; Lp.conductor = 227 * 229; Lp.normalisation = 0.0; Lp.mus = mus;
-  Lp.target_prec = DEFAULT_TARGET_PREC; Lp.wprec = 0; Lp.gprec = 0;
-  Lp.self_dual = DK; Lp.rank = DK; Lp.cache_dir = (char*)cache_dir;
+  Lp.cache_dir = (char*)cache_dir;
   Lp.max_t = max_t; Lp.max_fft_NN = max_fft_NN;
   mkdir(cache_dir, 0777);
   *ecode = ERR_SUCCESS;
@@ -354,8 +353,7 @@ int main() {
     assert(!fatal_error(ecp));
     // The cache must actually have been written (dir exists -> fopen "w" ok).
     {
-      struct stat sb;
-      assert(stat("build/wt_cache_poison/g_0.5_1.5", &sb) == 0);
+      assert(wt_cache_dir_has_file("build/wt_cache_poison"));
     }
     Lfunc_clear(Lp_big);
 
@@ -646,87 +644,6 @@ int main() {
     Lfunc_clear(Ldk); Lfunc_clear(Lr1);
   }
   printf("supplied-rank-window ok\n");
-
-  // ---- power-of-two window-geometry sweep (init-only, white-box) ----
-  // For degree r and k=1..9 with H = 2^k/r the geometry is forced to exact powers
-  // of two: B = 2^(k+3)/r, one_over_B = r/2^(k+3), fft_NN = 2^(k+10), A = 128*r,
-  // output reach fft_NN/(OUTPUT_RATIO*A) = H, and Turing-end reach
-  // (fft_NN/OUTPUT_RATIO + fft_NN/TURING_RATIO)/A = 1.5*H. This pins those
-  // relationships across the whole degree range (the "what about other powers of
-  // two" question) with no Euler factors or zero-finding. Windows below the
-  // small-window floor are rejected LOUD (ERR_WINDOW_TOO_SMALL) and skipped. The
-  // first four equalities are exact (integer / power-of-two scaling / a single
-  // correctly-rounded division of 2^k/r); the Turing reach gets a tolerance
-  // because 1.5*H double-rounds (off by 1 ulp at e.g. r=5).
-  for (uint64_t r = 2; r <= (uint64_t)MAX_DEGREE; ++r) {
-    for (int k = 1; k <= 9; ++k) {
-      double H = ldexp(1.0, k) / (double)r;                       // 2^k / r
-      Lerror_t ecg;
-      Lfunc_t Lg = geo_init(r, H, (uint64_t)1 << 20, &ecg);
-      if (fatal_error(ecg)) {                                     // below the floor => loud
-        assert(ecg & ERR_WINDOW_TOO_SMALL);
-        if (Lg) Lfunc_clear(Lg);
-        continue;
-      }
-      Lfunc *G = (Lfunc*)Lg;
-      assert(G->fft_NN == ((uint64_t)1 << (k + 10)));             // fft_NN = 2^(k+10)
-      assert(G->one_over_B == (double)r / ldexp(1.0, k + 3));     // 1/B = r/2^(k+3)
-      assert(G->A == 128.0 * (double)r);                          // A = 128*r
-      double reach_out = (double)G->fft_NN / ((double)OUTPUT_RATIO * G->A);
-      assert(reach_out == H);                                     // output reach = H
-      double reach_tur = ((double)(G->fft_NN / OUTPUT_RATIO) + (double)(G->fft_NN / TURING_RATIO)) / G->A;
-      assert(fabs(reach_tur - 1.5 * H) <= 1e-12 * (1.5 * H));     // Turing-end reach = 1.5*H
-      Lfunc_clear(Lg);
-    }
-  }
-  printf("geometry-sweep ok\n");
-
-  // ---- boundary: explicit H = 64/r reproduces the sentinel (max_t = 0) geometry ----
-  for (uint64_t r = 2; r <= (uint64_t)MAX_DEGREE; ++r) {
-    Lerror_t es, ee;
-    Lfunc_t Ls = geo_init(r, 0.0, 0, &es);                            // sentinel default
-    Lfunc_t Le = geo_init(r, 64.0 / (double)r, (uint64_t)1 << 20, &ee); // explicit 64/r
-    assert(!fatal_error(es) && !fatal_error(ee));
-    Lfunc *S = (Lfunc*)Ls, *E = (Lfunc*)Le;
-    assert(S->fft_NN == ((uint64_t)1 << 16) && E->fft_NN == S->fft_NN);
-    assert(E->one_over_B == S->one_over_B);
-    assert(E->A == S->A && S->A == 128.0 * (double)r);
-    Lfunc_clear(Ls); Lfunc_clear(Le);
-  }
-  printf("explicit-default ok\n");
-
-  // ---- boundary: the cap rejects below / admits at the required power of two ----
-  // H = 128/r needs fft_NN = 2^17: a 2^16 cap must fail loud, a 2^17 cap must pass.
-  for (uint64_t r = 2; r <= (uint64_t)MAX_DEGREE; ++r) {
-    double H = 128.0 / (double)r;
-    Lerror_t e1, e2;
-    Lfunc_t L1 = geo_init(r, H, (uint64_t)1 << 16, &e1);
-    assert(e1 & ERR_WINDOW_TOO_LARGE);
-    if (L1) Lfunc_clear(L1);
-    Lfunc_t L2 = geo_init(r, H, (uint64_t)1 << 17, &e2);
-    assert(!fatal_error(e2));
-    assert(((Lfunc*)L2)->fft_NN == ((uint64_t)1 << 17));
-    Lfunc_clear(L2);
-  }
-  printf("cap-threshold ok\n");
-
-  // ---- boundary: round-up just above / just below the default H = 64/r ----
-  // Just above 64/r the required length rounds up to 2^17 and A climbs above 128*r;
-  // just below it stays at 2^16 but A still rises above 128*r -- A = fft_NN/(8H) is
-  // not pinned to 128*r for non-default windows.
-  for (uint64_t r = 2; r <= (uint64_t)MAX_DEGREE; ++r) {
-    double A128 = 128.0 * (double)r;
-    Lerror_t eu, eb;
-    Lfunc_t Lu = geo_init(r, 64.0 / (double)r + 1.0 / 1024.0, (uint64_t)1 << 20, &eu);
-    assert(!fatal_error(eu));
-    assert(((Lfunc*)Lu)->fft_NN == ((uint64_t)1 << 17) && ((Lfunc*)Lu)->A > A128);
-    Lfunc_clear(Lu);
-    Lfunc_t Lb = geo_init(r, 64.0 / (double)r - 1.0 / 1024.0, (uint64_t)1 << 20, &eb);
-    assert(!fatal_error(eb));
-    assert(((Lfunc*)Lb)->fft_NN == ((uint64_t)1 << 16) && ((Lfunc*)Lb)->A > A128);
-    Lfunc_clear(Lb);
-  }
-  printf("round-boundary ok\n");
 
   Lfunc_clear(L);
   return 0;

--- a/test/zero_overflow_small_test.cpp
+++ b/test/zero_overflow_small_test.cpp
@@ -1,0 +1,71 @@
+// Fast default-suite regression for zero-cap exhaustion.
+//
+// The heavy zero_overflow_test.cpp proves that the real MAX_ZEROS=2048 cap is
+// reachable and fatal on a large computation. This test uses the internal test
+// hook to lower the active cap on an ordinary ec_37.a1 run, so make check covers
+// the same control-flow invariant cheaply: filling the zero storage is fatal and
+// sets ERR_ZERO_OVERFLOW.
+
+#include <flint/acb_poly.h>
+#include "glfunc.h"
+#include "glfunc_internals.h"
+#include <cassert>
+#include <cstdint>
+#include <map>
+#include <vector>
+#include <sys/stat.h>
+using std::map; using std::vector;
+
+static map<int64_t, vector<int64_t>> ef = {
+  {2,{1,2,2}},{3,{1,3,3}},{5,{1,2,5}},{7,{1,1,7}},{11,{1,5,11}},{13,{1,2,13}},
+  {17,{1,0,17}},{19,{1,0,19}},{23,{1,-2,23}},{29,{1,-6,29}},{31,{1,4,31}},{37,{1,1}},
+  {41,{1,9,41}},{43,{1,-2,43}},{47,{1,9,47}},{53,{1,-1,53}},{59,{1,-8,59}},{61,{1,8,61}},
+  {67,{1,-8,67}},{71,{1,-9,71}},{73,{1,1,73}},{79,{1,-4,79}},{83,{1,15,83}},{89,{1,-4,89}},
+  {97,{1,-4,97}},{101,{1,-3,101}},{103,{1,-18,103}},{107,{1,12,107}},{109,{1,16,109}},
+  {113,{1,18,113}},{127,{1,-1,127}},{131,{1,12,131}},{137,{1,6,137}},{139,{1,-4,139}},
+  {149,{1,5,149}},{151,{1,-16,151}},{157,{1,-23,157}},{163,{1,18,163}},{167,{1,12,167}},
+  {173,{1,-9,173}},{179,{1,-18,179}},{181,{1,-5,181}},{191,{1,4,191}},
+};
+
+static void cb(acb_poly_t poly, uint64_t p, int, int64_t, void*) {
+  acb_poly_zero(poly);
+  auto it = ef.find((int64_t)p);
+  if (it != ef.end())
+    for (size_t i = 0; i < it->second.size(); ++i)
+      acb_poly_set_coeff_si(poly, i, it->second[i]);
+}
+
+static int count_zeros_to_cap(Lfunc_t L, uint64_t side, int cap) {
+  int n = 0;
+  while (n < cap && !arb_is_zero(Lfunc_zeros(L, side) + n)) n++;
+  return n;
+}
+
+int main() {
+  static double mus[2] = {0, 1};
+  Lparams_t Lp;
+  Lparams_init(&Lp);
+  Lp.degree = 2;
+  Lp.conductor = 37;
+  Lp.normalisation = 0.5;
+  Lp.mus = mus;
+  Lp.self_dual = YES;
+  Lp.cache_dir = (char*)"build/zero_overflow_small_cache";
+  mkdir("build/zero_overflow_small_cache", 0777);
+
+  Lerror_t ec = ERR_SUCCESS;
+  Lfunc_t L = Lfunc_init_advanced(&Lp, &ec);
+  assert(!fatal_error(ec));
+  Lfunc_set_zero_cap_for_tests(L, 2);
+
+  ec |= Lfunc_use_all_lpolys(L, cb, NULL);
+  assert(!fatal_error(ec));
+
+  ec |= Lfunc_compute(L);
+  assert(fatal_error(ec));
+  assert(ec & ERR_ZERO_OVERFLOW);
+  assert(count_zeros_to_cap(L, 0, 2) == 2);
+
+  Lfunc_clear(L);
+  return 0;
+}

--- a/test/zero_overflow_test.cpp
+++ b/test/zero_overflow_test.cpp
@@ -58,16 +58,14 @@ static int count_zeros(Lfunc_t L, uint64_t side) {
 
 int main() {
   static double mus[2] = {0, 1};
-  Lparams_t Lp = {};
+  Lparams_t Lp;
+  Lparams_init(&Lp);
   Lp.degree = 2;
   Lp.conductor = (uint64_t)P * (uint64_t)Q; // 100160063 ~ 1e8
   Lp.normalisation = 0.0;
   Lp.mus = mus;
   Lp.target_prec = 300;                     // survive precision decay to the 1.5*H Turing end
-  Lp.wprec = 0;
-  Lp.gprec = 0;
   Lp.self_dual = YES;                        // self-dual: skip the dual side (halve the work)
-  Lp.rank = DK;
   Lp.cache_dir = (char *)"build/zero_overflow_cache";
   Lp.max_t = 384.0;                          // H: want_fft_NN = next_pow2(2048*384) = 2^20
   Lp.max_fft_NN = (uint64_t)1 << 21;         // cap comfortably above the required 2^20

--- a/test/zero_overflow_test.cpp
+++ b/test/zero_overflow_test.cpp
@@ -1,0 +1,102 @@
+// Opt-in regression test: hitting the per-side zero cap MAX_ZEROS must fail
+// LOUDLY and FATALLY with ERR_ZERO_OVERFLOW, never silently truncate.
+//
+// Before this fix, find_zeros (src/zeros.c) `return ecode` when the zeros array
+// filled, indistinguishable from the legitimate end-of-range return. A truncated
+// zero set then fed the RH check, silently invalidating it. The fix flags
+// ERR_ZERO_OVERFLOW (fatal) at the three cap sites so a caller can never trust a
+// truncated result.
+//
+// This drives a REAL degree-2 computation whose analyzed range packs MORE than
+// MAX_ZEROS (2048) zeros, and asserts the result is fatal with ERR_ZERO_OVERFLOW
+// set. It is HEAVY (fft_NN = 2^20, ~1.4M Euler factors, ~3 GB peak resident;
+// the zero-finding alone isolates ~2048 zeros, so it runs for several minutes,
+// longer on a busy machine), so it is DENY-LISTED from the default `make check`
+// via CHECK_EXCLUDE in Makefile.in. Build and run it directly:
+//
+//     ./configure --enable-assert && make test
+//     ./build/test/zero_overflow_test.exe
+//
+// Exit 0 (no assertion fired) = pass.
+//
+// The trigger object is the product of the quadratic characters mod 10007 and
+// mod 10009 (conductor 100160063 ~ 1e8), a self-dual degree-2 L-function, run at
+// an enlarged output window H = max_t = 384 with target_prec = 300. A large
+// conductor boosts the zero DENSITY (~ (1/2pi) log N per unit height) without
+// growing fft_NN as fast as raising max_t on a small conductor would, and the
+// raised precision lets the working precision survive to the far (1.5*H) end of
+// the analyzed range where the 2048nd zero lies. At these parameters find_zeros
+// fills the array (count == MAX_ZEROS) before reaching the end of the Turing
+// zone, so the cap, not legitimate completion, is what stops it.
+
+#include <flint/acb_poly.h>
+#include <flint/ulong_extras.h>
+#include "glfunc.h"
+#include <cassert>
+#include <cstdio>
+#include <cstdint>
+#include <sys/stat.h>
+
+// Good-prime Euler factor of chi_P * chi_Q at p: (1 - chi_P(p) x)(1 - chi_Q(p) x).
+// A ramified chi(p) = 0 drops its factor (n_jacobi returns 0 on a shared factor).
+static long P = 10007, Q = 10009;
+static void dir_cb(acb_poly_t poly, uint64_t p, int, int64_t, void *) {
+  acb_poly_zero(poly);
+  long a = n_jacobi((slong)(p % P), P);   // chi_P(p) in {-1,0,1}
+  long b = n_jacobi((slong)(p % Q), Q);   // chi_Q(p)
+  acb_poly_set_coeff_si(poly, 0, 1);
+  acb_poly_set_coeff_si(poly, 1, -(a + b));
+  if (a != 0 && b != 0) acb_poly_set_coeff_si(poly, 2, a * b);
+}
+
+// Count the (contiguous, zero-terminated) zeros stored on a side.
+static int count_zeros(Lfunc_t L, uint64_t side) {
+  int n = 0;
+  while (n < (int)MAX_ZEROS && !arb_is_zero(Lfunc_zeros(L, side) + n)) n++;
+  return n;
+}
+
+int main() {
+  static double mus[2] = {0, 1};
+  Lparams_t Lp = {};
+  Lp.degree = 2;
+  Lp.conductor = (uint64_t)P * (uint64_t)Q; // 100160063 ~ 1e8
+  Lp.normalisation = 0.0;
+  Lp.mus = mus;
+  Lp.target_prec = 300;                     // survive precision decay to the 1.5*H Turing end
+  Lp.wprec = 0;
+  Lp.gprec = 0;
+  Lp.self_dual = YES;                        // self-dual: skip the dual side (halve the work)
+  Lp.rank = DK;
+  Lp.cache_dir = (char *)"build/zero_overflow_cache";
+  Lp.max_t = 384.0;                          // H: want_fft_NN = next_pow2(2048*384) = 2^20
+  Lp.max_fft_NN = (uint64_t)1 << 21;         // cap comfortably above the required 2^20
+
+  mkdir("build/zero_overflow_cache", 0777);
+
+  Lerror_t ec = ERR_SUCCESS;
+  Lfunc_t L = Lfunc_init_advanced(&Lp, &ec);
+  assert(!fatal_error(ec));                  // the window/geometry itself is valid
+
+  ec |= Lfunc_use_all_lpolys(L, dir_cb, NULL);
+  assert(!fatal_error(ec));                  // supplying Euler factors must not fail
+
+  ec |= Lfunc_compute(L);
+
+  // The discriminating assertions: on the FIXED code the cap is reached and the
+  // result is FATAL with ERR_ZERO_OVERFLOW set; on the BROKEN code (silent
+  // `return ecode` at the cap sites) the same compute fills the array but returns
+  // a NON-fatal code, so both of these fail.
+  assert(fatal_error(ec));
+  assert(ec & ERR_ZERO_OVERFLOW);
+
+  // Corroboration: the array did fill to exactly the cap (this alone does NOT
+  // distinguish fixed from broken -- the broken code also stores MAX_ZEROS zeros
+  // -- so it is a sanity check, not the discriminator).
+  int nz = count_zeros(L, 0);
+  assert(nz == (int)MAX_ZEROS);
+
+  Lfunc_clear(L);
+  printf("zero_overflow ok (found %d zeros on side 0, ERR_ZERO_OVERFLOW fatal)\n", nz);
+  return 0;
+}


### PR DESCRIPTION
# Configurable critical-line output-window height

Makes the height `H` of the trusted critical-line output window, historically hard-wired to
`64/degree`, a caller-supplied `Lparams_t` parameter, supporting both shrinking (cheaper) and
enlarging (more zeros / higher reach) while keeping the output certified and the default path
bit-for-bit unchanged. Implements bead `lfunctions-31c` (children `31c.1`-`.9`).

## API

`Lparams_t` gains two advanced knobs (honoured only via `Lfunc_init_advanced`; `Lfunc_init`
sets the sentinels, so existing default callers are unaffected):

- `double max_t` : output-window half-height `H`. `<= 0` means the default `64/degree`.
- `uint64_t max_fft_NN` : cap on the output transform length. `0` means the current `1<<16`.

Two new fatal error codes (`glfunc.h`, with `fprint_errors` branches): `ERR_WINDOW_TOO_LARGE`
and `ERR_WINDOW_TOO_SMALL`.

NOTE: zero-initialise `Lparams_t` before `Lfunc_init_advanced` (documented in the header). The
new fields use `0`/`<=0` as the "use default" sentinel, so a partially-initialised struct is a
caller error; the two in-tree advanced-API tests were updated accordingly.

## Geometry

A requested `H` drives `B = OUTPUT_RATIO*H` and `fft_NN = next_pow2(1024*degree*H)`, and the G
grid is recomputed at that `B`. The default `H = 64/degree` reproduces today exactly
(`B = 512/degree`, `fft_NN = 2^16`, `A = 128*degree`, same G cache), verified bit-for-bit
across degrees.

Enlarging needs a larger short Euler-convolution FFT, so `fft_N` (was hard-wired `1<<11`) now
**scales**: `fft_N = max(1<<11, next_pow2(conv_support(L)))`. `conv_support` upper-bounds the
linear-convolution support of the G grid `[low_i, hi_i]` and the coefficient buckets, whose
smallest member is coefficient `n=1` at `calc_m(1) = round(log(1/sqrt(N))/(2*pi/B))`; it is
therefore **conductor-dependent**. This preserves the default (`conv_support < 2^11` for every
realizable conductor, so `fft_N` stays `2048`) and prevents the cyclic-convolution aliasing that
would otherwise return silently-wrong certified zeros for an enlarged window at conductor above
~1e4. The rigorous error bounds are independent of the value of `fft_N`, so no bound
re-derivation was needed; the init sizing and a `finalise_comp` backstop share the helper and
re-check the support at compute time.

## Loud failure, never silent-wrong

Every out-of-range or degenerate request fails with a fatal `Lerror_t`, never a wrong ball, a
hang, or an `exit()`:

- Above the cap: `ERR_WINDOW_TOO_LARGE`. Non-finite/overflowing `max_t` is caught before the
  cast (no integer wraparound).
- Below the valid floor: `ERR_WINDOW_TOO_SMALL`, from `fft_NN >= fft_N`, `B > 4/degree`,
  `B > 0.5 + max(mus)` with a side-effect-free positive-`beta` preflight, a `taylor_terms`
  termination cap, and an upsample period-fit check.
- An `exit(0)` on the `F_hat_twiddle_error` side condition is converted to a fatal return.

## G cache is window-aware

The on-disk G cache now stores `one_over_B` in its header (exact hex-float), validated against
the request; a cache written for one window can no longer be silently reused for another
(`GCACHE_VERSION` bumped to 2). Without this, a default-window run sharing a cache directory
with a larger-window run silently inherited the wrong `B`/grid.

## Pre-existing bugs fixed here

**Required by this feature (`src/rank.c`).** `df_zero` cached `a_pi_d[i] = (pi*A)^i` in
function-static storage and recomputed it only when the working precision increased (keyed on
`prec`, not on `A`). Every degree-`d` L-function used to share `A = 128*degree`, so the cache was
always consistent and this was unreachable. With per-object windows `A = fft_NN/B` varies, so
computing an enlarged object (higher precision, larger `A`) before a default-window object of the
same degree in one process makes the second read the first's `(pi*A)^d`: its `Lfunc_Taylor` comes
back scaled by `A_enlarge/A_default` (`ec_37.a1`: 0.40800 instead of 0.30600) -- a certified ball
not containing the truth, raised with only a non-fatal warning. The window feature makes this
reachable, so the fix ships here (recompute `(pi*A)^d` per call; keep `i!/pi^i` cached by
precision). Regression test: the multi-window case in `test/window_test.cpp`. This is the
`rank.c` half of bead `1yx`; the `turing.c` half (a spurious, non-fatal `ERR_RH_ERROR` on a later
different-window object -- loud, not silent) is owned by branch `fix/turing-static-cache`.

**Independent (`src/error.c`, cherry-pickable).** A pre-existing error-propagation bug in
`do_pre_iFFT_errors` (the F_hat-twiddle and eq59 errors were added to `res[i]` instead of
`res[j]`, so the populated bins omitted them). Impact is numerically negligible (~1e-62, ~12
orders below the dominant term), but the certification is now sound. It touches only
`src/error.c` and is independent of the window feature.

## Testing

`test/window_test.cpp` covers: default-equivalence; explicit-equals-default; enlarge (H=64,
cross-checked against LMFDB `EllipticCurve/Q/37/a` for the first 13 zeros, with overlap and
`|eps|=1` for the enlarge-only region); valid shrink (correct prefix of the default zeros);
too-large (cap); too-small (fft_NN floor, and a high-weight tau case isolating the `beta`
preflight); cache-poisoning (a larger window's cache must not poison a default run); and a
high-conductor case (`chi_227 * chi_229`, conductor 51983, `M0=3`) whose enlarged-window zeros
must overlap the always-correct default, exercising the conductor-dependent `conv_support` that
conductor 37 (`M0=1`) cannot. `test/error_propagation_test.c` distinguishes the incidental fix
from the bug: the omitted G-tail term is masked by `M_error` in every reachable public output
(lowering `gprec` inflates both in lockstep), so a white-box check inflates `sum_ans` (which
`M_error` ignores) and calls `do_pre_iFFT_errors` directly, asserting the term lands on the
populated bin `res[0]` (fix) rather than on the later-zeroed `res[break]` (bug). The
window-rejection paths are Valgrind-clean (0 bytes leaked). `make check` passes. Each commit
received an independent spec-compliance and a code-quality review.

## Design doc

`docs/superpowers/specs/2026-06-02-output-window-height-design.md` (excluded from git) holds the
full design and certification argument, reconciled to the implemented `fft_N`-scaling approach.

## Follow-ups (filed as separate beads, not in this PR)

Library-wide issues surfaced during review, independent of this feature: `3xq` (`M_error` uses
global `L->M`), `1yx` (static per-call caches reuse stale state across objects), `b8a` (working
precision lacks an `fft_NN`-dependent roundoff term), `v50` (silent `MAX_ZEROS` truncation),
`1eb` (free the partial `Lfunc` on the remaining init OOM paths; the window-rejection paths are
freed in this PR).
