### PR TITLE
docs: Sphinx documentation site and public C API guide

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,28 @@
+name: Docs
+on:
+  push:
+    branches: [main]
+  pull_request:
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3"
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          # doxygen for the API reference; the docs build is self-contained and
+          # does not compile the library, so no FLINT / primesieve are needed.
+          sudo apt-get install -y doxygen
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -r doc/requirements.txt
+      - name: Build docs (warnings are errors)
+        run: make -C doc html
+      - name: Upload HTML
+        uses: actions/upload-artifact@v4
+        with:
+          name: html-docs
+          path: doc/_build/html

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,15 @@
-# Makefile
-Makefile
+# Generated root Makefile (./configure writes it from Makefile.in); anchored to
+# the repo root so it does not also ignore the hand-written doc/Makefile.
+/Makefile
 
 
 # Hidden files
 .?*
 !.github
+!.readthedocs.yaml
+
+# Sphinx documentation build output (doc/.venv is already covered by .?* above)
+doc/_build/
 
 # g files
 g_[0-9]*

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# Read the Docs build configuration for the liblfun documentation.
+# https://docs.readthedocs.io/en/stable/config-file/v2.html
+#
+# conf.py runs doxygen itself (it is on PATH thanks to build.apt_packages), so
+# Read the Docs only needs to install the Python requirements and run Sphinx.
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3"
+  apt_packages:
+    - doxygen
+
+sphinx:
+  configuration: doc/conf.py
+  # Match the local `make html` (doc/Makefile): fail the build on any Sphinx warning.
+  fail_on_warning: true
+
+python:
+  install:
+    - requirements: doc/requirements.txt

--- a/README.md
+++ b/README.md
@@ -6,6 +6,36 @@ For details of the methods we refer to:
  - *Computing motivic L-functions*, (under preparation) by Jonathan W. Bober, Andrew R. Booker, Edgar Costa, Min Lee, David J. Platt, and Andrew V. Sutherland.
 
 
