### PR TITLE
docs: install guide, rational CLI, high-degree suite, and symmetric powers

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,245 @@
+# Installing and building lfunctions
+
+This document is the full build and install guide for `lfunctions`, the generic
+L-function calculator (shared library `liblfun`). The `README.md` keeps only a
+short summary and links here.
+
+The build is driven by [GNU Autoconf](https://www.gnu.org/software/autoconf/):
+the build description lives in `configure.ac`, and the generated `./configure`
+script is **committed to the repository**, so building from a checkout needs no
+autotools. `configure` substitutes its results into `Makefile.in` to produce the
+`Makefile`. The committed `configure` was generated with Autoconf 2.72.
+
+## Prerequisites
+
+| Dependency | Minimum version | Notes |
+| --- | --- | --- |
+| [FLINT](http://flintlib.org/) | 3.0 | Since FLINT 3.0 the Arb ball-arithmetic library is merged into FLINT: the `flint/acb.h`, `flint/arb.h`, ... headers ship in FLINT and the `acb_*` / `arb_*` symbols live in `libflint`, so **no separate Arb install is needed**. (FLINT 2.x with a standalone `libarb` is detected as a fallback, but 3.0+ is the supported configuration.) |
+| [primesieve](https://github.com/kimwalisch/primesieve) | any recent | Fast prime generator, used to enumerate the primes at which Euler factors are supplied. |
+| [GMP](https://gmplib.org/) | any FLINT-compatible | Pulled in by FLINT. |
+| [MPFR](http://www.mpfr.org/) | any FLINT-compatible | Pulled in by FLINT. |
+| C / C++ toolchain | C11 (`gnu11`) and C++17 (`c++1z`) | The library is C; the example and test drivers are C++. A recent GCC or Clang works. |
+
+You also need `make`. You do **not** need autotools unless you edit
+`configure.ac` (see [Regenerating configure](#regenerating-configure)).
+
+### The SageMath shortcut
+
+[SageMath](http://www.sagemath.org/) already ships FLINT (>= 3.0), GMP, and MPFR.
+With a Sage install you only need to add `primesieve` separately, then point
+`configure` at Sage's prefix:
+
+```
+./configure --with-flint=$SAGE_DIR/local --with-primesieve=/usr/local
+```
+
+`$SAGE_DIR` is the root of your Sage installation (the directory containing
+`local/`). Because FLINT provides GMP, MPFR, and Arb under that same prefix, the
+single `--with-flint` usually pins all three.
+
+## Platform notes
+
+`lfunctions` builds on Linux and macOS. `configure` adapts to the host OS:
+
+- **Shared-library extension.** The library is `build/liblfun.so` on Linux and
+  `build/liblfun.dylib` on macOS. The Makefile variable `SHLIB_EXT` (`so` or
+  `dylib`) is set by `configure` from `uname -s`; the rest of this document
+  writes `.so` for brevity.
+- **The `.exe` suffix is used on every platform, including Linux and macOS.**
+  Compiled tests live in `build/test/*.exe` and compiled examples in
+  `build/examples/*.exe`. This is a naming convention of this project's
+  Makefile, not a Windows artifact.
+- **rpath.** When a dependency is supplied via `--with-<name>=DIR`, that
+  library directory is baked into the binaries as an rpath, so the examples and
+  tests run without setting `LD_LIBRARY_PATH` (Linux) or
+  `DYLD_LIBRARY_PATH` (macOS). On Linux the library additionally links `-lrt`;
+  on macOS the install name is `@rpath/liblfun.dylib`.
+
+## 1. Get the source
+
+```
+git clone https://github.com/edgarcosta/lfunctions.git
+cd lfunctions
+```
+
+## 2. Configure
+
+```
+./configure [options]
+```
+
+`configure` locates the dependencies, then writes `Makefile` from `Makefile.in`
+and prints a configuration report (host OS, chosen compilers, the resolved
+header and library paths for each dependency, and any search directories added).
+Re-run `./configure` after editing `Makefile.in` or changing any flag.
+
+### Finding the dependencies
+
+`configure` looks for each dependency in this order:
+
+1. Any prefix you pass explicitly with `--with-<name>=DIR` (searched first).
+2. `pkg-config`, if it is installed: `configure` runs `pkg-config` for `flint`
+   and `primesieve` and adds their reported include and library directories
+   automatically.
+3. The compiler and linker default search paths (typically `/usr` and
+   `/usr/local`).
+
+If a library lives outside the default search path and `pkg-config` does not
+know about it, pass the matching `--with-<name>=DIR`, where `DIR` is the install
+prefix (the directory containing `lib/` and `include/`).
+
+### Configure options
+
+These are the package-specific options (run `./configure --help` for the full
+Autoconf-generated list, including the standard `--prefix`, `--bindir`, and
+environment variables such as `CC`, `CFLAGS`, `CPPFLAGS`, `LDFLAGS`, `LIBS`,
+`CXX`, `CXXFLAGS`):
+
+| Option | Effect |
+| --- | --- |
+| `--with-flint=DIR` | Use the FLINT (and bundled Arb) installed under prefix `DIR`. |
+| `--with-primesieve=DIR` | Use the primesieve installed under prefix `DIR`. |
+| `--with-gmp=DIR` | Use the GMP installed under prefix `DIR`. |
+| `--with-mpfr=DIR` | Use the MPFR installed under prefix `DIR`. |
+| `--disable-assert` | Compile with `-DNDEBUG`, which turns `assert`s **off**. Asserts are **on** by default, and the test suite uses them as its oracle, so leave them on when running the tests. |
+| `--disable-gdb` | Omit the `-g` debug symbols that are added by default. |
+| `--enable-sanitize` | Build with `-fsanitize=address,undefined -fno-omit-frame-pointer` (ASan / UBSan). Intended for CI and debugging; off by default. The sanitizer flags are appended to both the compile and link steps, so `libasan` must be present at link time. |
+
+The default compiler flags are
+`-pedantic -Wall -Wextra -O2 -funroll-loops -fPIC` (plus `-g` unless
+`--disable-gdb`, plus `-DNDEBUG` if `--disable-assert`), with `-std=gnu11` for C
+and `-std=c++1z` for C++. Setting `CFLAGS` or `CXXFLAGS` on the `configure` line
+**replaces** these defaults (the `-fPIC` needed for the shared link is part of
+the default set, so if you override `CFLAGS` keep `-fPIC`).
+
+## 3. Build
+
+All build artifacts live under `build/`. The make targets are:
+
+- `make` (or `make all`): build the object files, the shared library, the
+  tests, and the examples.
+- `make lib`: build only the shared library `build/liblfun.so` (`.dylib` on
+  macOS).
+- `make test`: *compile* the tests into `build/test/*.exe` (it does not run
+  them).
+- `make executables`: compile the examples into `build/examples/*.exe`.
+- `make clean`: remove the `build/` directory (`rm -rf build`).
+
+`make` runs in parallel by default: `configure` sets the `JOBS` variable to the
+CPU count plus one and the Makefile adds `-j$(JOBS)`.
+
+To run a single test or example, execute its binary directly, for example
+`./build/test/dir_test.exe` or `./build/examples/ec_37.a1.exe`.
+
+## 4. Run the tests
+
+### `make check` (the curated regression suite)
+
+```
+make check
+```
+
+`make check` builds everything, then runs every compiled `test/` and `examples/`
+binary (minus a small deny-list of binaries that require command-line
+arguments). The **exit code is the oracle**: it exits non-zero if any binary
+fails, and the binaries assert against certified values. Because the asserts are
+the oracle, run the suite with assertions **on** (the default); a build
+configured with `--disable-assert` will compile the asserts out and the tests
+will silently pass.
+
+`make check` scrubs stale `g_<...>` cache files before the suite and after each
+binary (see [Troubleshooting](#troubleshooting)).
+
+### `make check-highdeg` (the high-degree suite)
+
+```
+make check-highdeg
+```
+
+This is a separate suite that certifies degree 2 through 9 L-functions
+(elliptic curves, their symmetric powers, genus-2 curves, classical newforms)
+against LMFDB and Pari golden values. By default it runs purely from committed
+base fixtures, so it needs no external toolchain. Regenerating those fixtures, or
+running without them, needs `smalljac`'s `lpdata` (and, for some objects, Sage);
+in particular the genus-2 objects need a genus-2 `lpdata` build passed as
+`LPDATA=.../lpdata2`. Its knobs (`FIXTURES`, `LABEL`, `BACKEND`, `LPDATA`) and
+the fixture-regeneration target (`make highdeg-data`) are documented in
+[`test/highdeg/INTERFACES.md`](test/highdeg/INTERFACES.md) and the README's
+Build & Test section.
+
+## 5. Use the library
+
+The public interface is the single header [`include/glfunc.h`](include/glfunc.h);
+the shared library is `build/liblfun.so` (`.dylib` on macOS). To compile and
+link your own program against it:
+
+```
+cc myprog.c \
+  -I/path/to/lfunctions/include \
+  $(pkg-config --cflags flint primesieve) \
+  -L/path/to/lfunctions/build -llfun \
+  $(pkg-config --libs flint primesieve) \
+  -o myprog
+```
+
+At run time the loader must find `liblfun.so` and the dependency libraries; the
+simplest options are to set `LD_LIBRARY_PATH` (Linux) or `DYLD_LIBRARY_PATH`
+(macOS) to include `build/`, or to pass an rpath at link time
+(`-Wl,-rpath,/path/to/lfunctions/build`).
+
+`examples/rational.c` is a ready-made command-line front end that reads an
+L-function spec on one line and computes it without writing any C; see
+[`doc/rational.md`](doc/rational.md). The C examples (for instance
+`examples/rational.c` and `test/dir_test.c`) use only `glfunc.h`; the C++
+examples additionally use FLINT's C++ bindings.
+
+## Troubleshooting
+
+- **Header / library prefix-mismatch warning.** If a dependency's header and
+  library are found under different install prefixes, `configure` prints a
+  non-fatal warning of the form
+
+  ```
+  configure: WARNING: flint header and library resolve to different prefixes --
+  configure: WARNING:   you may compile against one flint and link another:
+  ```
+
+  This means the build would compile against one copy of the dependency and link
+  another, a silent ABI mismatch. Pass `--with-<name>=DIR` to pin both the
+  header and the library to the same prefix. (This commonly happens when a
+  system copy and a Sage or local copy are both installed.)
+
+- **Stale `g_<...>` cache files poison results.** The G-function (the gamma
+  factor product) is cached to disk in the current working directory as files
+  named `g_<normalisation>` (for example `g_0.5`, `g_1.5`). A stale or
+  mismatched cache file sitting in the CWD is silently reused and can corrupt a
+  computation. `make check` and `make check-highdeg` scrub `g_[0-9]*` for you,
+  but for ad-hoc runs remove them first:
+
+  ```
+  rm -f g_*
+  ```
+
+  For hermetic runs, point `cache_dir` (in `Lparams_t`, via
+  `Lfunc_init_advanced`) at a clean, per-run directory.
+
+- **`make` does not pick up a `Makefile.in` or flag change.** The `Makefile` is
+  generated. Re-run `./configure` (with the same options) after editing
+  `Makefile.in` or changing any configure flag, then `make` again.
+
+- **A dependency is installed but not found.** Pass its prefix with
+  `--with-<name>=DIR`. The configuration report at the end of `./configure`
+  prints the exact header and library paths the toolchain selected for each
+  dependency, which is the quickest way to see what was picked up.
+
+## Regenerating configure
+
+You only need this if you edit `configure.ac`; the generated `./configure` is
+committed, so ordinary builds never regenerate it. Maintainers can rebuild it
+with:
+
+```
+make configure
+```
+
+which runs `autoreconf -i` and therefore requires `autoconf` to be installed.

--- a/README.md
+++ b/README.md
@@ -47,3 +47,7 @@ To run a single test or example, execute its binary directly, e.g. `./build/test
 
 See [INSTALL.md](INSTALL.md) for the configure options, the SageMath shortcut, and troubleshooting (including scrubbing stale `g_*` cache files).
 
+## Usage
+
+The quickest way to compute an L-function without writing C is the `rational` command-line tool (`examples/rational.c`), which reads a one-line spec `label:degree:conductor:weight:[mus]:[[euler_factors]]` and prints the rank, root number, leading Taylor coefficient, and first zero. See [doc/rational.md](doc/rational.md) for the input grammar and a worked example.
+

--- a/README.md
+++ b/README.md
@@ -41,9 +41,14 @@ The main targets are:
  - `make lib`: build only the shared library `build/liblfun.so` (`.dylib` on macOS).
  - `make test` / `make executables`: *compile* the tests / examples into `build/test/*.exe` and `build/examples/*.exe` (they do not run them).
  - `make check`: build everything, then run the curated self-checking regression suite; it exits non-zero if any binary fails (the exit code is the oracle). It also scrubs stale `g_<...>` cache files before the suite and after each binary.
+ - `make check-highdeg`: run the high-degree regression suite (certified degree 2 to 9 L-functions: elliptic curves, their symmetric powers, genus-2 curves, classical newforms) against LMFDB and Pari golden values. By default it runs purely from committed base fixtures, so it needs no external toolchain. See below.
  - `make clean`: remove the `build/` directory (`rm -rf build`).
 
 To run a single test or example, execute its binary directly, e.g. `./build/test/dir_test.exe` or `./build/examples/ec_37.a1.exe`.
+
+### High-degree regression suite
+
+`make check-highdeg` certifies the degree 2 to 9 objects listed in `test/highdeg/objects.yaml`. By default it runs from the committed base fixtures in `test/highdeg/fixtures/`, so it needs no `smalljac` or Sage; regenerating those fixtures, or running without them, needs `smalljac`'s `lpdata` (and, for the genus-2 objects, a genus-2 `lpdata` build passed as `LPDATA=.../lpdata2`). Its knobs (`FIXTURES`, `LABEL`, `BACKEND`, `LPDATA`), the `make highdeg-data` fixture-regeneration target, and how to add an object to `objects.yaml` are documented in **[test/highdeg/INTERFACES.md](test/highdeg/INTERFACES.md)**.
 
 See [INSTALL.md](INSTALL.md) for the configure options, the SageMath shortcut, and troubleshooting (including scrubbing stale `g_*` cache files).
 

--- a/README.md
+++ b/README.md
@@ -10,63 +10,40 @@ For details of the methods we refer to:
 
 The primary dependencies are:
 
- - [FLINT: Fast Library for Number Theory](http://flintlib.org/) — version ≥ 3.0. Since FLINT 3.0 the Arb ball-arithmetic library is merged into FLINT (the `flint/acb.h`, `flint/arb.h`, … headers live in FLINT, and the `acb_*`/`arb_*` symbols are in `libflint`), so **no separate Arb install is needed**.
+ - [FLINT: Fast Library for Number Theory](http://flintlib.org/), version ≥ 3.0. Since FLINT 3.0 the Arb ball-arithmetic library is merged into FLINT (the `flint/acb.h`, `flint/arb.h`, ... headers live in FLINT, and the `acb_*`/`arb_*` symbols are in `libflint`), so **no separate Arb install is needed**.
  - [primesieve - Fast prime number generator](https://github.com/kimwalisch/primesieve)
+ - [GMP](https://gmplib.org/) and [MPFR](http://www.mpfr.org/), which FLINT pulls in.
 
-FLINT in turn pulls in:
+[SageMath](http://www.sagemath.org/) already ships FLINT (≥ 3.0), GMP, and MPFR; with Sage you only need to install `primesieve` separately.
 
- - [GMP: GNU Multiple Precision Arithmetic Library](https://gmplib.org/)
- - [MPFR: GNU Multiple Precision Floating-Point Reliably](http://www.mpfr.org/)
+## Install
 
-[SageMath](http://www.sagemath.org/) already ships FLINT (≥ 3.0), GMP, and MPFR; with Sage you only need to install `primesieve` separately. 
+The build is driven by [GNU Autoconf](https://www.gnu.org/software/autoconf/); the generated `./configure` is committed, so a checkout needs no autotools. The short version is:
 
-## Installation
-
-1. Download `lfunctions`
 ```
 git clone https://github.com/edgarcosta/lfunctions.git
-```
-
-2. Change your working directory and run the configure script
-```
 cd lfunctions
-./configure <options>
-```
-
-3. If any of these libraries are installed in some other location than the default path `/usr/local`, pass `--with-flint=DIR`, `--with-primesieve=DIR`, `--with-gmp=DIR`, or `--with-mpfr=DIR` with the correct prefix (run `./configure --help` to see all options). When `pkg-config` is available, `configure` will also pick up FLINT and primesieve automatically.
-
-Note that, with the exception of `primesieve`, all these libraries are already provided by [SageMath](http://www.sagemath.org/),
-so with a Sage install you can do `--with-flint=<SAGE_DIR>/local/`.
-
-4. Compile everything by doing
-```
+./configure                 # add --with-flint=DIR etc. if deps are not on the default path
 make
 ```
 
-5. You can use it as a shared library: the interface is defined in `include/glfunc.h`, and the shared library is built at
-`build/liblfun.so` (or `build/liblfun.dylib` on macOS).
+The public interface is `include/glfunc.h`; the shared library is built at `build/liblfun.so` (`build/liblfun.dylib` on macOS).
+
+For the full guide, see **[INSTALL.md](INSTALL.md)**: prerequisites and versions, platform notes, every `./configure` option, the SageMath shortcut, linking against `liblfun`, and troubleshooting.
 
 ## Build & Test
 
-The build is driven by [Autoconf](https://www.gnu.org/software/autoconf/). The build description lives in `configure.ac`, and the generated `./configure` script is **committed to the repository**, so building from a checkout needs no autotools — just run `./configure` as above. `configure` substitutes its results into `Makefile.in` to produce the `Makefile` (the `Makefile` itself is generated; do not edit it). Re-run `./configure` after editing `Makefile.in` or changing any configure flag.
+`configure` substitutes its results into `Makefile.in` to produce the `Makefile` (the `Makefile` is generated; do not edit it). Re-run `./configure` after editing `Makefile.in` or changing any configure flag. All build artifacts live under `build/`, and the binaries use a `.exe` suffix on every platform, including Linux and macOS.
 
-Useful `./configure` flags:
+The main targets are:
 
- - `--with-flint=DIR`, `--with-primesieve=DIR`, `--with-gmp=DIR`, `--with-mpfr=DIR` — prefixes for dependencies installed outside the default search path.
- - `--disable-assert` — compile with `-DNDEBUG` (turns `assert`s off; they are **on** by default).
- - `--disable-gdb` — omit `-g` debug symbols (added by default).
- - `--enable-sanitize` — build with `-fsanitize=address,undefined` (ASan/UBSan; intended for CI/debugging, off by default).
-
-Maintainers who edit `configure.ac` can regenerate the committed `./configure` with `make configure` (this runs `autoreconf -i` and so requires `autoconf` to be installed).
-
-All build artifacts live under `build/` (the binaries use a `.exe` suffix on every platform, including Linux). The make targets are:
-
- - `make` (or `make all`) — build the object files, the shared library, the tests, and the examples.
- - `make lib` — build only the shared library `build/liblfun.so` (`.dylib` on macOS).
- - `make test` — *compile* the tests into `build/test/*.exe` (it does not run them).
- - `make executables` — compile the examples into `build/examples/*.exe`.
- - `make check` — build everything, then run the curated self-checking regression suite; it exits non-zero if any binary fails (the exit code is the oracle). It also scrubs stale `g_<…>` cache files before the suite and after each binary.
- - `make clean` — remove the `build/` directory (`rm -rf build`).
+ - `make` (or `make all`): build the object files, the shared library, the tests, and the examples.
+ - `make lib`: build only the shared library `build/liblfun.so` (`.dylib` on macOS).
+ - `make test` / `make executables`: *compile* the tests / examples into `build/test/*.exe` and `build/examples/*.exe` (they do not run them).
+ - `make check`: build everything, then run the curated self-checking regression suite; it exits non-zero if any binary fails (the exit code is the oracle). It also scrubs stale `g_<...>` cache files before the suite and after each binary.
+ - `make clean`: remove the `build/` directory (`rm -rf build`).
 
 To run a single test or example, execute its binary directly, e.g. `./build/test/dir_test.exe` or `./build/examples/ec_37.a1.exe`.
+
+See [INSTALL.md](INSTALL.md) for the configure options, the SageMath shortcut, and troubleshooting (including scrubbing stale `g_*` cache files).
 

--- a/README.md
+++ b/README.md
@@ -56,3 +56,7 @@ See [INSTALL.md](INSTALL.md) for the configure options, the SageMath shortcut, a
 
 The quickest way to compute an L-function without writing C is the `rational` command-line tool (`examples/rational.c`), which reads a one-line spec `label:degree:conductor:weight:[mus]:[[euler_factors]]` and prints the rank, root number, leading Taylor coefficient, and first zero. See [doc/rational.md](doc/rational.md) for the input grammar and a worked example.
 
+### Symmetric powers
+
+The library can compute symmetric-power L-functions `Sym^k(E)` of an elliptic curve. The good-prime Euler factors are formed from the curve's `a_p` by the helper `sym_power_lpoly` (`include/sym_power.h`); a worked example (Sym^2 and Sym^3 of `11.a1`, with certified assertions) is [`examples/ec_sym.cpp`](examples/ec_sym.cpp). See [doc/sympow.md](doc/sympow.md) for the assembly conventions (degree, normalisation, `mus`, `self_dual`) and the bad-factor caveats.
+

--- a/doc/rational.md
+++ b/doc/rational.md
@@ -1,0 +1,152 @@
+# The `rational` command-line tool
+
+`examples/rational.c` is a small command-line front end that computes an
+L-function from a one-line text spec, without writing any C against
+[`glfunc.h`](../include/glfunc.h). It is the quickest way to drive the library
+for a motivic L-function of a "rational" object (an elliptic curve, a genus-2
+curve, a classical newform, ...) once you have its degree, conductor, motivic
+weight, Gamma-shifts, and Euler factors in hand.
+
+For programmatic use against the C API, see the API guide at
+[`doc/api.md`](api.md); for symmetric-power L-functions, see
+[`doc/sympow.md`](sympow.md).
+
+## Building and invoking
+
+Build the example (it is compiled by `make` / `make executables`):
+
+```sh
+./configure
+make executables          # or: make build/examples/rational.exe
+```
+
+The binary takes exactly **two** arguments, an input file and an output file:
+
+```
+./build/examples/rational.exe <input_file> <output_file>
+```
+
+It reads `<input_file>` line by line, computing one L-function per non-empty
+line, and prints the result of each to **standard output**. The `<output_file>`
+argument is currently required by the tool but not yet written to (the
+per-line results are reported on stdout); pass any writable path for it.
+
+Each result block printed to stdout contains the analytic rank, the root number
+(epsilon, a complex ball), the leading Taylor coefficient at the central point,
+and the first zero on the critical line, each as a certified ball (midpoint
+`+/-` radius).
+
+## Input-line grammar
+
+Each line has exactly six colon-separated fields:
+
+```
+label:degree:conductor:weight:[mus]:[[euler_factors]]
+```
+
+A line is tokenised by splitting on `:` into exactly six tokens (a line with a
+different number of `:`-separated fields is rejected). The fields are:
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `label` | string | A free-form identifier for the object (echoed back in the output; not otherwise interpreted). It must not contain a `:`. |
+| `degree` | integer | The degree `d` of the L-function. This fixes the length of `mus` (`d` entries) and the width of each Euler factor (`d + 1` coefficients). |
+| `conductor` | integer | The conductor `N`. Together with the Gamma-shifts it determines `Lfunc_nmax`, the largest prime at which an Euler factor is needed. |
+| `weight` | integer | The motivic weight `w`. The tool passes `normalisation = weight/2` to `Lfunc_init` (so an elliptic curve, motivic weight 1, uses `weight = 1`; a classical newform of weight `k` uses motivic weight `k - 1`). |
+| `[mus]` | list of `degree` numbers | The Gamma_R shifts `mu_i`, as a bracketed comma-separated list. Each `mu_i + normalisation` must be a non-negative half-integer (otherwise `Lfunc_init` fails). Values may be integers or decimals. |
+| `[[euler_factors]]` | list of lists | The local L-polynomial coefficients, one inner list per prime; see below. |
+
+### The `[mus]` field
+
+`[mus]` is a single bracketed list of exactly `degree` numbers, for example
+`[0,1]` for an elliptic curve or `[0,0,1,1]` for a genus-2 curve. With
+`normalisation = weight/2`, the convention matches `Lfunc_init`: for an elliptic
+curve over Q (`weight = 1`, so `normalisation = 0.5`), `mus = [0,1]` gives the
+half-integer shifts `[0.5, 1.5]` after normalisation.
+
+### The `[[euler_factors]]` field
+
+`[[euler_factors]]` is a list of inner lists. Each inner list is the coefficient
+vector of one local L-polynomial, written in **ascending** order (constant term
+first), and must have exactly `degree + 1` entries:
+
+```
+[c0, c1, ..., c_degree]   <->   c0 + c1*T + ... + c_degree*T^degree
+```
+
+with the convention `c0 = 1`. The inner lists are matched to the primes
+`2, 3, 5, 7, 11, ...` **in order**: the first inner list is the factor at
+`p = 2`, the second at `p = 3`, and so on. You must supply at least as many
+factors as there are primes up to `Lfunc_nmax` (the tool asserts this); for an
+elliptic curve, a degree-2 factor is `[1, -a_p, p]` at a good prime `p`.
+
+Coefficients are parsed as 64-bit integers, so this tool is suited to objects
+whose local factors have integer coefficients that fit in `int64` (elliptic
+curves, genus-2 curves, and newforms with rational coefficients). Symmetric
+powers, whose coefficients overflow 64 bits, are assembled differently; see
+[`doc/sympow.md`](sympow.md).
+
+The bad primes are included in the list at their prime position, with their
+(usually lower-degree) local factor padded to `degree + 1` entries with trailing
+zeros. For example, an elliptic curve of conductor 11 has a degree-1 bad factor
+at `p = 11`, written as `[1, -a_11, 0]` (a trailing `0` so the inner list still
+has `degree + 1 = 3` entries).
+
+## Worked example
+
+The elliptic curve `11.a2` (LMFDB label, equation `y^2 + y = x^3 - x^2`) has
+degree 2, conductor 11, motivic weight 1, and `mus = [0,1]`. The file header of
+`examples/rational.c` gives its spec with Euler factors at every prime up to 79
+(the bad prime 11 appears as `[1,-1,0]`, split multiplicative with `a_11 = 1`):
+
+```
+11a2:2:11:1:[0,1]:[[1,2,2],[1,1,3],[1,-1,5],[1,2,7],[1,-1,0],[1,-4,13],[1,2,17],[1,0,19],[1,1,23],[1,0,29],[1,-7,31],[1,-3,37],[1,8,41],[1,6,43],[1,-8,47],[1,6,53],[1,-5,59],[1,-12,61],[1,7,67],[1,3,71],[1,-4,73],[1,10,79]]
+```
+
+Save that single line to `input.txt` and run:
+
+```text
+$ rm -f g_*                       # scrub any stale G-cache in the CWD first
+$ ./build/examples/rational.exe input.txt output.txt
+Input: input.txt
+Output: output.txt
+label = 11a2
+degree = 2 conductor = 11 weight = 1 mus = [ 0.00 1.00 ]
+Rank = 0
+Epsilon = (1.0000000000000000000 + 0j)  +/-  (2.26e-115, 6.72e-58j)
+Leading Taylor coeff = 0.25384186085591068434 +/- 1.8368e-57
+First zero = 6.3626138947130887014 +/- 8.3524e-53
+```
+
+The rank, the root number (`+1`), the leading Taylor coefficient
+(`0.25384186...`), and the first zero (`6.36261389...`) agree with the LMFDB
+data for this isogeny class (its newform is `11.2.a.a`), and with the `11.a1`
+golden values in `test/highdeg/objects.yaml` (`11.a1` and `11.a2` share an
+L-function).
+
+## Where the Euler-factor data comes from
+
+The tool consumes Euler factors; it does not compute them (the library has no
+point counting or Hecke-eigenvalue machinery of its own). Typical sources:
+
+- **[LMFDB](https://www.lmfdb.org).** Each L-function / object page lists the
+  Euler factors (or the `a_p`, from which `[1, -a_p, p]` is formed for an
+  elliptic curve). This is the easiest source for a single named object.
+- **smalljac / `lpdata`.** Andrew Sutherland's `smalljac` ships an `lpdata`
+  utility that emits good-prime local data for elliptic and genus-2 curves in
+  bulk; this is what the high-degree regression suite uses (see
+  [`test/highdeg/INTERFACES.md`](https://github.com/edgarcosta/lfunctions/blob/main/test/highdeg/INTERFACES.md) and
+  [`test/highdeg/SMALLJAC_FORMAT.md`](https://github.com/edgarcosta/lfunctions/blob/main/test/highdeg/SMALLJAC_FORMAT.md)). Bad
+  primes are not produced by `lpdata` and must be supplied from a reliable
+  source such as the LMFDB.
+- **Pari/GP, Sage, Magma.** Any of these can produce `a_p` / local factors for
+  the object you have in mind.
+
+Whatever the source, the factors must be in the ascending, `degree + 1`-wide,
+prime-ordered form described above, and they must cover every prime up to
+`Lfunc_nmax`.
+
+> **Stale `g_*` cache files.** The library caches the gamma-factor product to
+> disk as `g_<normalisation>` files in the current directory. Remove any such
+> files (`rm -f g_*`) before a run; a stale one is silently reused and can
+> corrupt the result.

--- a/doc/sympow.md
+++ b/doc/sympow.md
@@ -1,0 +1,139 @@
+# Symmetric-power L-functions of an elliptic curve
+
+This is a how-to for computing the symmetric-power L-function `Sym^k(E)` of an
+elliptic curve `E/Q` with `lfunctions`. The good-prime Euler factors are formed
+from the curve's `a_p` by the helper `sym_power_lpoly`
+([`include/sym_power.h`](../include/sym_power.h)); a complete worked example
+(Sym^2 and Sym^3 of `11.a1`, with certified assertions) is
+[`examples/ec_sym.cpp`](../examples/ec_sym.cpp).
+
+There is **no native `Sym^k` constructor yet** (tracked as a future feature):
+you assemble the L-function by hand from its degree, normalisation, `mus`,
+`self_dual` flag, and Euler factors, exactly as for any object built through the
+public API. For the general C API (init, supplying factors, computing, querying)
+see [`doc/api.md`](api.md); this document covers only the `Sym^k`-specific
+conventions and the factor assembly.
+
+## Conventions
+
+For `Sym^k` of an elliptic curve over Q (motivic weight `k`):
+
+| Parameter | Value | Notes |
+| --- | --- | --- |
+| `degree` | `k + 1` | `Sym^1` is the curve itself (degree 2). |
+| `normalisation` | `k / 2` | The algebraic-to-analytic shift; `Lfunc_init`'s `normalisation` argument, or `Lparams_t.normalisation`. |
+| `self_dual` | `YES` | A symmetric power of the self-dual L-function of an elliptic curve is self-dual. |
+| `mus` | length `k + 1`, see below | The Gamma_R shifts. |
+
+The `mus` vector has `k + 1` entries. The closed form (the one the high-degree
+suite uses) is:
+
+```
+u = ceil(k / 2)
+mus[i]     = -i        for i in [0, u)
+mus[i + u] = -i + 1    for i in [0, u)
+if k is even (so degree = k + 1 > k):  mus[k] = -2 * floor(u / 2)
+```
+
+Worked out for the first few powers:
+
+| `k` | `degree` | `normalisation` | `mus` |
+| --- | --- | --- | --- |
+| 1 | 2 | 0.5 | `[0, 1]` (the curve itself) |
+| 2 | 3 | 1.0 | `[0, 1, 0]` |
+| 3 | 4 | 1.5 | `[0, -1, 1, 0]` |
+| 4 | 5 | 2.0 | `[0, -1, 1, 0, -2]` |
+
+(`mus[i] + normalisation` must be a non-negative half-integer, which these
+satisfy.) The `k = 2` and `k = 3` rows are exactly the vectors used in
+`examples/ec_sym.cpp`.
+
+## Forming the good-prime Euler factors
+
+At a prime `p` of **good** reduction the Satake parameters `alpha, beta` of `E`
+satisfy `alpha + beta = a_p` and `alpha * beta = p`. The local factor of the
+k-th symmetric power is the integer polynomial of degree `k + 1`
+
+```
+out(T) = prod_{i=0}^{k} (1 - alpha^i beta^{k-i} T).
+```
+
+`sym_power_lpoly` computes this exactly, without complex roots, from the Lucas
+sequence `V_m = alpha^m + beta^m` (`V_0 = 2`, `V_1 = a_p`,
+`V_m = a_p*V_{m-1} - p*V_{m-2}`):
+
+```c
+#include "sym_power.h"   // include/sym_power.h
+
+void sym_power_lpoly(fmpz_poly_t out, slong a_p, ulong p, int k);
+```
+
+- **Input:** the curve's `a_p`, the good prime `p`, and the power `k >= 1`.
+- **Output:** `out`, the degree-`(k + 1)` local L-polynomial in ascending order
+  (constant term first), with constant term 1.
+- With `k = 1` this returns the curve's own factor `1 - a_p*T + p*T^2`.
+
+The output is an `fmpz_poly_t` (arbitrary-precision integer coefficients) on
+purpose: the coefficients routinely exceed 64 bits (the leading one has absolute
+value `p^{k(k+1)/2}`), so an `int64` representation would overflow from `Sym^5`
+upward. Convert it to the `acb_poly_t` the library expects with
+`acb_poly_set_fmpz_poly(poly, out, prec)`.
+
+### a_p are caller-supplied
+
+The library has no elliptic-curve point counting and no Hecke machinery, so
+**you must supply the `a_p` yourself** (from the LMFDB, smalljac/`lpdata`,
+Pari/GP, Sage, or Magma). `sym_power_lpoly` is a pure function of `(a_p, p, k)`;
+it turns your `a_p` into the `Sym^k` factor but does not compute `a_p`. You need
+`a_p` at every good prime up to `Lfunc_nmax` (query it after init), which grows
+with `k` because `nmax` scales with the conductor of `Sym^k(E)`.
+
+A convenient pattern is to drive the supply step with `Lfunc_use_all_lpolys`,
+whose callback is invoked for each prime `p <= Lfunc_nmax`: look up `a_p`, call
+`sym_power_lpoly`, convert to `acb_poly_t`, and return it. (At a missing good
+prime, returning the zero polynomial only OR-s in the warning
+`ERR_INSUFF_EULER`, not a fatal error, so a gap silently corrupts the result;
+`examples/ec_sym.cpp` deliberately aborts loudly instead.)
+
+## The bad-factor caveat
+
+`sym_power_lpoly` is for **good primes only**. Bad primes are the caller's
+responsibility, and they split into two cases:
+
+- **Multiplicative reduction.** At a prime of multiplicative reduction the
+  `Sym^k` bad factor is the degree-1 polynomial `1 - a_p^k * T`, where
+  `a_p = +1` (split) or `a_p = -1` (non-split). This **is** a function of `a_p`,
+  so you can write it down directly. For example `11.a1` has split
+  multiplicative reduction at 11 with `a_11 = +1`, so its `Sym^k` factor at 11 is
+  `1 - T` (coefficients `[1, -1]`) for every `k`. Pad the factor to `degree + 1`
+  coefficients with trailing zeros if your supply path expects a fixed width.
+- **Additive (ramified) reduction.** At a prime of additive reduction the
+  `Sym^k` bad factor is **not** a function of `a_p` and cannot be derived from
+  it. (For instance, `Sym^4` of `27.a` at `p = 3` is `1 - p^2*T`, which is not
+  recoverable from `a_3 = 0`.) These factors are out of scope for the helper and
+  must be supplied from a reliable source such as the LMFDB.
+
+`examples/ec_sym.cpp` deliberately uses `11.a1`, whose only bad prime is
+multiplicative, to stay within the part of the workflow the helper supports.
+
+## Putting it together
+
+The end-to-end recipe, as carried out in `examples/ec_sym.cpp`:
+
+1. Choose `k`. Set `degree = k + 1`, `normalisation = k / 2`, `self_dual = YES`,
+   and the `mus` vector above; initialise with `Lfunc_init_advanced`.
+2. Query `Lfunc_nmax`. Make sure you have `a_p` at every good prime up to it.
+3. Supply the factors (for example via `Lfunc_use_all_lpolys`): at each good
+   prime, `sym_power_lpoly(out, a_p, p, k)` then
+   `acb_poly_set_fmpz_poly`; at each bad prime, the explicit bad factor above.
+4. `Lfunc_compute`, then query rank, root number, zeros, leading Taylor
+   coefficient, and special values as usual (see [`doc/api.md`](api.md)).
+
+For degree `>= 3` (so any `Sym^k` with `k >= 2`) the computation currently emits
+a tolerated `ERR_RH_ERROR` **warning** (the Turing zero count is miscalibrated
+for degree `>= 3`); it is a warning, not a fatal error, so collect and report it
+rather than asserting against it, as `examples/ec_sym.cpp` does.
+
+The same `sym_power_lpoly` implementation backs both `examples/ec_sym.cpp` and
+the high-degree regression driver, and is checked against Pari `lfunsympow` for
+`k = 1..8` in `test/sympow_lpoly_test.c`.

--- a/test/highdeg/INTERFACES.md
+++ b/test/highdeg/INTERFACES.md
@@ -3,6 +3,100 @@
 These are the fixed contracts shared by `gen.py`, `highdeg_check.cpp`, and
 `objects.yaml`; keep all three in sync when changing the format.
 
+Sections A through E below are the format contracts. The section immediately
+below is the operator's guide: how to run the suite, regenerate fixtures, and
+add an object.
+
+## Running the suite
+
+The suite certifies the degree 2 to 9 objects in `test/highdeg/objects.yaml`
+against LMFDB and Pari golden values. Run it from the repository root after a
+build (`make check-highdeg` depends on `all`):
+
+```
+make check-highdeg
+```
+
+For each object, the `make check-highdeg` target generates a driver input file,
+runs `build/test/highdeg_check.exe` on it, and checks the assertions in
+section C. The exit code is the oracle (it exits non-zero if any non-`xfail`
+object fails). `g_*` caches are scrubbed before the run and after each object.
+
+### Fixtures versus on-the-fly generation
+
+By default the suite runs **purely from committed base fixtures** and needs no
+external toolchain:
+
+- `FIXTURES` (default `test/highdeg/fixtures`) is the directory of committed
+  base data (`<label>.base`, stored in Git LFS). When `$(FIXTURES)/<label>.base`
+  exists, `gen.py` reconstructs the full driver input from it (`--base-from`)
+  with **no** `smalljac` and **no** Sage. This is the CI path
+  (`.github/workflows/highdeg.yml` runs purely from fixtures).
+- Set `FIXTURES=` (empty) to force on-the-fly generation, which runs the backend
+  toolchain for every object. This needs `lpdata` (and Sage for the `cmf` and,
+  by default, the `genus2` objects).
+
+### Knobs
+
+| Make variable | Default | Effect |
+| --- | --- | --- |
+| `FIXTURES` | `test/highdeg/fixtures` | Directory of committed base fixtures. A present `<label>.base` is used (toolchain-free); `FIXTURES=` forces on-the-fly generation. |
+| `LABEL` | (empty) | Restrict the run to a single object by label (for example `LABEL=11.a1`). Empty runs the full sweep. With `LABEL` set, the generated input file `build/test/highdeg_<label>.in` is **kept** (and the re-run command printed) for debugging. |
+| `BACKEND` | `smalljac` | Good-factor source for the **genus-2** objects when generating: `smalljac` (needs a genus-2 `lpdata`) or `pari` (routes genus-2 good factors through Sage's `hyperellcharpoly`, slower). `ec` / `sympow` good factors always come from `lpdata` regardless of `BACKEND`; only genus-2 is affected. Irrelevant when running from fixtures. |
+| `LPDATA` | `/usr/local/bin/lpdata` | Path to the `smalljac` `lpdata` binary used when generating. |
+| `HIGHDEG_OBJECTS` | `test/highdeg/objects.yaml` | The object list to run. |
+
+### The genus-2 `lpdata` requirement
+
+The default `lpdata` on a typical box is a **genus-1-only** `smalljac` build: it
+silently emits no good factors for the genus-2 (degree-4) objects, so when those
+objects are generated on the fly they end up with only their hardcoded bad
+factors and fail. **When regenerating genus-2 data, or running the suite without
+fixtures, point `LPDATA` at a genus-2 build:**
+
+```
+make check-highdeg BACKEND=smalljac LPDATA=/usr/local/bin/lpdata2
+```
+
+`test/highdeg/install_smalljac.sh` builds a suitable genus-2 `lpdata` (smalljac
+v4.1.3 with `SMALLJAC_GENUS=2`, which handles genus 1 and 2 simultaneously); see
+[`SMALLJAC_FORMAT.md`](SMALLJAC_FORMAT.md). The fixtures path (the default) needs
+no `lpdata` at all, since the genus-2 L-polys are stored in the fixture.
+
+### Regenerating the base fixtures
+
+`make highdeg-data` regenerates the committed base fixtures under `$(FIXTURES)`.
+This is the **only** step that needs the backend toolchain (`lpdata` for
+`ec` / `sympow`, `lpdata2` or Sage for `genus2`, Sage for `cmf`):
+
+```
+make highdeg-data                                  # regenerate all fixtures
+make highdeg-data LABEL=169.a LPDATA=/usr/local/bin/lpdata2   # one object
+```
+
+The base data is minimal (for `ec` / `sympow` it is the base curve's `a_p`; the
+Sym^k factor is re-expanded at run time), so the fixtures stay small. Regenerate
+a fixture whenever its object's curve, conductor, or `mus` (hence `nmax`)
+changes; `gen.py --base-from` aborts if a fixture's recorded `nmax` no longer
+matches the object.
+
+To generate (only) one object's driver input for interactive debugging without
+running the assertions, use `make highdeg-gen LABEL=<label>`, which writes
+`build/test/highdeg_<label>.in` and prints the command to run it.
+
+### Adding an object to `objects.yaml`
+
+Append a new entry to the `objects:` list in `test/highdeg/objects.yaml`
+following the schema in section A: a unique filename-safe `label`, the `kind`
+(`ec`, `sympow`, `genus2`, or `cmf`), the curve / form data that `kind` requires,
+the `conductor`, the hardcoded `bad_factors` (from the LMFDB, never from
+`lpdata`), and the `expected` block (rank, epsilon, first zero and its error,
+optional Taylor coefficient, and `tolerate_rh_error`, which **must** be `true`
+for degree >= 3). `gen.py` derives degree / normalisation / `mus` / `self_dual`
+from `kind` (+ `sym` for `sympow`), so do not store those. Then generate the base
+fixture for the new object with `make highdeg-data LABEL=<label>` (using
+`LPDATA=.../lpdata2` for a `genus2` object) and commit `<label>.base`.
+
 ## A. `test/highdeg/objects.yaml` (data) — consumed by `gen.py`
 ```yaml
 objects:


### PR DESCRIPTION
## Summary

Four user-facing documentation additions, one commit each, bundled onto one branch because they all touch `README.md`.

- `INSTALL.md`: a dedicated install and compile document; the README build section is trimmed to a summary that links to it.
- `doc/rational.md`: the `rational` command-line tool, its input grammar, a worked example, and where Euler-factor data comes from.
- `README.md` + `test/highdeg/INTERFACES.md`: the high-degree regression suite (`make check-highdeg`).
- `doc/sympow.md`: the symmetric-power L-function workflow.

## INSTALL.md

Prerequisites and minimum versions (FLINT >= 3.0 with Arb merged in, primesieve, GMP, MPFR, and the SageMath shortcut), platform notes (Linux and macOS, `.so` vs `.dylib`, the `.exe` suffix on all platforms), the configure step and every option (taken from `./configure --help` and `configure.ac`), building, running `make check` and `make check-highdeg`, linking against `build/liblfun.so` through `include/glfunc.h`, and troubleshooting (prefix-mismatch warnings, scrubbing stale `g_*` cache files). The README Dependencies, Installation, and Build sections are condensed to a summary that points here.

## rational CLI

`doc/rational.md` documents `examples/rational.c`: the `label:degree:conductor:weight:[mus]:[[euler_factors]]` line grammar with per-field semantics (read from the parser), a worked `11.a2` invocation with its output reproduced verbatim, and the Euler-factor data sources. The worked example was built and run: rank 0, epsilon +1, leading Taylor coefficient `0.25384186085591068434`, first zero `6.3626138947130887014`, matching LMFDB newform `11.2.a.a` and the `11.a1` goldens in `test/highdeg/objects.yaml`.

## high-degree suite

The README Build & Test section gains a `make check-highdeg` mention and a pointer to `test/highdeg/INTERFACES.md`, which is expanded with an operator section: the `FIXTURES` / `LABEL` / `BACKEND` knobs, running from committed base fixtures versus on-the-fly generation, the genus-2 `lpdata2` requirement, adding an object to `objects.yaml`, and regenerating fixtures with `make highdeg-data`.

## symmetric powers

`doc/sympow.md` is a how-to for Sym^k of an elliptic curve: the conventions (degree = k+1, normalisation = k/2, the `mus` vector, `self_dual = YES`), forming the good-prime factors from `a_p` with `sym_power_lpoly` (good primes only; `a_p` are caller-supplied, since the library has no point counting), and the multiplicative versus additive bad-factor caveat. The README gains a symmetric-powers note linking `examples/ec_sym.cpp`. A native Sym^k constructor does not exist yet, so factors are assembled by hand for now.

## Notes

- The build documentation is taken from `configure.ac`, `Makefile.in`, and `./configure --help` (the project uses GNU Autoconf).
- `doc/rational.md` and `doc/sympow.md` render as Markdown on GitHub and are also picked up by the Sphinx site (companion docs branch); they were integration-tested inside that scaffold and build clean under `-W`.

## Testing

The library is unchanged. The rational worked example was verified by building and running `build/examples/rational.exe`. Documentation-build integration with the Sphinx site was verified clean under `-W`.