+## Documentation
+
+The API reference and guides are built with [Sphinx](https://www.sphinx-doc.org/)
+from the sources under `doc/`. The per-function reference is generated from the
+comments in `include/glfunc.h` (via Doxygen and Breathe), so the header stays the
+single source of truth. The docs build is self-contained under `doc/` and is
+independent of the library build.
+
+Build the HTML locally, from the repository root:
+
+```sh
+make -C doc html
+```
+
+This writes the site to `doc/_build/html/index.html`. It needs `sphinx-build`
+(with the `myst-parser` and `breathe` packages) and the `doxygen` binary. A
+convenient setup is a virtual environment under `doc/`:
+
+```sh
+python3 -m venv doc/.venv
+doc/.venv/bin/pip install -r doc/requirements.txt
+sudo apt-get install doxygen        # or: brew install doxygen
+make -C doc html
+```
+
+`make -C doc html` (equivalently `cd doc && make html`) runs Doxygen over
+`include/glfunc.h` and then Sphinx. `doc/Makefile` is a standard Sphinx
+makefile, so its other targets work too (`make -C doc clean`, `make -C doc help`).
+
+
 ## Dependencies
 
 The primary dependencies are:

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -1,0 +1,61 @@
+# Doxygen configuration for liblfun.
+#
+# This file is consumed by Breathe (via conf.py, which runs `doxygen` before the
+# Sphinx build). It extracts the declarations and comments from the public
+# header include/glfunc.h into XML under doc/_build/doxygen/xml, which Breathe
+# then renders inside Sphinx. The header therefore stays the single source of
+# truth for the per-function reference.
+#
+# Paths are relative to the repository root: conf.py changes into the repo root
+# (the parent of doc/) before invoking doxygen, so `doxygen doc/Doxyfile` is run
+# from there and resolves INPUT/OUTPUT_DIRECTORY consistently with the Makefile.
+
+PROJECT_NAME           = liblfun
+PROJECT_BRIEF          = "Generic motivic L-function calculator"
+
+# Only the public API header. The internal header (glfunc_internals.h) and the
+# .c sources are deliberately excluded: the docs cover the public interface.
+INPUT                  = include/glfunc.h
+FILE_PATTERNS          = *.h
+RECURSIVE              = NO
+
+# All output lands under the Sphinx build tree so `make clean`-style removal of
+# doc/_build wipes the generated XML too. Only the XML feeds Breathe.
+OUTPUT_DIRECTORY       = doc/_build/doxygen
+GENERATE_HTML          = NO
+GENERATE_LATEX         = NO
+GENERATE_XML           = YES
+XML_OUTPUT             = xml
+XML_PROGRAMLISTING     = YES
+
+# C, not C++: turn off the C++-isms in the output and parse the header as C.
+OPTIMIZE_OUTPUT_FOR_C  = YES
+
+# Render every declaration in the header even when it carries no doc-comment, so
+# the API reference is complete (all types, macros, and function prototypes)
+# from day one. As the header's comments are migrated to Doxygen style (/// or
+# /** */), their text attaches to these entries automatically, with no change
+# here or in conf.py.
+EXTRACT_ALL            = YES
+EXTRACT_STATIC         = YES
+HIDE_UNDOC_MEMBERS     = NO
+HIDE_UNDOC_CLASSES     = NO
+
+# Treat a leading comment line as the brief description (JavaDoc style) when the
+# header gains /** */ blocks.
+JAVADOC_AUTOBRIEF      = YES
+
+# Expand the error-code and tri-state macros so they appear with their values.
+# PREDEFINED feeds the preprocessor the guards the header expects.
+ENABLE_PREPROCESSING   = YES
+MACRO_EXPANSION        = YES
+EXPAND_ONLY_PREDEF     = NO
+PREDEFINED             = __cplusplus TURING
+
+# Keep the run quiet and fail loudly on a genuinely broken header. WARN_AS_ERROR
+# is left off so an undocumented-but-valid prototype does not break the docs build;
+# Sphinx's own -W (warnings-as-errors) guards the prose build.
+QUIET                  = YES
+WARNINGS               = YES
+WARN_IF_UNDOCUMENTED   = NO
+WARN_NO_PARAMDOC       = NO

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,0 +1,35 @@
+# Minimal makefile for the liblfun documentation.
+#
+# Sphinx + Breathe over the Doxygen XML of ../include/glfunc.h. This build is
+# self-contained under doc/: it does not depend on the library build, and the
+# library Makefile does not depend on it. conf.py runs Doxygen itself, so the
+# only tools needed are sphinx-build and the doxygen binary on PATH.
+#
+# Set up the toolchain once, then build from this directory:
+#   python3 -m venv .venv
+#   .venv/bin/pip install -r requirements.txt
+#   sudo apt-get install doxygen        # or: brew install doxygen
+#   make html                           # HTML in _build/html/index.html
+#
+# Override the tool or options from the command line, e.g.
+#   make html SPHINXBUILD=/path/to/sphinx-build
+#   make html SPHINXOPTS=               # do not treat warnings as errors
+
+# Prefer a sphinx-build under .venv if a contributor created one here; otherwise
+# use whatever is on PATH (an activated venv, a system package, Read the Docs).
+SPHINXBUILD  ?= $(if $(wildcard .venv/bin/sphinx-build),.venv/bin/sphinx-build,sphinx-build)
+# -W --keep-going turns Sphinx warnings into errors (collecting them all first),
+# so a broken cross-reference or an orphaned page fails the build.
+SPHINXOPTS   ?= -W --keep-going
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# `make` with no target prints Sphinx's list of builders (html, clean, ...).
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all: route any target (html, clean, linkcheck, ...) through sphinx-build.
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/doc/_static/custom.css
+++ b/doc/_static/custom.css
@@ -1,0 +1,7 @@
+/* Custom styles for the liblfun documentation (furo theme).
+ *
+ * Intentionally minimal: this file exists so doc/_static/ is tracked (the
+ * repository .gitignore drops hidden files such as .gitkeep) and so there is an
+ * obvious place to add documentation-specific CSS later. Add rules below; the
+ * file is wired in via html_css_files in conf.py.
+ */

--- a/doc/api.md
+++ b/doc/api.md
@@ -1,0 +1,26 @@
+# API reference
+
+```{note}
+This page is a scaffold placeholder. The narrative API guide (the lifecycle
+walk-through, the mu / normalisation convention, error handling, and worked
+examples) is written under bead **lfunctions-rrt**, which lands on this same
+branch. TODO(rrt): replace this note and the prose below; keep or extend the
+Breathe directive at the bottom so the reference stays generated from the
+header.
+```
+
+The public interface is declared in
+[`include/glfunc.h`](https://github.com/edgarcosta/lfunctions/blob/main/include/glfunc.h).
+All work flows through one lifecycle: initialise an `Lfunc_t`, supply the Euler
+factors, call `Lfunc_compute`, query the results, then clear.
+
+## Full header reference
+
+The declarations below are generated from `include/glfunc.h` by Doxygen and
+rendered through Breathe, so the header is the single source of truth. As the
+header's comments are migrated to Doxygen style, their descriptions appear here
+automatically.
+
+```{doxygenfile} glfunc.h
+:project: liblfun
+```

--- a/doc/api.md
+++ b/doc/api.md
@@ -1,25 +1,607 @@
-# API reference
+# Public C API guide
 
-```{note}
-This page is a scaffold placeholder. The narrative API guide (the lifecycle
-walk-through, the mu / normalisation convention, error handling, and worked
-examples) is written under bead **lfunctions-rrt**, which lands on this same
-branch. TODO(rrt): replace this note and the prose below; keep or extend the
-Breathe directive at the bottom so the reference stays generated from the
-header.
+`liblfun` exposes a single opaque-pointer C interface, declared in
+[`include/glfunc.h`](https://github.com/edgarcosta/lfunctions/blob/main/include/glfunc.h).
+This page is the narrative guide to that interface: the object lifecycle, the
+mu / normalisation convention, how to supply Euler factors, how to read the
+results back, the error model, and the hard limits. The complete
+per-function reference, generated from the header, is at the
+[bottom of this page](#full-header-reference); the prose below links into it
+with cross-references such as {c:func}`Lfunc_init`.
+
+Everything the library computes is returned as a *certified ball*: FLINT/Arb
+`arb_t` (real) and `acb_t` (complex) values whose radius is a rigorous error
+bound, never a bare floating-point number. To consume a result you read its
+midpoint and radius with the usual Arb accessors, or compare it against a
+reference ball with `arb_overlaps` / `acb_overlaps` / `arb_contains`.
+
+```{contents}
+:local:
+:depth: 2
 ```
 
-The public interface is declared in
-[`include/glfunc.h`](https://github.com/edgarcosta/lfunctions/blob/main/include/glfunc.h).
-All work flows through one lifecycle: initialise an `Lfunc_t`, supply the Euler
-factors, call `Lfunc_compute`, query the results, then clear.
+## At a glance
+
+The whole interface follows one lifecycle. Create an L-function object, tell it
+the Euler factors of the L-series, run the computation, query whichever
+quantities you need, then free it.
+
+```c
+#include <flint/acb_poly.h>
+#include "glfunc.h"
+
+Lerror_t ecode = ERR_SUCCESS;     // accumulate errors here
+double mus[2] = {0.0, 1.0};       // Gamma_R shifts (algebraic normalisation)
+
+// 1. create: degree 2, conductor 37, weight-2 normalisation 0.5
+Lfunc_t L = Lfunc_init(2, 37, 0.5, mus, &ecode);
+if (fatal_error(ecode)) { fprint_errors(stderr, ecode); return 1; }
+
+// 2. supply the Euler factors (callback over every prime <= Lfunc_nmax(L))
+ecode |= Lfunc_use_all_lpolys(L, lpoly_callback, NULL);
+if (fatal_error(ecode)) { fprint_errors(stderr, ecode); return 1; }
+
+// 3. run the full computation
+ecode |= Lfunc_compute(L);
+if (fatal_error(ecode)) { fprint_errors(stderr, ecode); return 1; }
+
+// 4. query
+int64_t   rank  = Lfunc_rank(L);          // analytic rank
+acb_srcptr sign = Lfunc_sign(L);          // root number epsilon
+arb_srcptr lead = Lfunc_Taylor(L);        // leading Taylor coefficient
+arb_srcptr zer  = Lfunc_zeros(L, 0);      // zeros of L on the critical line
+
+// 5. free
+Lfunc_clear(L);
+
+// any warnings collected along the way:
+fprint_errors(stderr, ecode);
+```
+
+The numbered steps map onto the sections below. The two helpers that bracket
+the lifecycle, {c:func}`fatal_error` (does this accumulator hold a fatal flag?)
+and {c:func}`fprint_errors` (print one human-readable line per flag), are
+covered under [Error handling](#error-handling).
+
+## The Lfunc_t lifecycle
+
+### 1. Create: `Lfunc_init` and `Lfunc_init_advanced`
+
+{c:func}`Lfunc_init` is the common entry point:
+
+```c
+Lfunc_t Lfunc_init(uint64_t degree, uint64_t conductor,
+                   double normalisation, const double *mus,
+                   Lerror_t *ecode);
+```
+
+- `degree` is the degree of the L-function. It must satisfy
+  `2 <= degree <= MAX_DEGREE`; otherwise {c:macro}`ERR_BAD_DEGREE` fires.
+- `conductor` is the (integer) conductor.
+- `normalisation` and `mus` set the gamma factor and the algebraic-to-analytic
+  shift; see [The mu / normalisation convention](#mu-normalisation).
+  `mus` is an array of `degree` doubles that the library copies, so the caller
+  may free it immediately after the call.
+- `ecode` points at a {c:type}`Lerror_t` accumulator. On any fatal flag the
+  returned pointer is unusable; check {c:func}`fatal_error` before continuing.
+
+{c:func}`Lfunc_init_advanced` takes the same information through a
+{c:struct}`Lparams_t` struct and additionally exposes the precision and
+strategy knobs:
+
+```c
+typedef struct {
+  uint64_t degree;
+  uint64_t conductor;
+  double   normalisation;
+  double  *mus;
+  int64_t  target_prec;   // target output precision, in bits
+  int64_t  wprec;         // working precision, in bits
+  int64_t  gprec;         // precision for the gamma-factor (G) computation
+  int      self_dual;     // DK / YES / NO
+  int      rank;          // DK, or a known rank
+  char    *cache_dir;     // directory for the cached G data
+} Lparams_t;
+```
+
+| Field | Meaning | Default when left as 0 / `DK` |
+| --- | --- | --- |
+| {c:member}`target_prec <Lparams_t.target_prec>` | precision the results are refined to | {c:macro}`DEFAULT_TARGET_PREC` (100 bits) |
+| {c:member}`wprec <Lparams_t.wprec>` | internal working precision | derived from `target_prec` |
+| {c:member}`gprec <Lparams_t.gprec>` | precision of the gamma-factor product | derived from the working precision |
+| {c:member}`self_dual <Lparams_t.self_dual>` | whether the L-function equals its dual | `DK`: the library decides |
+| {c:member}`rank <Lparams_t.rank>` | analytic rank, if already known | `DK`: the library determines it |
+| {c:member}`cache_dir <Lparams_t.cache_dir>` | where to read/write cached G data | current directory; see [The G-data cache](#g-data-cache) |
+
+The tri-state fields use the macros {c:macro}`DK` (-1, "don't know"),
+{c:macro}`YES` (1), and {c:macro}`NO` (0). Setting `self_dual = YES` when you
+know the L-function is self-dual (every elliptic curve over Q, for instance)
+lets the library skip computing the dual side. Supplying a known `rank` lets it
+skip the rank search; if the computed rank then disagrees with what you
+supplied, you get the {c:macro}`ERR_CONFLICT_RANK` warning.
+
+Leaving a numeric knob at 0 asks the library to choose it. There is no need to
+set `target_prec`, `wprec`, or `gprec` unless you have a specific reason;
+{c:func}`Lfunc_init` is exactly `Lfunc_init_advanced` with those left to their
+defaults, `self_dual = DK`, `rank = DK`, and no cache directory.
+
+### 2. Supply the Euler factors
+
+Between creation and computation you hand the library the local L-factors of
+the L-series. The routes are described in detail in
+[Supplying Euler factors](#supplying-euler-factors). In brief: either let the
+library drive a callback over every prime it needs
+({c:func}`Lfunc_use_all_lpolys`), or push factors one prime at a time
+({c:func}`Lfunc_use_lpoly`).
+
+### 3. Compute
+
+{c:func}`Lfunc_compute` runs the whole numerical pipeline (the FFT, the
+upsampling, the zero search, the RH check, and the rank determination) and
+returns an accumulated {c:type}`Lerror_t`. OR it into your accumulator and
+check {c:func}`fatal_error` before reading any result. After it returns,
+{c:func}`Lfunc_wprec` reports the working precision the computation actually
+used.
+
+### 4. Query
+
+Read back the rank, root number, leading Taylor coefficient, zeros, special
+values, and plot samples. See [Querying the results](#querying-the-results).
+
+### 5. Clear
+
+{c:func}`Lfunc_clear` frees the entire object. An {c:struct}`Lplot_t` returned
+by {c:func}`Lfunc_plot_data` owns its own buffer and is freed separately with
+{c:func}`Lfunc_clear_plot`.
+
+(mu-normalisation)=
+
+## The mu / normalisation convention
+
+An L-function in this library is specified in the **algebraic** normalisation
+(integer Dirichlet coefficients, functional equation `s -> k - s` for motivic
+weight `k`) but is computed internally in the **analytic** normalisation
+(functional equation centered at `1/2`). Two inputs bridge the two:
+
+- `mus[i]` are the shifts of the `Gamma_R` factors that make up the completed
+  L-function's gamma factor, in the algebraic normalisation.
+- `normalisation` is the shift along the `s`-axis that converts algebraic to
+  analytic. If `a_n` is the n-th Dirichlet coefficient in the algebraic
+  normalisation, then `a_n / n^{normalisation}` is the coefficient in the
+  analytic one. For a functional equation `Lambda(s) = eps Lambda(k - s)`, take
+  `normalisation = (k - 1) / 2`.
+
+Internally the library stores `mus[i] + normalisation` for each `i` and runs
+entirely in the analytic normalisation. The hard constraint is:
+
+> Every `mus[i] + normalisation` must be a **non-negative half-integer** (an
+> element of `{0, 1/2, 1, 3/2, ...}`). Otherwise {c:func}`Lfunc_init` sets the
+> fatal {c:macro}`ERR_MU_HALF` flag.
+
+Because only the sum `mus[i] + normalisation` matters, the same L-function has
+many equivalent `(mus, normalisation)` encodings. For an elliptic curve over Q
+(degree 2, weight 2):
+
+```
+mus = [0, 1],   normalisation = 0.5     <==>     mus = [0.5, 1.5], normalisation = 0
+```
+
+Both feed the library the analytic shifts `[0.5, 1.5]` and must produce
+identical output. For a classical modular form of weight 13 (motivic weight
+12, so `normalisation = 6`):
+
+```
+mus = [0, 1],   normalisation = 6       <==>     mus = [6, 7],     normalisation = 0
+```
+
+Choosing `normalisation = (k - 1) / 2` and small `mus` keeps the encoding close
+to how the object is usually tabulated (for example on the LMFDB), which is why
+the worked examples use `mus = [0, 1]` with the weight-derived
+`normalisation`.
+
+## Supplying Euler factors
+
+The library needs the local L-factor `L_p(T)` (an `acb_poly_t`, a polynomial in
+`T` with the constant term normalised to 1) for every prime `p` up to a bound
+fixed by the conductor and degree. {c:func}`Lfunc_nmax` returns that bound:
+
+```c
+uint64_t nmax = Lfunc_nmax(L);   // largest prime p for which a factor is expected
+```
+
+There are two ways to deliver the factors.
+
+### Driven by the library: `Lfunc_use_all_lpolys`
+
+```c
+Lerror_t Lfunc_use_all_lpolys(
+    Lfunc_t L,
+    void (*lpoly_callback)(acb_poly_t lpoly, uint64_t p, int d,
+                           int64_t prec, void *parm),
+    void *param);
+```
+
+The library calls `lpoly_callback` once for each prime `p <= Lfunc_nmax(L)`,
+in increasing order. The callback fills `lpoly` with `L_p(T)`; `d` is the
+expected degree of the factor and `prec` the working precision, and `param` is
+your opaque pointer passed straight through. This is the most convenient route:
+you never enumerate the primes yourself.
+
+It also carries a **short-circuit**: if the callback leaves `lpoly` set to the
+zero polynomial for some prime, the library stops calling, takes that prime as
+the end of your data, and reduces its internal `nmax` accordingly (as if you had
+called {c:func}`Lfunc_reduce_nmax`). This is the idiomatic way to say "I have
+factors up to here and no further": return zero for the first prime you cannot
+supply.
+
+A minimal callback that serves factors from a lookup table and zero-terminates
+when it runs out:
+
+```c
+void lpoly_callback(acb_poly_t poly, uint64_t p, int d, int64_t prec, void *param)
+{
+  acb_poly_zero(poly);                 // default: zero -> short-circuits
+  const factor_t *f = lookup(param, p);
+  if (f)                               // we have a factor for this prime
+    for (size_t i = 0; i < f->len; ++i)
+      acb_poly_set_coeff_si(poly, i, f->coeff[i]);
+}
+```
+
+### One prime at a time: `Lfunc_use_lpoly`
+
+```c
+void Lfunc_use_lpoly(Lfunc_t L, uint64_t p, const acb_poly_t poly);
+```
+
+Push a single factor for the prime `p`. Use this when you already have the
+primes enumerated (for example from `primesieve`) and want to loop yourself.
+The library copies `poly`. The [worked example](#a-worked-end-to-end-example)
+on this page uses the callback form;
+[`examples/rational.c`](https://github.com/edgarcosta/lfunctions/blob/main/examples/rational.c)
+uses this push form over a `primesieve`-generated prime list.
+
+### Supplying fewer factors than `nmax`: `Lfunc_reduce_nmax`
+
+```c
+bool Lfunc_reduce_nmax(Lfunc_t L, uint64_t nmax);
+```
+
+If you cannot reach {c:func}`Lfunc_nmax`, call this *before* supplying factors
+to declare a smaller bound. **The library takes your word for it and does not
+check** that the reduced bound still yields a correct result, so use it only
+when you understand the consequence. Supplying too few factors (whether through
+this call, or by zero-terminating the callback early, or by simply pushing
+fewer with {c:func}`Lfunc_use_lpoly`) is reported after the computation as the
+{c:macro}`ERR_INSUFF_EULER` warning: the library expected more Euler factors
+than it received, so the results may be degraded or, in the worst case,
+meaningless.
+
+```{note}
+**Batch supply is on the way.** Array / batch supply of Euler factors and of
+raw Dirichlet coefficients `a_n` (and the associated input-validation error
+codes) is being added in the batch-supply API. Those entry points are not part
+of the interface on `main` yet; this guide will document them once they land.
+For now the supply routes are the callback ({c:func}`Lfunc_use_all_lpolys`) and
+the single-prime push ({c:func}`Lfunc_use_lpoly`) described above.
+```
+
+## Querying the results
+
+Call these only after {c:func}`Lfunc_compute` has returned without a fatal
+flag. The `arb_srcptr` / `acb_srcptr` return values are **borrowed**: they point
+into the `Lfunc_t` and stay valid until {c:func}`Lfunc_clear`. Do not free
+them; copy out (`arb_set` / `acb_set`) anything you need to outlive the object.
+
+### Rank: `Lfunc_rank`
+
+{c:func}`Lfunc_rank` returns the analytic rank (order of vanishing at the
+central point) as an `int64_t`. A returned rank of 0 or 1 is rigorous; a value
+greater than 1 is not certified. If the rank could not be determined you get
+the {c:macro}`ERR_NO_RANK` warning, and if it disagrees with a rank you supplied
+through {c:struct}`Lparams_t` you get {c:macro}`ERR_CONFLICT_RANK`.
+
+### Root number: `Lfunc_sign` and `Lfunc_sqrt_sign`
+
+{c:func}`Lfunc_sign` returns the sign (root number) `eps` of the functional
+equation `Lambda(s) = eps * Lambda(k - s)`, as a borrowed `acb_srcptr`. It is a
+complex number of absolute value 1; `|eps| = 1` is a useful sanity check on a
+computation.
+
+```{note}
+The relevant symbol is {c:func}`Lfunc_sign`. Some example programs print this
+quantity under the label `Epsilon`, but there is no `Lfunc_epsilon` function;
+the accessor is `Lfunc_sign`.
+```
+
+{c:func}`Lfunc_sqrt_sign` returns a square root of the sign, with the branch
+chosen so that `Lambda` is positive at the central point.
+
+### Leading Taylor coefficient: `Lfunc_Taylor`
+
+{c:func}`Lfunc_Taylor` returns the first non-zero Taylor coefficient at the
+central point, that is `L^{(rank)}((w + 1)/2) / rank!`, where `w/2` is the
+normalisation (when the input is algebraic, `w` is the motivic weight). It
+carries the same rigour caveat as the rank: rigorous for rank 0 or 1. To
+evaluate the L-function exactly at the central point, use this rather than
+{c:func}`Lfunc_special_value`.
+
+### Zeros: `Lfunc_zeros`
+
+```c
+arb_srcptr Lfunc_zeros(Lfunc_t L, uint64_t side);
+```
+
+Returns the array of imaginary parts of the zeros on the critical line, as
+borrowed `arb_t` balls. `side = 0` gives the zeros of `L`; `side = 1` gives
+those of the dual L-function (for a self-dual L-function the two agree). When
+the rank is 0 or 1 and the RH check succeeded (no {c:macro}`ERR_RH_ERROR`
+warning), the list is complete up to the height reached; otherwise some zeros
+may be missing. At most {c:macro}`MAX_ZEROS` (256) zeros are stored per side.
+If the zeros could not be refined to the target precision you get the
+{c:macro}`ERR_ZERO_PREC` warning.
+
+### Special values: `Lfunc_special_value`
+
+```c
+Lerror_t Lfunc_special_value(acb_t res, Lfunc_t L, double re, double im);
+```
+
+Writes `L(re + i*im)` into `res` (an `acb_t` the caller has initialised) and
+returns an accumulated {c:type}`Lerror_t`. Accuracy is excellent near the
+critical line and falls away rapidly as you move away from it, but values such
+as `L(k)` and `L(0)` come out sensibly. The routine requires `im >= 0`;
+`im < 0` raises {c:macro}`ERR_SPEC_NZ`. For the central point use
+{c:func}`Lfunc_Taylor` instead. The lower-level
+{c:func}`Lfunc_special_value_choice` additionally returns the derivative and
+lets you choose between `L` and the completed `Lambda`.
+
+### Plot data: `Lfunc_plot_data` and `Lfunc_clear_plot`
+
+```c
+Lplot_t *Lfunc_plot_data(Lfunc_t L, uint64_t side, double max_t,
+                         uint64_t n_points);
+void     Lfunc_clear_plot(Lplot_t *Lp);
+```
+
+Returns roughly `n_points` samples of the real-valued Z-function
+`exp(i*theta(t)) * L(k/2 + i*t)` over `t` in `[0, max_t]`, for `L` (`side = 0`)
+or its dual (`side = 1`). The samples come back as plain doubles in a
+heap-allocated {c:struct}`Lplot_t`:
+
+```c
+typedef struct {
+  uint64_t n_points;   // number of samples actually produced
+  double   spacing;    // t-step between consecutive samples
+  double  *points;     // the sample values, length n_points
+} Lplot_t;
+```
+
+Free it with {c:func}`Lfunc_clear_plot` when done. Unlike the query accessors
+above, this struct is a separate allocation that you own.
+
+## Error handling
+
+Every API entry point that can fail returns an {c:type}`Lerror_t`, a 64-bit
+bitfield. The convention is:
+
+- **The lower 32 bits are fatal**; if any is set the computation cannot
+  continue and the results are invalid.
+- **The upper 32 bits are warnings**; the computation produced output, but with
+  a caveat (degraded precision, an unverified rank, an incomplete zero list).
+
+The idiom is to keep one accumulator and OR every return value into it, then
+gate on {c:func}`fatal_error` before each next step:
+
+```c
+Lerror_t ecode = ERR_SUCCESS;
+ecode |= Lfunc_use_all_lpolys(L, cb, NULL);
+ecode |= Lfunc_compute(L);
+if (fatal_error(ecode)) {       // true iff any low-32 (fatal) bit is set
+  fprint_errors(stderr, ecode); // one human-readable line per set flag
+  /* abort this L-function */
+}
+/* ... query ... */
+fprint_errors(stderr, ecode);   // surface any warnings collected en route
+```
+
+{c:func}`fatal_error` returns `true` iff any fatal (low-32) bit is set;
+warnings alone return `false`. {c:func}`fprint_errors` writes one line per set
+flag to the given `FILE *`. {c:macro}`ERR_SUCCESS` (0) is the clean state.
+
+### Fatal codes
+
+| Macro | Meaning |
+| --- | --- |
+| {c:macro}`ERR_NO_DATA` | the first two `Lambda(t)` samples contained zero: nothing usable |
+| {c:macro}`ERR_ZERO_ERROR` | unexpected failure isolating zeros |
+| {c:macro}`ERR_OOM` | out of memory |
+| {c:macro}`ERR_UPSAMPLE` | failure during upsampling |
+| {c:macro}`ERR_MU_HALF` | some `mus[i] + normalisation` is not a non-negative half-integer |
+| {c:macro}`ERR_M_ERROR` | could not compute the coefficient-count bound `M` |
+| {c:macro}`ERR_STAT_POINT` | failure locating a stationary point |
+| {c:macro}`ERR_SPEC_VALUE` | failure in the special-value routine |
+| {c:macro}`ERR_G_INFILE` | failure reading the G-data cache file |
+| {c:macro}`ERR_BAD_DEGREE` | degree below 2 or above {c:macro}`MAX_DEGREE` |
+| {c:macro}`ERR_SPEC_NZ` | special value requested with `Im(s) < 0` |
+| {c:macro}`ERR_G_EXTENT` | the G grid does not extend low enough (conductor too large for the fixed grid floor, or a stale cached grid was reused) |
+
+### Warning codes
+
+| Macro | Meaning |
+| --- | --- |
+| {c:macro}`ERR_SOME_DATA` | had sensible data, but not all the way through the Turing zone |
+| {c:macro}`ERR_ZERO_PREC` | could not isolate zeros to the target precision |
+| {c:macro}`ERR_RH_ERROR` | the RH check on the computed zeros failed |
+| {c:macro}`ERR_INSUFF_EULER` | ran out of Euler factors before the expected bound |
+| {c:macro}`ERR_NO_RANK` | could not determine the rank |
+| {c:macro}`ERR_CONFLICT_RANK` | the computed rank disagreed with the supplied one |
+| {c:macro}`ERR_DBL_ZERO` | a stationary point failed to converge (a double zero?) |
+| {c:macro}`ERR_SPEC_PREC` | could not reach the target error bound in a special value |
+| {c:macro}`ERR_G_OUTFILE` | could not open the file to write the G-data cache |
+
+When you add a new error code, it belongs in the header next to these and needs
+a matching message branch in `fprint_errors` (in `src/glfunc.c`).
+
+## Hard limits
+
+```{list-table}
+:header-rows: 1
+
+* - Macro
+  - Value
+  - Meaning
+* - {c:macro}`MAX_DEGREE`
+  - 9
+  - largest supported degree; raising it requires extending the Buthe integral
+    tables in `src/buthe.c` and reviewing `src/g.c`
+* - {c:macro}`MAX_ZEROS`
+  - 256
+  - hard cap on the number of zeros found and stored per side
+* - {c:macro}`DEFAULT_TARGET_PREC`
+  - 100
+  - default target precision, in bits, when {c:member}`target_prec <Lparams_t.target_prec>` is left at 0
+```
+
+({c:macro}`MAX_R` is an alias for {c:macro}`MAX_DEGREE` that sizes the Buthe
+tables.)
+
+(g-data-cache)=
+
+## The G-data cache and `cache_dir`
+
+The gamma-factor product (the "G data") depends only on the degree, the gamma
+shifts, and the precision, not on the Euler factors. Computing it is expensive,
+so the library caches it to disk, keyed by the analytic normalisation, in a file
+named `g_<normalisation>` (for example `g_0.5`). On a subsequent run with a
+matching gamma factor the cache is read back instead of recomputed.
+
+{c:member}`cache_dir <Lparams_t.cache_dir>` (settable through
+{c:func}`Lfunc_init_advanced`) chooses the directory for these files; left
+unset, the current working directory is used.
+
+```{warning}
+A stale or mismatched `g_<normalisation>` file in the cache directory can poison
+a run. For a hermetic computation, point {c:member}`cache_dir
+<Lparams_t.cache_dir>` at a clean directory, or remove any `g_*` files from the
+working directory first. A cache that cannot be read raises the fatal
+{c:macro}`ERR_G_INFILE`; a grid that does not extend far enough (which a stale
+cache can also cause) raises {c:macro}`ERR_G_EXTENT`.
+```
+
+## A worked end-to-end example
+
+The example below builds the degree-2 L-function of the Ramanujan tau form
+(the unique newform of weight 12 and level 1) from its Euler factors and reads
+back the rank, root number, leading Taylor coefficient, two special values, and
+the first zeros. It is a condensed version of
+[`examples/tau.cpp`](https://github.com/edgarcosta/lfunctions/blob/main/examples/tau.cpp),
+whose committed expected output the values below are taken from, so they are
+verified rather than illustrative. The motivic weight is 11, hence
+`normalisation = 5.5` and `mus = [0, 1]`.
+
+```c
+#include <flint/acb_poly.h>
+#include <stdio.h>
+#include "glfunc.h"
+
+// A few good Euler factors L_p(T) = 1 - a_p T + p^{11} T^2, from the LMFDB
+// page for the weight-12 level-1 newform 1.12.a.a. (The real program carries
+// every prime up to Lfunc_nmax; this excerpt keeps the table short.)
+static const struct { uint64_t p; long c[3]; } table[] = {
+  { 2, {1,      24,             2048} },
+  { 3, {1,    -252,           177147} },
+  { 5, {1,   -4830,         48828125} },
+  { 7, {1,   16744,       1977326743} },
+  {11, {1, -534612,     285311670611} },
+  /* ... up to Lfunc_nmax(L) ... */
+};
+
+static void lpoly_callback(acb_poly_t poly, uint64_t p, int d,
+                           int64_t prec, void *param)
+{
+  acb_poly_zero(poly);                 // unknown prime -> zero -> short-circuit
+  for (size_t i = 0; i < sizeof(table)/sizeof(table[0]); ++i)
+    if (table[i].p == p) {
+      for (int j = 0; j < 3; ++j)
+        acb_poly_set_coeff_si(poly, j, table[i].c[j]);
+      return;
+    }
+}
+
+int main(void)
+{
+  Lerror_t ecode = ERR_SUCCESS;
+  double   mus[2] = {0.0, 1.0};
+
+  // degree 2, conductor 1, motivic weight 11 -> normalisation 5.5
+  Lfunc_t L = Lfunc_init(2, 1, 5.5, mus, &ecode);
+  if (fatal_error(ecode)) { fprint_errors(stderr, ecode); return 1; }
+
+  ecode |= Lfunc_use_all_lpolys(L, lpoly_callback, NULL);
+  if (fatal_error(ecode)) { fprint_errors(stderr, ecode); return 1; }
+
+  ecode |= Lfunc_compute(L);
+  if (fatal_error(ecode)) { fprint_errors(stderr, ecode); return 1; }
+
+  printf("rank = %ld\n", (long) Lfunc_rank(L));   // 0
+
+  printf("epsilon = ");                            // 1 (this form is self-dual)
+  acb_printd(Lfunc_sign(L), 20); printf("\n");
+
+  printf("leading Taylor coeff = ");               // 0.79212283864603056936...
+  arb_printd(Lfunc_Taylor(L), 20); printf("\n");
+
+  acb_t v; acb_init(v);
+  ecode |= Lfunc_special_value(v, L, 6.5, 0.0);    // 0.83934551203194208649...
+  printf("L(6.5) = "); acb_printd(v, 20); printf("\n");
+  acb_clear(v);
+
+  arb_srcptr zeros = Lfunc_zeros(L, 0);            // first zero 9.2223793999...
+  printf("first zero = "); arb_printd(zeros + 0, 20); printf("\n");
+
+  Lfunc_clear(L);
+  fprint_errors(stderr, ecode);                    // print any warnings
+  return 0;
+}
+```
+
+Running the full example prints, among other lines:
+
+```text
+Order of vanishing = 0
+Epsilon = (1 + 0j)  +/-  (1.09e-105, 4.67e-53j)
+First non-zero Taylor coeff = 0.79212283864603056936 +/- 6.0749e-52
+L(6.5) = (0.83934551203194208649 - 2.1002674689610803795e-51j)  +/-  (1.29e-37, 1.29e-37j)
+Zero 0 = 9.2223793999211025222 +/- 2.1895e-47
+```
+
+Each printed value is a ball: the `+/-` part is the rigorous radius. A test
+asserts correctness with `acb_overlaps` / `arb_overlaps` against reference
+balls rather than by string-matching this output.
+
+### More examples in the tree
+
+The [`examples/`](https://github.com/edgarcosta/lfunctions/tree/main/examples)
+directory has runnable programs covering the API end to end. A few worth
+reading:
+
+- [`tau.cpp`](https://github.com/edgarcosta/lfunctions/blob/main/examples/tau.cpp):
+  the full version of the example above (Ramanujan tau, degree 2).
+- [`ec_37.a1.cpp`](https://github.com/edgarcosta/lfunctions/blob/main/examples/ec_37.a1.cpp):
+  a rank-1 elliptic curve, also exercising {c:func}`Lfunc_sqrt_sign` and a
+  BSD leading-coefficient check.
+- [`rational.c`](https://github.com/edgarcosta/lfunctions/blob/main/examples/rational.c):
+  a generic command-line driver that parses
+  `label:degree:conductor:weight:[mus]:[[euler_factors]]` lines and uses the
+  {c:func}`Lfunc_use_lpoly` push route over a `primesieve` prime list.
 
 ## Full header reference
 
-The declarations below are generated from `include/glfunc.h` by Doxygen and
-rendered through Breathe, so the header is the single source of truth. As the
-header's comments are migrated to Doxygen style, their descriptions appear here
-automatically.
+The declarations below are generated from
+[`include/glfunc.h`](https://github.com/edgarcosta/lfunctions/blob/main/include/glfunc.h)
+by Doxygen and rendered through Breathe, so the header stays the single source
+of truth for the per-function reference.
 
 ```{doxygenfile} glfunc.h
 :project: liblfun

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,0 +1,135 @@
+# Sphinx configuration for the liblfun documentation.
+#
+# TOOLCHAIN CHOICE (recorded here per bead lfunctions-ofr)
+# -------------------------------------------------------
+# Doxygen + Breathe + Sphinx (with MyST for Markdown sources).
+#
+# Why this stack:
+#   * include/glfunc.h is the public API and is already commented, so we keep it
+#     as the single source of truth for the per-function reference. Doxygen
+#     parses the header into XML; Breathe surfaces that XML through Sphinx's C
+#     domain. Hand-written narrative (MyST Markdown under doc/*.md) sits on top
+#     and links into the generated reference.
+#   * Doxygen is packaged everywhere we build (apt, Read the Docs native
+#     support, GitHub Actions) and emits structured C-domain XML, which is more
+#     robust than scraping a header with a libclang Python binding whose version
+#     must track the system libclang (the hawkmoth / sphinx-c-autodoc route).
+#
+# Doxygen runs automatically below (run_doxygen), so a plain `sphinx-build` and a
+# Read the Docs build both regenerate the XML; the doc/Makefile build only has to
+# invoke sphinx-build. The Doxygen settings live in doc/Doxyfile.
+#
+# NOTE for the API-guide author (bead lfunctions-rrt): the reference is wired up
+# in doc/api.md via Breathe's `doxygenfile` directive against the project named
+# "liblfun" below. Fill that page; no change is needed here.
+
+import os
+import shutil
+import subprocess
+
+# -- Paths -------------------------------------------------------------------
+# conf.py lives in doc/; the repository root is its parent. Doxygen is run from
+# the repo root so its relative INPUT/OUTPUT paths match the Makefile target.
+_here = os.path.abspath(os.path.dirname(__file__))
+_repo_root = os.path.abspath(os.path.join(_here, ".."))
+
+# -- Project information -----------------------------------------------------
+project = "liblfun"
+author = "Bober, Booker, Costa, Lee, Platt, and Sutherland"
+copyright = "2016-2026 Edgar Costa and contributors"
+
+# Version is intentionally light: liblfun ships no public version macro yet, so
+# track the Autoconf package version (AC_INIT in configure.ac).
+release = "0.1"
+version = "0.1"
+
+# -- General configuration ---------------------------------------------------
+extensions = [
+    "myst_parser",       # Markdown (MyST) sources, so doc/*.md just work
+    "breathe",           # bridge Doxygen XML -> Sphinx C domain
+    "sphinx.ext.intersphinx",
+]
+
+# Accept both Markdown and reStructuredText sources.
+source_suffix = {
+    ".md": "markdown",
+    ".rst": "restructuredtext",
+}
+
+master_doc = "index"
+root_doc = "index"
+
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", ".venv"]
+
+# Treat the C header as C (not C++) when Sphinx resolves cross-references.
+primary_domain = "c"
+highlight_language = "c"
+
+# MyST niceties used by the narrative pages (and by sibling-PR topic pages).
+myst_enable_extensions = [
+    "colon_fence",       # ::: fenced directives, friendlier than ```{...}
+    "deflist",
+    "linkify",           # bare URLs become links
+    "smartquotes",
+]
+myst_heading_anchors = 3  # auto heading anchors so pages can deep-link
+
+# -- Breathe (Doxygen bridge) ------------------------------------------------
+# XML is generated under doc/_build/doxygen/xml by run_doxygen() below.
+_doxygen_xml = os.path.join(_here, "_build", "doxygen", "xml")
+breathe_projects = {"liblfun": _doxygen_xml}
+breathe_default_project = "liblfun"
+breathe_domain_by_extension = {"h": "c"}
+breathe_show_define_initializer = True  # show the values of the ERR_* / tri-state macros
+
+
+def run_doxygen(app=None):
+    """Generate the Doxygen XML that Breathe consumes.
+
+    Run from the repository root so doc/Doxyfile's relative paths resolve the
+    same way regardless of where sphinx-build is invoked from (doc/Makefile, or
+    Read the Docs). If the
+    doxygen binary is missing we emit a clear, actionable message instead of
+    failing with a cryptic Breathe "project ... not found" error later.
+    """
+    if shutil.which("doxygen") is None:
+        msg = (
+            "doxygen not found on PATH: the API reference cannot be generated. "
+            "Install it (Debian/Ubuntu: `apt-get install doxygen`; macOS: "
+            "`brew install doxygen`) and rebuild."
+        )
+        if app is not None:
+            from sphinx.util import logging as sphinx_logging
+
+            sphinx_logging.getLogger(__name__).warning(msg)
+        else:
+            print("WARNING:", msg)
+        return
+    subprocess.run(
+        ["doxygen", os.path.join("doc", "Doxyfile")],
+        cwd=_repo_root,
+        check=True,
+    )
+
+
+def setup(app):
+    # Regenerate the XML at the start of every build (local and Read the Docs).
+    app.connect("builder-inited", run_doxygen)
+    return {"parallel_read_safe": True, "parallel_write_safe": True}
+
+
+# Read the Docs builds run conf.py directly (no Makefile), so make sure the XML
+# exists before the build proper begins there too.
+if os.environ.get("READTHEDOCS") == "True":
+    run_doxygen()
+
+# -- HTML output -------------------------------------------------------------
+html_theme = "furo"
+html_title = "liblfun documentation"
+html_static_path = ["_static"]
+html_css_files = ["custom.css"]
+
+# -- Cross-project references ------------------------------------------------
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+}

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,0 +1,53 @@
+# liblfun
+
+`liblfun` is a C library that numerically computes data for motivic
+L-functions of degree 2 through 9: the root number, the zeros on the critical
+line, the analytic rank, the leading Taylor coefficient at the central point,
+special values, and plot samples. The numerical methods are described in
+*Computing motivic L-functions* by Bober, Booker, Costa, Lee, Platt, and
+Sutherland (in preparation).
+
+The library exposes an opaque-pointer C interface in
+[`include/glfunc.h`](https://github.com/edgarcosta/lfunctions/blob/main/include/glfunc.h):
+create an `Lfunc_t`, supply the Euler factors, call `Lfunc_compute`, then query
+the results. See the [API reference](api.md) for the full lifecycle and every
+entry point.
+
+## Building
+
+The build is driven by [Autoconf](https://www.gnu.org/software/autoconf/);
+`./configure` is committed, so a checkout needs no autotools. See the
+[README](https://github.com/edgarcosta/lfunctions/blob/main/README.md) for
+dependencies, `./configure` flags, and the make targets.
+
+To build these docs locally, from the `doc/` directory:
+
+```sh
+make html
+```
+
+`make html` runs Doxygen over `include/glfunc.h` and then Sphinx, writing HTML
+to `_build/html`. It needs `sphinx-build` (with `myst-parser` and `breathe`)
+and the `doxygen` binary installed; see the repository README for a one-time
+virtualenv setup.
+
+<!--
+Glob toctree: every top-level page (api.md, plus topic pages a sibling PR adds,
+e.g. rational.md / sympow.md) is auto-included in alphabetical order, so adding
+doc/<name>.md needs no edit here and never triggers a "document isn't included
+in any toctree" warning under -W. `api` sorts first among the planned pages and
+is the entry point; if a page must precede it, list that page explicitly above
+the glob. The glob already matches api.md, so it is never empty.
+-->
+```{toctree}
+:maxdepth: 2
+:caption: Contents
+:glob:
+
+*
+```
+
+## Indices
+
+- {ref}`genindex`
+- {ref}`search`

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,11 @@
+# Python packages needed to build the liblfun documentation (run `make html` from this directory)
+# (and on Read the Docs / CI). The doxygen *binary* is a separate, non-pip
+# dependency: install it from your OS package manager (Debian/Ubuntu:
+# `apt-get install doxygen`; macOS: `brew install doxygen`).
+#
+# Lower bounds, not exact pins: these are the versions the scaffold was built
+# and verified against. Bump as needed.
+sphinx>=8.0
+myst-parser[linkify]>=4.0
+breathe>=4.36
+furo>=2024.8


### PR DESCRIPTION
## Summary

Stands up a documentation build for liblfun and writes the public C API guide as its first content page. Two commits.

- `docs(build)`: a Sphinx documentation build under `doc/`, driven by a self-contained `doc/Makefile` (the library build is left untouched), plus a README link.
- `docs(api)`: the public C API guide at `doc/api.md`, narrative plus the auto-generated per-function reference.

## Toolchain

Doxygen parses `include/glfunc.h` into XML, Breathe surfaces it through Sphinx's C domain, MyST allows Markdown narrative on top, and furo themes the result. The header stays the single source of truth for the per-function reference, with hand-written prose wrapped around it. The choice and rationale are recorded in `doc/conf.py`.

## What is here

- `doc/conf.py`, `doc/Doxyfile`, `doc/index.md`, `doc/requirements.txt`, `doc/_static/custom.css`: the Sphinx project, configured to run Doxygen automatically so a local build and Read the Docs share one path.
- `doc/api.md`: the API guide. Covers the `Lfunc_t` lifecycle (`Lfunc_init` / `Lfunc_init_advanced` and the `Lparams_t` knobs), the mu/normalisation convention and its invariants, supplying Euler factors, the query functions (`Lfunc_rank`, `Lfunc_sign`, `Lfunc_Taylor`, `Lfunc_zeros`, `Lfunc_special_value`, `Lfunc_plot_data`), the `Lerror_t` model with fatal and warning code tables, the hard limits, the G-data cache, and a worked end-to-end example, followed by the full generated reference.
- `doc/Makefile`: a self-contained Sphinx makefile (`make -C doc html`, or `cd doc && make html`), the same split FLINT uses. It runs `sphinx-build -W --keep-going` and prefers a `sphinx-build` under `doc/.venv` when present. The library `Makefile.in` is not modified, so the docs build and the library build stay independent.
- `README.md`: a short Documentation section (placed away from the build sections).
- `.readthedocs.yaml`, `.github/workflows/docs.yml`: optional hosting and CI, both failing on Sphinx warnings.
- `.gitignore`: ignores `doc/_build/`, and anchors the generated-Makefile rule to `/Makefile` so it no longer also ignores the tracked `doc/Makefile`.

## Notes

- The root toctree uses a glob, so topic pages added by the companion usage-docs branch (the rational CLI guide, the symmetric-power guide) are picked up automatically. Verified: `make -C doc html` builds clean under `-W` with those pages present.
- The guide documents the API as it exists on `main`. Array and batch supply of Euler factors and raw Dirichlet coefficients (open PR #31) is flagged as pending and will be documented once that API lands.
- The root number accessor is `Lfunc_sign` (there is no `Lfunc_epsilon`); the guide documents the header as it is.

## Building the docs locally

```sh
python3 -m venv doc/.venv
doc/.venv/bin/pip install -r doc/requirements.txt
sudo apt-get install doxygen          # or: brew install doxygen
make -C doc html                      # HTML in doc/_build/html
```

## Testing

`make -C doc html` builds the HTML with no warnings under `-W` (Doxygen 1.15, Sphinx 9.1, Breathe 4.36, MyST 5.1), independently of the library build. No library code changes; `Makefile.in` is untouched.
